### PR TITLE
Add addons docs template

### DIFF
--- a/docs/CHANGELOG-0.1.md
+++ b/docs/CHANGELOG-0.1.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.1
     name: Changelog-0.1
     parent: welcome
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.1/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.1/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.1/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.1/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.1.md
+++ b/docs/CHANGELOG-0.1.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.1
     name: Changelog-0.1
     parent: welcome
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.1/
+url: /products/stash/{{ .version }}/welcome/changelog-0.1/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.1/
+  - /products/stash/{{ .version }}/CHANGELOG-0.1/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.2.md
+++ b/docs/CHANGELOG-0.2.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.2
     name: Changelog-0.2
     parent: welcome
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.2/
+url: /products/stash/{{ .version }}/welcome/changelog-0.2/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.2/
+  - /products/stash/{{ .version }}/CHANGELOG-0.2/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.2.md
+++ b/docs/CHANGELOG-0.2.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.2
     name: Changelog-0.2
     parent: welcome
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.2/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.2/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.2/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.2/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.3.md
+++ b/docs/CHANGELOG-0.3.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.3
     name: Changelog-0.3
     parent: welcome
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.3/
+url: /products/stash/{{ .version }}/welcome/changelog-0.3/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.3/
+  - /products/stash/{{ .version }}/CHANGELOG-0.3/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.3.md
+++ b/docs/CHANGELOG-0.3.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.3
     name: Changelog-0.3
     parent: welcome
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.3/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.3/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.3/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.3/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.4.md
+++ b/docs/CHANGELOG-0.4.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.4
     name: Changelog-0.4
     parent: welcome
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.4/
+url: /products/stash/{{ .version }}/welcome/changelog-0.4/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.4/
+  - /products/stash/{{ .version }}/CHANGELOG-0.4/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.4.md
+++ b/docs/CHANGELOG-0.4.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.4
     name: Changelog-0.4
     parent: welcome
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.4/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.4/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.4/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.4/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.5.md
+++ b/docs/CHANGELOG-0.5.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.5
     name: Changelog-0.5
     parent: welcome
     weight: 50
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.5/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.5/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.5/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.5/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.5.md
+++ b/docs/CHANGELOG-0.5.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.5
     name: Changelog-0.5
     parent: welcome
     weight: 50
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.5/
+url: /products/stash/{{ .version }}/welcome/changelog-0.5/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.5/
+  - /products/stash/{{ .version }}/CHANGELOG-0.5/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.6.md
+++ b/docs/CHANGELOG-0.6.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.6
     name: Changelog-0.6
     parent: welcome
     weight: 60
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.6/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.6/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.6/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.6/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.6.md
+++ b/docs/CHANGELOG-0.6.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.6
     name: Changelog-0.6
     parent: welcome
     weight: 60
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.6/
+url: /products/stash/{{ .version }}/welcome/changelog-0.6/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.6/
+  - /products/stash/{{ .version }}/CHANGELOG-0.6/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.7.md
+++ b/docs/CHANGELOG-0.7.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.7
     name: Changelog-0.7
     parent: welcome
     weight: 70
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.7/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.7/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.7/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.7/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.7.md
+++ b/docs/CHANGELOG-0.7.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.7
     name: Changelog-0.7
     parent: welcome
     weight: 70
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.7/
+url: /products/stash/{{ .version }}/welcome/changelog-0.7/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.7/
+  - /products/stash/{{ .version }}/CHANGELOG-0.7/
 ---
 # Change Log
 

--- a/docs/CHANGELOG-0.8.md
+++ b/docs/CHANGELOG-0.8.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.8
     name: Changelog-0.8
     parent: welcome
     weight: 80
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.8/
+url: /products/stash/{{ .version }}/welcome/changelog-0.8/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.8/
+  - /products/stash/{{ .version }}/CHANGELOG-0.8/
 ---
 
 # Change Log

--- a/docs/CHANGELOG-0.8.md
+++ b/docs/CHANGELOG-0.8.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.8
     name: Changelog-0.8
     parent: welcome
     weight: 80
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.8/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.8/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.8/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.8/
 ---
 
 # Change Log

--- a/docs/CHANGELOG-0.9.md
+++ b/docs/CHANGELOG-0.9.md
@@ -2,25 +2,25 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: changelog-stash-0.9
     name: Changelog-0.9
     parent: welcome
     weight: 90
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog-0.9/
+url: /products/stash/{{ .version }}/welcome/changelog-0.9/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG-0.9/
+  - /products/stash/{{ .version }}/CHANGELOG-0.9/
 ---
 # Change Log
 
-## [{{ .Version }}](https://github.com/stashed/stash/tree/{{ .Version }})
+## [v0.9.0-rc.0](https://github.com/stashed/stash/tree/v0.9.0-rc.0)
 
-[Full Changelog](https://github.com/stashed/stash/compare/0.8.3...{{ .Version }})
+[Full Changelog](https://github.com/stashed/stash/compare/0.8.3...v0.9.0-rc.0)
 
-We are very excited to announce Stash `{{ .Version }}`. This release introduces `v1beta1` API and a design overhaul. The new API and design enable Stash to support the use cases that were not possible before. This makes Stash more powerful, transparent, extensible and customizable. We are expecting that this new API will graduate to GA after some maturity. Check out the new architecture from [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/what-is-stash/architecture.md).
+We are very excited to announce Stash `v0.9.0-rc.0`. This release introduces `v1beta1` API and a design overhaul. The new API and design enable Stash to support the use cases that were not possible before. This makes Stash more powerful, transparent, extensible and customizable. We are expecting that this new API will graduate to GA after some maturity. Check out the new architecture from [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/what-is-stash/architecture.md).
 
 ### What's New
 
@@ -30,46 +30,46 @@ This release introduces lots of new features and changes. A summary of these new
 
 The following custom resources have been introduced in this release:
 
-- [BackupConfiguration](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/backupconfiguration.md).
-- [BackupSession](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/backupsession.md).
-- [RestoreSession](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/restoresession.md).
-- [Function](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/function.md).
-- [Task](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/task.md).
-- [BackupBlueprint](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/backupblueprint.md).
-- [AppBinding](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/appbinding.md).
+- [BackupConfiguration](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/backupconfiguration.md).
+- [BackupSession](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/backupsession.md).
+- [RestoreSession](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/restoresession.md).
+- [Function](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/function.md).
+- [Task](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/task.md).
+- [BackupBlueprint](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/backupblueprint.md).
+- [AppBinding](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/appbinding.md).
 
 #### New Features
 
 In addition to improving existing features, this release introduces the following new features:
 
 - **Backup & Restore Stand-alone PVC :**
-  Stash now supports taking backup of a stand-alone PVC. To learn more about how Stash takes backup of a stand-alone PVC, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/volumes/overview.md).
+  Stash now supports taking backup of a stand-alone PVC. To learn more about how Stash takes backup of a stand-alone PVC, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/volumes/overview.md).
 
 - **Backup & Restore Databases :**
-  Stash now can backup PostgreSQL, MongoDB, Elasticsearch and MySQL databases in both stand-alone and clustered mode. To learn more about how Stash takes backup of a database, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/databases/overview.md).
+  Stash now can backup PostgreSQL, MongoDB, Elasticsearch and MySQL databases in both stand-alone and clustered mode. To learn more about how Stash takes backup of a database, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/databases/overview.md).
 
 - **VolumeSnapshot :**
-  Now, you can take a scheduled snapshot of the volumes of a workload using Kubernetes [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) API. Check out how volume snapshotting works in Stash from [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/volumesnapshot/overview.md).
+  Now, you can take a scheduled snapshot of the volumes of a workload using Kubernetes [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) API. Check out how volume snapshotting works in Stash from [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/volumesnapshot/overview.md).
 
 - **Instant Backup :**
-  You can now trigger a backup instantly. To learn how, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/volumesnapshot/overview.md).
+  You can now trigger a backup instantly. To learn how, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/volumesnapshot/overview.md).
 
 - **Auto Backup :**
-  Now, Stash will let you configure a common template to backup similar types of target. You will require to add just a few annotations to the targeted workload to enable backup for it. Want to know how? Please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/auto-backup/overview.md).
+  Now, Stash will let you configure a common template to backup similar types of target. You will require to add just a few annotations to the targeted workload to enable backup for it. Want to know how? Please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/auto-backup/overview.md).
 
 - **Support PSP Enabled Cluster :**
   Stash now supports PSP enabled cluster.
 
 - **Improved Prometheus Metrics :**
-  We have improved Prometheus metrics in this release. Check out the new metrics from [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/monitoring/overview.md).
+  We have improved Prometheus metrics in this release. Check out the new metrics from [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/monitoring/overview.md).
 
 - **Support REST Server as Backend :**
-  Stash now supports REST server as backend. To learn how to configure REST backend, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/backends/rest.md).
+  Stash now supports REST server as backend. To learn how to configure REST backend, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/backends/rest.md).
 
 - **KubeDB Integration :**
   Stash now seemingly integrates with [KubeDB](https://kubedb.com/). It is now recommended tool to backup & restore KubeDB supported databases.
 
-For a complete feature list of this release, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/what-is-stash/overview.md).
+For a complete feature list of this release, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/what-is-stash/overview.md).
 
 ### Significant Changes
 

--- a/docs/CHANGELOG-0.9.md
+++ b/docs/CHANGELOG-0.9.md
@@ -2,25 +2,25 @@
 title: Changelog | Stash
 description: Changelog
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: changelog-stash-0.9
     name: Changelog-0.9
     parent: welcome
     weight: 90
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog-0.9/
+url: /products/stash/{{ .Version }}/welcome/changelog-0.9/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG-0.9/
+  - /products/stash/{{ .Version }}/CHANGELOG-0.9/
 ---
 # Change Log
 
-## [v0.9.0-rc.0](https://github.com/stashed/stash/tree/v0.9.0-rc.0)
+## [{{ .Version }}](https://github.com/stashed/stash/tree/{{ .Version }})
 
-[Full Changelog](https://github.com/stashed/stash/compare/0.8.3...v0.9.0-rc.0)
+[Full Changelog](https://github.com/stashed/stash/compare/0.8.3...{{ .Version }})
 
-We are very excited to announce Stash `v0.9.0-rc.0`. This release introduces `v1beta1` API and a design overhaul. The new API and design enable Stash to support the use cases that were not possible before. This makes Stash more powerful, transparent, extensible and customizable. We are expecting that this new API will graduate to GA after some maturity. Check out the new architecture from [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/what-is-stash/architecture.md).
+We are very excited to announce Stash `{{ .Version }}`. This release introduces `v1beta1` API and a design overhaul. The new API and design enable Stash to support the use cases that were not possible before. This makes Stash more powerful, transparent, extensible and customizable. We are expecting that this new API will graduate to GA after some maturity. Check out the new architecture from [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/what-is-stash/architecture.md).
 
 ### What's New
 
@@ -30,46 +30,46 @@ This release introduces lots of new features and changes. A summary of these new
 
 The following custom resources have been introduced in this release:
 
-- [BackupConfiguration](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/backupconfiguration.md).
-- [BackupSession](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/backupsession.md).
-- [RestoreSession](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/restoresession.md).
-- [Function](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/function.md).
-- [Task](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/task.md).
-- [BackupBlueprint](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/backupblueprint.md).
-- [AppBinding](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/crds/appbinding.md).
+- [BackupConfiguration](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/backupconfiguration.md).
+- [BackupSession](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/backupsession.md).
+- [RestoreSession](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/restoresession.md).
+- [Function](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/function.md).
+- [Task](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/task.md).
+- [BackupBlueprint](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/backupblueprint.md).
+- [AppBinding](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/crds/appbinding.md).
 
 #### New Features
 
 In addition to improving existing features, this release introduces the following new features:
 
 - **Backup & Restore Stand-alone PVC :**
-  Stash now supports taking backup of a stand-alone PVC. To learn more about how Stash takes backup of a stand-alone PVC, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/volumes/overview.md).
+  Stash now supports taking backup of a stand-alone PVC. To learn more about how Stash takes backup of a stand-alone PVC, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/volumes/overview.md).
 
 - **Backup & Restore Databases :**
-  Stash now can backup PostgreSQL, MongoDB, Elasticsearch and MySQL databases in both stand-alone and clustered mode. To learn more about how Stash takes backup of a database, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/databases/overview.md).
+  Stash now can backup PostgreSQL, MongoDB, Elasticsearch and MySQL databases in both stand-alone and clustered mode. To learn more about how Stash takes backup of a database, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/databases/overview.md).
 
 - **VolumeSnapshot :**
-  Now, you can take a scheduled snapshot of the volumes of a workload using Kubernetes [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) API. Check out how volume snapshotting works in Stash from [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/volumesnapshot/overview.md).
+  Now, you can take a scheduled snapshot of the volumes of a workload using Kubernetes [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) API. Check out how volume snapshotting works in Stash from [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/volumesnapshot/overview.md).
 
 - **Instant Backup :**
-  You can now trigger a backup instantly. To learn how, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/volumesnapshot/overview.md).
+  You can now trigger a backup instantly. To learn how, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/volumesnapshot/overview.md).
 
 - **Auto Backup :**
-  Now, Stash will let you configure a common template to backup similar types of target. You will require to add just a few annotations to the targeted workload to enable backup for it. Want to know how? Please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/auto-backup/overview.md).
+  Now, Stash will let you configure a common template to backup similar types of target. You will require to add just a few annotations to the targeted workload to enable backup for it. Want to know how? Please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/auto-backup/overview.md).
 
 - **Support PSP Enabled Cluster :**
   Stash now supports PSP enabled cluster.
 
 - **Improved Prometheus Metrics :**
-  We have improved Prometheus metrics in this release. Check out the new metrics from [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/monitoring/overview.md).
+  We have improved Prometheus metrics in this release. Check out the new metrics from [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/monitoring/overview.md).
 
 - **Support REST Server as Backend :**
-  Stash now supports REST server as backend. To learn how to configure REST backend, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/guides/latest/backends/rest.md).
+  Stash now supports REST server as backend. To learn how to configure REST backend, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/guides/latest/backends/rest.md).
 
 - **KubeDB Integration :**
   Stash now seemingly integrates with [KubeDB](https://kubedb.com/). It is now recommended tool to backup & restore KubeDB supported databases.
 
-For a complete feature list of this release, please visit [here](https://github.com/stashed/docs/blob/v0.9.0-rc.0/docs/concepts/what-is-stash/overview.md).
+For a complete feature list of this release, please visit [here](https://github.com/stashed/docs/blob/{{ .Version }}/docs/concepts/what-is-stash/overview.md).
 
 ### Significant Changes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Release History
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: release-history
     name: Changelog
     parent: welcome
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/changelog/
+url: /products/stash/{{ .Version }}/welcome/changelog/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CHANGELOG/
+  - /products/stash/{{ .Version }}/CHANGELOG/
 ---
 
 ## Current Release

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,17 +2,17 @@
 title: Changelog | Stash
 description: Release History
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: release-history
     name: Changelog
     parent: welcome
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/changelog/
+url: /products/stash/{{ .version }}/welcome/changelog/
 aliases:
-  - /products/stash/{{ .Version }}/CHANGELOG/
+  - /products/stash/{{ .version }}/CHANGELOG/
 ---
 
 ## Current Release

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 title: Contributing | Stash
 description: Contributing
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: contributing-stash
     name: Contributing
     parent: welcome
     weight: 1000
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/contributing/
+url: /products/stash/{{ .Version }}/welcome/contributing/
 aliases:
-  - /products/stash/v0.9.0-rc.0/CONTRIBUTING/
+  - /products/stash/{{ .Version }}/CONTRIBUTING/
 ---
 
 # Contribution Guidelines

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 title: Contributing | Stash
 description: Contributing
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: contributing-stash
     name: Contributing
     parent: welcome
     weight: 1000
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/contributing/
+url: /products/stash/{{ .version }}/welcome/contributing/
 aliases:
-  - /products/stash/{{ .Version }}/CONTRIBUTING/
+  - /products/stash/{{ .version }}/CONTRIBUTING/
 ---
 
 # Contribution Guidelines

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,18 @@
 title: Welcome | Stash
 description: Welcome to Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: readme-stash
     name: Readme
     parent: welcome
     weight: -1
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/
+url: /products/stash/{{ .Version }}/welcome/
 aliases:
-  - /products/stash/v0.9.0-rc.0/
-  - /products/stash/v0.9.0-rc.0/README/
+  - /products/stash/{{ .Version }}/
+  - /products/stash/{{ .Version }}/README/
 ---
 # Stash
  Stash by AppsCode is a Kubernetes operator for [restic](https://restic.net). If you are running production workloads in Kubernetes, you might want to take backup of your disks. Using Stash, you can backup Kubernetes volumes mounted in following types of workloads:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,18 @@
 title: Welcome | Stash
 description: Welcome to Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: readme-stash
     name: Readme
     parent: welcome
     weight: -1
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/
+url: /products/stash/{{ .version }}/welcome/
 aliases:
-  - /products/stash/{{ .Version }}/
-  - /products/stash/{{ .Version }}/README/
+  - /products/stash/{{ .version }}/
+  - /products/stash/{{ .version }}/README/
 ---
 # Stash
  Stash by AppsCode is a Kubernetes operator for [restic](https://restic.net). If you are running production workloads in Kubernetes, you might want to take backup of your disks. Using Stash, you can backup Kubernetes volumes mounted in following types of workloads:

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -2,9 +2,9 @@
 title: Docs | Stash
 description: Stash Docs
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: welcome
     name: Welcome
     weight: 10
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -2,9 +2,9 @@
 title: Docs | Stash
 description: Stash Docs
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: welcome
     name: Welcome
     weight: 10
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/acknowledgement.md
+++ b/docs/acknowledgement.md
@@ -2,17 +2,17 @@
 title: Acknowledgement | Stash
 description: Acknowledgement
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: acknowledgement-stash
     name: Acknowledgement
     parent: welcome
     weight: 1010
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/acknowledgement/
+url: /products/stash/{{ .Version }}/welcome/acknowledgement/
 aliases:
-  - /products/stash/v0.9.0-rc.0/acknowledgement/
+  - /products/stash/{{ .Version }}/acknowledgement/
 ---
 
 # Acknowledgement

--- a/docs/acknowledgement.md
+++ b/docs/acknowledgement.md
@@ -2,17 +2,17 @@
 title: Acknowledgement | Stash
 description: Acknowledgement
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: acknowledgement-stash
     name: Acknowledgement
     parent: welcome
     weight: 1010
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/acknowledgement/
+url: /products/stash/{{ .version }}/welcome/acknowledgement/
 aliases:
-  - /products/stash/{{ .Version }}/acknowledgement/
+  - /products/stash/{{ .version }}/acknowledgement/
 ---
 
 # Acknowledgement

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,17 +1,17 @@
 ---
 title: Concepts | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: concepts-readme
     name: README
     parent: concepts
     weight: -1
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
-url: /products/stash/v0.9.0-rc.0/concepts/
+url: /products/stash/{{ .Version }}/concepts/
 aliases:
-  - /products/stash/v0.9.0-rc.0/concepts/README/
+  - /products/stash/{{ .Version }}/concepts/README/
 ---
 
 # Concepts

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,17 +1,17 @@
 ---
 title: Concepts | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: concepts-readme
     name: README
     parent: concepts
     weight: -1
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
-url: /products/stash/{{ .Version }}/concepts/
+url: /products/stash/{{ .version }}/concepts/
 aliases:
-  - /products/stash/{{ .Version }}/concepts/README/
+  - /products/stash/{{ .version }}/concepts/README/
 ---
 
 # Concepts

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -2,9 +2,9 @@
 title: Concepts
 description: Stash Concepts
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: concepts
     name: Concepts
     weight: 20
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -2,9 +2,9 @@
 title: Concepts
 description: Stash Concepts
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: concepts
     name: Concepts
     weight: 20
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/concepts/crds/_index.md
+++ b/docs/concepts/crds/_index.md
@@ -2,10 +2,10 @@
 title: Declarative API | Stash
 description: Declarative API
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: crds
     parent: concepts
     name: Declarative API
     weight: 15
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/concepts/crds/_index.md
+++ b/docs/concepts/crds/_index.md
@@ -2,10 +2,10 @@
 title: Declarative API | Stash
 description: Declarative API
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: crds
     parent: concepts
     name: Declarative API
     weight: 15
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/concepts/crds/appbinding.md
+++ b/docs/concepts/crds/appbinding.md
@@ -1,13 +1,13 @@
 ---
 title: AppBinding Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: appbinding-overview
     name: AppBinding
     parent: crds
     weight: 45
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/appbinding.md
+++ b/docs/concepts/crds/appbinding.md
@@ -1,13 +1,13 @@
 ---
 title: AppBinding Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: appbinding-overview
     name: AppBinding
     parent: crds
     weight: 45
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/backupblueprint.md
+++ b/docs/concepts/crds/backupblueprint.md
@@ -1,13 +1,13 @@
 ---
 title: BackupBlueprint Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backupblueprint-overview
     name: BackupBlueprint
     parent: crds
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/backupblueprint.md
+++ b/docs/concepts/crds/backupblueprint.md
@@ -1,13 +1,13 @@
 ---
 title: BackupBlueprint Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backupblueprint-overview
     name: BackupBlueprint
     parent: crds
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/backupconfiguration.md
+++ b/docs/concepts/crds/backupconfiguration.md
@@ -1,13 +1,13 @@
 ---
 title: BackupConfiguration Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backupconfiguration-overview
     name: BackupConfiguration
     parent: crds
     weight: 15
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/backupconfiguration.md
+++ b/docs/concepts/crds/backupconfiguration.md
@@ -1,13 +1,13 @@
 ---
 title: BackupConfiguration Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backupconfiguration-overview
     name: BackupConfiguration
     parent: crds
     weight: 15
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/backupsession.md
+++ b/docs/concepts/crds/backupsession.md
@@ -1,13 +1,13 @@
 ---
 title: BackupSession Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backupsession-overview
     name: BackupSession
     parent: crds
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/backupsession.md
+++ b/docs/concepts/crds/backupsession.md
@@ -1,13 +1,13 @@
 ---
 title: BackupSession Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backupsession-overview
     name: BackupSession
     parent: crds
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/function.md
+++ b/docs/concepts/crds/function.md
@@ -1,13 +1,13 @@
 ---
 title: Function Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: function-overview
     name: Function
     parent: crds
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/function.md
+++ b/docs/concepts/crds/function.md
@@ -1,13 +1,13 @@
 ---
 title: Function Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: function-overview
     name: Function
     parent: crds
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/repository.md
+++ b/docs/concepts/crds/repository.md
@@ -1,13 +1,13 @@
 ---
 title: Repository Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: repository-overview
     name: Repository
     parent: crds
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/repository.md
+++ b/docs/concepts/crds/repository.md
@@ -1,13 +1,13 @@
 ---
 title: Repository Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: repository-overview
     name: Repository
     parent: crds
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/restoresession.md
+++ b/docs/concepts/crds/restoresession.md
@@ -1,13 +1,13 @@
 ---
 title: RestoreSession Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: restoresession-overview
     name: RestoreSession
     parent: crds
     weight: 25
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/restoresession.md
+++ b/docs/concepts/crds/restoresession.md
@@ -1,13 +1,13 @@
 ---
 title: RestoreSession Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: restoresession-overview
     name: RestoreSession
     parent: crds
     weight: 25
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/snapshot.md
+++ b/docs/concepts/crds/snapshot.md
@@ -1,13 +1,13 @@
 ---
 title: Snapshot Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: snapshot-overview
     name: Snapshot
     parent: crds
     weight: 50
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 > New to Stash? Please start [here](/docs/concepts/README.md).

--- a/docs/concepts/crds/snapshot.md
+++ b/docs/concepts/crds/snapshot.md
@@ -1,13 +1,13 @@
 ---
 title: Snapshot Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: snapshot-overview
     name: Snapshot
     parent: crds
     weight: 50
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 > New to Stash? Please start [here](/docs/concepts/README.md).

--- a/docs/concepts/crds/task.md
+++ b/docs/concepts/crds/task.md
@@ -1,13 +1,13 @@
 ---
 title: Task Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: task-overview
     name: Task
     parent: crds
     weight: 35
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/task.md
+++ b/docs/concepts/crds/task.md
@@ -1,13 +1,13 @@
 ---
 title: Task Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: task-overview
     name: Task
     parent: crds
     weight: 35
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/v1alpha1/_index.md
+++ b/docs/concepts/crds/v1alpha1/_index.md
@@ -2,10 +2,10 @@
 title: v1alhpa1 API | Stash
 description: v1alpha1 Declarative API
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-crds
     parent: concepts
     name: v1alpha1 API
     weight: 20
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/concepts/crds/v1alpha1/_index.md
+++ b/docs/concepts/crds/v1alpha1/_index.md
@@ -2,10 +2,10 @@
 title: v1alhpa1 API | Stash
 description: v1alpha1 Declarative API
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-crds
     parent: concepts
     name: v1alpha1 API
     weight: 20
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/concepts/crds/v1alpha1/recovery.md
+++ b/docs/concepts/crds/v1alpha1/recovery.md
@@ -1,13 +1,13 @@
 ---
 title: Recovery Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: recovery-overview
     name: Recovery
     parent: v1alpha1-crds
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/v1alpha1/recovery.md
+++ b/docs/concepts/crds/v1alpha1/recovery.md
@@ -1,13 +1,13 @@
 ---
 title: Recovery Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: recovery-overview
     name: Recovery
     parent: v1alpha1-crds
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/v1alpha1/restic.md
+++ b/docs/concepts/crds/v1alpha1/restic.md
@@ -1,13 +1,13 @@
 ---
 title: Restic Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: restic-overview
     name: Restic
     parent: v1alpha1-crds
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/crds/v1alpha1/restic.md
+++ b/docs/concepts/crds/v1alpha1/restic.md
@@ -1,13 +1,13 @@
 ---
 title: Restic Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: restic-overview
     name: Restic
     parent: v1alpha1-crds
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/what-is-stash/_index.md
+++ b/docs/concepts/what-is-stash/_index.md
@@ -2,10 +2,10 @@
 title: What is Stash
 description: What is Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: what-is-stash
     parent: concepts
     name: What is Stash
     weight: 10
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/concepts/what-is-stash/_index.md
+++ b/docs/concepts/what-is-stash/_index.md
@@ -2,10 +2,10 @@
 title: What is Stash
 description: What is Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: what-is-stash
     parent: concepts
     name: What is Stash
     weight: 10
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/concepts/what-is-stash/architecture.md
+++ b/docs/concepts/what-is-stash/architecture.md
@@ -2,13 +2,13 @@
 title: Stash Architecture
 description: Stash Architecture
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: architecture-concepts
     name: Architecture
     parent: what-is-stash
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/what-is-stash/architecture.md
+++ b/docs/concepts/what-is-stash/architecture.md
@@ -2,13 +2,13 @@
 title: Stash Architecture
 description: Stash Architecture
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: architecture-concepts
     name: Architecture
     parent: what-is-stash
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/what-is-stash/overview.md
+++ b/docs/concepts/what-is-stash/overview.md
@@ -2,13 +2,13 @@
 title: Stash Overview
 description: Stash Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: overview-concepts
     name: Overview
     parent: what-is-stash
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: concepts
 ---
 

--- a/docs/concepts/what-is-stash/overview.md
+++ b/docs/concepts/what-is-stash/overview.md
@@ -2,13 +2,13 @@
 title: Stash Overview
 description: Stash Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: overview-concepts
     name: Overview
     parent: what-is-stash
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: concepts
 ---
 

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Guides | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: guides
     name: Guides
     weight: 40
     pre: dropdown
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Guides | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: guides
     name: Guides
     weight: 40
     pre: dropdown
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/README.md
+++ b/docs/guides/latest/README.md
@@ -2,17 +2,17 @@
 title: Table of Contents | Guides
 description: Table of Contents | Guides
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: latest-guides-readme
     name: Readme
     parent: latest-guides
     weight: -1
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
-url: /products/stash/{{ .Version }}/guides/latest/
+url: /products/stash/{{ .version }}/guides/latest/
 aliases:
-  - /products/stash/{{ .Version }}/guides/latest/README/
+  - /products/stash/{{ .version }}/guides/latest/README/
 ---
 
 # Guides

--- a/docs/guides/latest/README.md
+++ b/docs/guides/latest/README.md
@@ -2,17 +2,17 @@
 title: Table of Contents | Guides
 description: Table of Contents | Guides
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: latest-guides-readme
     name: Readme
     parent: latest-guides
     weight: -1
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
-url: /products/stash/v0.9.0-rc.0/guides/latest/
+url: /products/stash/{{ .Version }}/guides/latest/
 aliases:
-  - /products/stash/v0.9.0-rc.0/guides/latest/README/
+  - /products/stash/{{ .Version }}/guides/latest/README/
 ---
 
 # Guides

--- a/docs/guides/latest/_index.md
+++ b/docs/guides/latest/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Latest Guides
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: latest-guides
     name: Latest Guides
     parent: guides
     weight: 10
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/_index.md
+++ b/docs/guides/latest/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Latest Guides
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: latest-guides
     name: Latest Guides
     parent: guides
     weight: 10
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/advanced-use-case/_index.md
+++ b/docs/guides/latest/advanced-use-case/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Advance Use Cases | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: advance-use-case
     name: Advance Use Cases
     parent: latest-guides
     weight: 80
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/advanced-use-case/_index.md
+++ b/docs/guides/latest/advanced-use-case/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Advance Use Cases | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: advance-use-case
     name: Advance Use Cases
     parent: latest-guides
     weight: 80
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/advanced-use-case/clone-pvc.md
+++ b/docs/guides/latest/advanced-use-case/clone-pvc.md
@@ -2,13 +2,13 @@
 title: Clone Data Volumes | Stash
 description: An step by step guide on how to clone data volumes using Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: advance-use-case-clone-pvc
     name: Clone Data Volumes
     parent: advance-use-case
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/clone-pvc.md
+++ b/docs/guides/latest/advanced-use-case/clone-pvc.md
@@ -2,13 +2,13 @@
 title: Clone Data Volumes | Stash
 description: An step by step guide on how to clone data volumes using Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: advance-use-case-clone-pvc
     name: Clone Data Volumes
     parent: advance-use-case
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/instant-backup.md
+++ b/docs/guides/latest/advanced-use-case/instant-backup.md
@@ -2,13 +2,13 @@
 title: Instant Backup | Stash
 description: An step by step guide on how to take instant backup using Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: advance-use-case-instant-backup
     name: Instant Backup
     parent: advance-use-case
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/instant-backup.md
+++ b/docs/guides/latest/advanced-use-case/instant-backup.md
@@ -2,13 +2,13 @@
 title: Instant Backup | Stash
 description: An step by step guide on how to take instant backup using Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: advance-use-case-instant-backup
     name: Instant Backup
     parent: advance-use-case
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/ownership.md
+++ b/docs/guides/latest/advanced-use-case/ownership.md
@@ -2,13 +2,13 @@
 title: File Ownership | Stash
 description: Handling Restored File Ownership in Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: file-ownership-stash
     name: File Ownership
     parent: advance-use-case
     weight: 150
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/ownership.md
+++ b/docs/guides/latest/advanced-use-case/ownership.md
@@ -2,13 +2,13 @@
 title: File Ownership | Stash
 description: Handling Restored File Ownership in Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: file-ownership-stash
     name: File Ownership
     parent: advance-use-case
     weight: 150
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/pause-backup.md
+++ b/docs/guides/latest/advanced-use-case/pause-backup.md
@@ -2,13 +2,13 @@
 title: Pause Backup | Stash
 description: An step by step guide on how to pause a scheduled backup in Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: advance-use-case-pause-backup
     name: Pause Backup
     parent: advance-use-case
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/advanced-use-case/pause-backup.md
+++ b/docs/guides/latest/advanced-use-case/pause-backup.md
@@ -2,13 +2,13 @@
 title: Pause Backup | Stash
 description: An step by step guide on how to pause a scheduled backup in Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: advance-use-case-pause-backup
     name: Pause Backup
     parent: advance-use-case
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/_index.md
+++ b/docs/guides/latest/auto-backup/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Auto Backup | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: auto-backup
     name: Auto Backup
     parent: latest-guides
     weight: 60
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/auto-backup/_index.md
+++ b/docs/guides/latest/auto-backup/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Auto Backup | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: auto-backup
     name: Auto Backup
     parent: latest-guides
     weight: 60
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/auto-backup/database.md
+++ b/docs/guides/latest/auto-backup/database.md
@@ -2,13 +2,13 @@
 title: Auto Backup Databases | Stash
 description: An step by step guide on how to configure automatic backup for Databases.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: auto-backup-database
     name: Auto Backup for Databases
     parent: auto-backup
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/database.md
+++ b/docs/guides/latest/auto-backup/database.md
@@ -2,13 +2,13 @@
 title: Auto Backup Databases | Stash
 description: An step by step guide on how to configure automatic backup for Databases.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: auto-backup-database
     name: Auto Backup for Databases
     parent: auto-backup
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/overview.md
+++ b/docs/guides/latest/auto-backup/overview.md
@@ -2,13 +2,13 @@
 title: Auto Backup Overview | Stash
 description: An overview on how auto backup works in Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: auto-backup-overview
     name: What is Auto Backup?
     parent: auto-backup
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/overview.md
+++ b/docs/guides/latest/auto-backup/overview.md
@@ -2,13 +2,13 @@
 title: Auto Backup Overview | Stash
 description: An overview on how auto backup works in Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: auto-backup-overview
     name: What is Auto Backup?
     parent: auto-backup
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/pvc.md
+++ b/docs/guides/latest/auto-backup/pvc.md
@@ -2,13 +2,13 @@
 title: Auto Backup PVC | Stash
 description: An step by step guide on how to configure automatic backup for PVCs.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: auto-backup-pvc
     name: Auto Backup for PVCs
     parent: auto-backup
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/pvc.md
+++ b/docs/guides/latest/auto-backup/pvc.md
@@ -2,13 +2,13 @@
 title: Auto Backup PVC | Stash
 description: An step by step guide on how to configure automatic backup for PVCs.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: auto-backup-pvc
     name: Auto Backup for PVCs
     parent: auto-backup
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/workload.md
+++ b/docs/guides/latest/auto-backup/workload.md
@@ -2,13 +2,13 @@
 title: Auto Backup Workload | Stash
 description: An step by step guide on how to configure automatic backup for workloads.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: auto-backup-workload
     name: Auto Backup for Workloads
     parent: auto-backup
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/auto-backup/workload.md
+++ b/docs/guides/latest/auto-backup/workload.md
@@ -2,13 +2,13 @@
 title: Auto Backup Workload | Stash
 description: An step by step guide on how to configure automatic backup for workloads.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: auto-backup-workload
     name: Auto Backup for Workloads
     parent: auto-backup
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/_index.md
+++ b/docs/guides/latest/backends/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Backends | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend
     name: Supported Backends
     parent: latest-guides
     weight: 10
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/backends/_index.md
+++ b/docs/guides/latest/backends/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Backends | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend
     name: Supported Backends
     parent: latest-guides
     weight: 10
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/backends/azure.md
+++ b/docs/guides/latest/backends/azure.md
@@ -2,13 +2,13 @@
 title: Azure Backend | Stash
 description: Configure Stash to use Microsoft Azure Storage as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-azure
     name: Azure Blob Storage
     parent: backend
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/azure.md
+++ b/docs/guides/latest/backends/azure.md
@@ -2,13 +2,13 @@
 title: Azure Backend | Stash
 description: Configure Stash to use Microsoft Azure Storage as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-azure
     name: Azure Blob Storage
     parent: backend
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -72,7 +72,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/azure.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/azure.yaml
 repository/azure-repo created
 ```
 

--- a/docs/guides/latest/backends/azure.md
+++ b/docs/guides/latest/backends/azure.md
@@ -72,7 +72,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/azure.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/azure.yaml
 repository/azure-repo created
 ```
 

--- a/docs/guides/latest/backends/b2.md
+++ b/docs/guides/latest/backends/b2.md
@@ -2,13 +2,13 @@
 title: Backblaze B2 Backend | Stash
 description: Configure Stash to use Backblaze B2 as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-b2
     name: Backblaze B2
     parent: backend
     weight: 70
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/b2.md
+++ b/docs/guides/latest/backends/b2.md
@@ -72,7 +72,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/b2.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/b2.yaml
 repository/b2-repo created
 ```
 

--- a/docs/guides/latest/backends/b2.md
+++ b/docs/guides/latest/backends/b2.md
@@ -2,13 +2,13 @@
 title: Backblaze B2 Backend | Stash
 description: Configure Stash to use Backblaze B2 as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-b2
     name: Backblaze B2
     parent: backend
     weight: 70
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -72,7 +72,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/b2.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/b2.yaml
 repository/b2-repo created
 ```
 

--- a/docs/guides/latest/backends/gcs.md
+++ b/docs/guides/latest/backends/gcs.md
@@ -2,13 +2,13 @@
 title: GCS Backend | Stash
 description: Configure Stash to use Google Cloud Storage (GCS) as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-gcs
     name: Google Cloud Storage
     parent: backend
     weight: 50
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/gcs.md
+++ b/docs/guides/latest/backends/gcs.md
@@ -74,7 +74,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/gcs.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/gcs.yaml
 repository/gcs-repo created
 ```
 

--- a/docs/guides/latest/backends/gcs.md
+++ b/docs/guides/latest/backends/gcs.md
@@ -2,13 +2,13 @@
 title: GCS Backend | Stash
 description: Configure Stash to use Google Cloud Storage (GCS) as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-gcs
     name: Google Cloud Storage
     parent: backend
     weight: 50
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -74,7 +74,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/gcs.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/gcs.yaml
 repository/gcs-repo created
 ```
 

--- a/docs/guides/latest/backends/local.md
+++ b/docs/guides/latest/backends/local.md
@@ -2,13 +2,13 @@
 title: Local Backend | Stash
 description: Configure Stash to Use Local Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-local
     name: Kubernetes Volumes
     parent: backend
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/local.md
+++ b/docs/guides/latest/backends/local.md
@@ -2,13 +2,13 @@
 title: Local Backend | Stash
 description: Configure Stash to Use Local Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-local
     name: Kubernetes Volumes
     parent: backend
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -70,7 +70,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_hostPath.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_hostPath.yaml
 repository/local-repo-with-hostpath created
 ```
 
@@ -98,7 +98,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_pvc.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_pvc.yaml
 repository/local-repo-with-pvc created
 ```
 
@@ -125,7 +125,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_nfs.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_nfs.yaml
 repository/local-repo-with-nfs created
 ```
 
@@ -152,7 +152,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_gcePersistentDisk.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_gcePersistentDisk.yaml
 repository/local-repo-with-gcepersistentdisk created
 ```
 
@@ -181,7 +181,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_awsElasticBlockStore.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_awsElasticBlockStore.yaml
 repository/local-repo-with-awsebs created
 ```
 
@@ -210,7 +210,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_azureDisk.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_azureDisk.yaml
 repository/local-repo-with-azuredisk created
 ```
 
@@ -237,7 +237,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/local_storageOS.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_storageOS.yaml
 repository/local-repo-with-storageos created
 ```
 
@@ -262,7 +262,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/emptyDir.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/emptyDir.yaml
 repository/local-repo-with-emptydir created
 ```
 

--- a/docs/guides/latest/backends/local.md
+++ b/docs/guides/latest/backends/local.md
@@ -70,7 +70,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_hostPath.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_hostPath.yaml
 repository/local-repo-with-hostpath created
 ```
 
@@ -98,7 +98,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_pvc.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_pvc.yaml
 repository/local-repo-with-pvc created
 ```
 
@@ -125,7 +125,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_nfs.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_nfs.yaml
 repository/local-repo-with-nfs created
 ```
 
@@ -152,7 +152,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_gcePersistentDisk.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_gcePersistentDisk.yaml
 repository/local-repo-with-gcepersistentdisk created
 ```
 
@@ -181,7 +181,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_awsElasticBlockStore.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_awsElasticBlockStore.yaml
 repository/local-repo-with-awsebs created
 ```
 
@@ -210,7 +210,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_azureDisk.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_azureDisk.yaml
 repository/local-repo-with-azuredisk created
 ```
 
@@ -237,7 +237,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/local_storageOS.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/local_storageOS.yaml
 repository/local-repo-with-storageos created
 ```
 
@@ -262,7 +262,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/emptyDir.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/emptyDir.yaml
 repository/local-repo-with-emptydir created
 ```
 

--- a/docs/guides/latest/backends/overview.md
+++ b/docs/guides/latest/backends/overview.md
@@ -2,13 +2,13 @@
 title: Backend Overview | Stash
 description: An overview of the backends used by Stash to store backed up data.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-overview
     name: What is Backend?
     parent: backend
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/overview.md
+++ b/docs/guides/latest/backends/overview.md
@@ -2,13 +2,13 @@
 title: Backend Overview | Stash
 description: An overview of the backends used by Stash to store backed up data.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-overview
     name: What is Backend?
     parent: backend
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/rest.md
+++ b/docs/guides/latest/backends/rest.md
@@ -70,7 +70,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/rest.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/rest.yaml
 repository/rest-repo created
 ```
 

--- a/docs/guides/latest/backends/rest.md
+++ b/docs/guides/latest/backends/rest.md
@@ -2,13 +2,13 @@
 title: REST Backend | Stash
 description: Configure Stash to REST Server as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-rest
     name: REST Server
     parent: backend
     weight: 80
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/rest.md
+++ b/docs/guides/latest/backends/rest.md
@@ -2,13 +2,13 @@
 title: REST Backend | Stash
 description: Configure Stash to REST Server as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-rest
     name: REST Server
     parent: backend
     weight: 80
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -70,7 +70,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/rest.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/rest.yaml
 repository/rest-repo created
 ```
 

--- a/docs/guides/latest/backends/s3.md
+++ b/docs/guides/latest/backends/s3.md
@@ -2,13 +2,13 @@
 title: AWS S3/Minio/Rook Backend | Stash
 description: Configure Stash to use AWS S3/Minio/Rook as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-s3
     name: AWS S3/Minio/Rook
     parent: backend
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -89,7 +89,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/s3.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/s3.yaml
 repository/s3-repo created
 ```
 

--- a/docs/guides/latest/backends/s3.md
+++ b/docs/guides/latest/backends/s3.md
@@ -89,7 +89,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/s3.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/s3.yaml
 repository/s3-repo created
 ```
 

--- a/docs/guides/latest/backends/s3.md
+++ b/docs/guides/latest/backends/s3.md
@@ -2,13 +2,13 @@
 title: AWS S3/Minio/Rook Backend | Stash
 description: Configure Stash to use AWS S3/Minio/Rook as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-s3
     name: AWS S3/Minio/Rook
     parent: backend
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/backends/swift.md
+++ b/docs/guides/latest/backends/swift.md
@@ -2,13 +2,13 @@
 title: Swift Backend | Stash
 description: Configure Stash to use OpenStack Swift as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backend-swift
     name: OpenStack Swift
     parent: backend
     weight: 60
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -143,7 +143,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/backends/swift.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/swift.yaml
 repository/swift-repo created
 ```
 

--- a/docs/guides/latest/backends/swift.md
+++ b/docs/guides/latest/backends/swift.md
@@ -143,7 +143,7 @@ spec:
 Create the `Repository` we have shown above using the following command,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/backends/swift.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/backends/swift.yaml
 repository/swift-repo created
 ```
 

--- a/docs/guides/latest/backends/swift.md
+++ b/docs/guides/latest/backends/swift.md
@@ -2,13 +2,13 @@
 title: Swift Backend | Stash
 description: Configure Stash to use OpenStack Swift as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backend-swift
     name: OpenStack Swift
     parent: backend
     weight: 60
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/databases/_index.md
+++ b/docs/guides/latest/databases/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Database Backup | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: database-backup
     name: Databases
     parent: latest-guides
     weight: 40
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/databases/_index.md
+++ b/docs/guides/latest/databases/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Database Backup | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: database-backup
     name: Databases
     parent: latest-guides
     weight: 40
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/databases/overview.md
+++ b/docs/guides/latest/databases/overview.md
@@ -2,13 +2,13 @@
 title: Database Backup Overview | Stash
 description: An overview of how Database backup works in Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: database-backup-overview
     name: How does it work?
     parent: database-backup
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/databases/overview.md
+++ b/docs/guides/latest/databases/overview.md
@@ -2,13 +2,13 @@
 title: Database Backup Overview | Stash
 description: An overview of how Database backup works in Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: database-backup-overview
     name: How does it work?
     parent: database-backup
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/monitoring/_index.md
+++ b/docs/guides/latest/monitoring/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Monitoring | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: monitoring
     name: Monitoring
     parent: latest-guides
     weight: 100
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/monitoring/_index.md
+++ b/docs/guides/latest/monitoring/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Monitoring | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: monitoring
     name: Monitoring
     parent: latest-guides
     weight: 100
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/monitoring/builtin.md
+++ b/docs/guides/latest/monitoring/builtin.md
@@ -32,7 +32,7 @@ namespace/monitoring created
 Enable Prometheus monitoring using `prometheus.io/builtin` agent while installing Stash. To know details about how to enable monitoring see [here](/docs/guides/v1alpha1/monitoring/overview.md#how-to-enable-monitoring). Here, we are going to enable monitoring for `backup`, `restore` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/builtin \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -120,7 +120,7 @@ stash-apiserver-cert   kubernetes.io/tls   2      2m21s
 If you are using a RBAC enabled cluster, you have to give necessary RBAC permissions for Prometheus. Let's create necessary RBAC stuffs for Prometheus,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/builtin/prom-rbac.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/monitoring/builtin/prom-rbac.yaml
 clusterrole.rbac.authorization.k8s.io/stash-prometheus-server created
 serviceaccount/stash-prometheus-server created
 clusterrolebinding.rbac.authorization.k8s.io/stash-prometheus-server created
@@ -245,7 +245,7 @@ Also note that, we have provided a bearer-token file through `bearer_token_file`
 Let's create the ConfigMap we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/builtin/prom-config.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/monitoring/builtin/prom-config.yaml
 configmap/stash-prometheus-server-conf created
 ```
 
@@ -306,7 +306,7 @@ Notice that, we have mounted `stash-apiserver-cert` secret as a volume at `/etc/
 Now, let's create the deployment,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/builtin/prom-deployment.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/monitoring/builtin/prom-deployment.yaml
 deployment.apps/stash-prometheus-server created
 ```
 

--- a/docs/guides/latest/monitoring/builtin.md
+++ b/docs/guides/latest/monitoring/builtin.md
@@ -2,13 +2,13 @@
 title: Builtin Prometheus | Stash
 description: Monitor Stash using official Prometheus server
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: monitoring-builtin
     name: Builtin Prometheus
     parent: monitoring
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/monitoring/builtin.md
+++ b/docs/guides/latest/monitoring/builtin.md
@@ -2,13 +2,13 @@
 title: Builtin Prometheus | Stash
 description: Monitor Stash using official Prometheus server
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: monitoring-builtin
     name: Builtin Prometheus
     parent: monitoring
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -32,7 +32,7 @@ namespace/monitoring created
 Enable Prometheus monitoring using `prometheus.io/builtin` agent while installing Stash. To know details about how to enable monitoring see [here](/docs/guides/v1alpha1/monitoring/overview.md#how-to-enable-monitoring). Here, we are going to enable monitoring for `backup`, `restore` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/builtin \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -120,7 +120,7 @@ stash-apiserver-cert   kubernetes.io/tls   2      2m21s
 If you are using a RBAC enabled cluster, you have to give necessary RBAC permissions for Prometheus. Let's create necessary RBAC stuffs for Prometheus,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/monitoring/builtin/prom-rbac.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/builtin/prom-rbac.yaml
 clusterrole.rbac.authorization.k8s.io/stash-prometheus-server created
 serviceaccount/stash-prometheus-server created
 clusterrolebinding.rbac.authorization.k8s.io/stash-prometheus-server created
@@ -245,7 +245,7 @@ Also note that, we have provided a bearer-token file through `bearer_token_file`
 Let's create the ConfigMap we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/monitoring/builtin/prom-config.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/builtin/prom-config.yaml
 configmap/stash-prometheus-server-conf created
 ```
 
@@ -306,7 +306,7 @@ Notice that, we have mounted `stash-apiserver-cert` secret as a volume at `/etc/
 Now, let's create the deployment,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/monitoring/builtin/prom-deployment.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/builtin/prom-deployment.yaml
 deployment.apps/stash-prometheus-server created
 ```
 

--- a/docs/guides/latest/monitoring/coreos.md
+++ b/docs/guides/latest/monitoring/coreos.md
@@ -2,13 +2,13 @@
 title: CoreOS Prometheus Operator | Stash
 description: Monitor Stash using CoreOS Prometheus operator
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: monitoring-coreos-operator
     name: Prometheus Operator
     parent: monitoring
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -36,7 +36,7 @@ Enable Prometheus monitoring using `prometheus.io/coreos-operator` agent while i
 Here, we are going to enable monitoring for both `backup`, `restore` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -135,7 +135,7 @@ Here, `spec.serviceMonitorSelector` is used to select the `ServiceMonitor` crd t
 Let's create the `Prometheus` object we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/guides/latest/monitoring/coreos/prometheus.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/coreos/prometheus.yaml
 prometheus.monitoring.coreos.com/prometheus created
 ```
 

--- a/docs/guides/latest/monitoring/coreos.md
+++ b/docs/guides/latest/monitoring/coreos.md
@@ -2,13 +2,13 @@
 title: CoreOS Prometheus Operator | Stash
 description: Monitor Stash using CoreOS Prometheus operator
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: monitoring-coreos-operator
     name: Prometheus Operator
     parent: monitoring
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/monitoring/coreos.md
+++ b/docs/guides/latest/monitoring/coreos.md
@@ -36,7 +36,7 @@ Enable Prometheus monitoring using `prometheus.io/coreos-operator` agent while i
 Here, we are going to enable monitoring for both `backup`, `restore` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -135,7 +135,7 @@ Here, `spec.serviceMonitorSelector` is used to select the `ServiceMonitor` crd t
 Let's create the `Prometheus` object we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/guides/latest/monitoring/coreos/prometheus.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/guides/latest/monitoring/coreos/prometheus.yaml
 prometheus.monitoring.coreos.com/prometheus created
 ```
 

--- a/docs/guides/latest/monitoring/overview.md
+++ b/docs/guides/latest/monitoring/overview.md
@@ -2,13 +2,13 @@
 title: Monitoring Overview | Stash
 description: A general overview of monitoring Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: monitoring-overview
     name: Overview
     parent: monitoring
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -149,7 +149,7 @@ You have to provides these flags while installing or upgrading or updating Stash
 **Helm:**
 
 ```console
-$ helm install appscode/stash --name stash-operator --version v0.9.0-rc.0 --namespace kube-system \
+$ helm install appscode/stash --name stash-operator --version {{ .Version }} --namespace kube-system \
   --set monitoring.agent=prometheus.io/coreos-operator \
   --set monitoring.backup=true \
   --set monitoring.operator=true \
@@ -160,7 +160,7 @@ $ helm install appscode/stash --name stash-operator --version v0.9.0-rc.0 --name
 **Script:**
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh  | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh  | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \

--- a/docs/guides/latest/monitoring/overview.md
+++ b/docs/guides/latest/monitoring/overview.md
@@ -149,7 +149,7 @@ You have to provides these flags while installing or upgrading or updating Stash
 **Helm:**
 
 ```console
-$ helm install appscode/stash --name stash-operator --version {{ .Version }} --namespace kube-system \
+$ helm install appscode/stash --name stash-operator --version {{< param "info.version" >}} --namespace kube-system \
   --set monitoring.agent=prometheus.io/coreos-operator \
   --set monitoring.backup=true \
   --set monitoring.operator=true \
@@ -160,7 +160,7 @@ $ helm install appscode/stash --name stash-operator --version {{ .Version }} --n
 **Script:**
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh  | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh  | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \

--- a/docs/guides/latest/monitoring/overview.md
+++ b/docs/guides/latest/monitoring/overview.md
@@ -2,13 +2,13 @@
 title: Monitoring Overview | Stash
 description: A general overview of monitoring Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: monitoring-overview
     name: Overview
     parent: monitoring
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/_index.md
+++ b/docs/guides/latest/platforms/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Platforms | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: platforms
     name: Platforms
     parent: latest-guides
     weight: 90
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/platforms/_index.md
+++ b/docs/guides/latest/platforms/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Platforms | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: platforms
     name: Platforms
     parent: latest-guides
     weight: 90
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/platforms/aks.md
+++ b/docs/guides/latest/platforms/aks.md
@@ -2,13 +2,13 @@
 title: AKS | Stash
 description: Using Stash in Azure Kubernetes Service
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: platforms-aks
     name: AKS
     parent: platforms
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/aks.md
+++ b/docs/guides/latest/platforms/aks.md
@@ -2,13 +2,13 @@
 title: AKS | Stash
 description: Using Stash in Azure Kubernetes Service
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: platforms-aks
     name: AKS
     parent: platforms
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/eks.md
+++ b/docs/guides/latest/platforms/eks.md
@@ -2,13 +2,13 @@
 title: EKS | Stash
 description: Using Stash in Amazon EKS
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: platforms-eks
     name: EKS
     parent: platforms
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/eks.md
+++ b/docs/guides/latest/platforms/eks.md
@@ -2,13 +2,13 @@
 title: EKS | Stash
 description: Using Stash in Amazon EKS
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: platforms-eks
     name: EKS
     parent: platforms
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/gke.md
+++ b/docs/guides/latest/platforms/gke.md
@@ -2,13 +2,13 @@
 title: GKE | Stash
 description: Using Stash in Google Kubernetes Engine
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: platforms-gke
     name: GKE
     parent: platforms
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/gke.md
+++ b/docs/guides/latest/platforms/gke.md
@@ -2,13 +2,13 @@
 title: GKE | Stash
 description: Using Stash in Google Kubernetes Engine
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: platforms-gke
     name: GKE
     parent: platforms
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/minio.md
+++ b/docs/guides/latest/platforms/minio.md
@@ -2,13 +2,13 @@
 title: Minio | Stash
 description: Using Stash with TLS secured Minio Server
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: platforms-minio
     name: Minio
     parent: platforms
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/minio.md
+++ b/docs/guides/latest/platforms/minio.md
@@ -2,13 +2,13 @@
 title: Minio | Stash
 description: Using Stash with TLS secured Minio Server
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: platforms-minio
     name: Minio
     parent: platforms
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/rook.md
+++ b/docs/guides/latest/platforms/rook.md
@@ -2,13 +2,13 @@
 title: Rook | Stash
 description: Using Stash with Rook Storage Service
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: platforms-rook
     name: Rook
     parent: platforms
     weight: 50
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/platforms/rook.md
+++ b/docs/guides/latest/platforms/rook.md
@@ -2,13 +2,13 @@
 title: Rook | Stash
 description: Using Stash with Rook Storage Service
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: platforms-rook
     name: Rook
     parent: platforms
     weight: 50
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumes/_index.md
+++ b/docs/guides/latest/volumes/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Volume Backup | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-backup
     name: Stand-alone Volumes
     parent: latest-guides
     weight: 30
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/volumes/_index.md
+++ b/docs/guides/latest/volumes/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Volume Backup | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-backup
     name: Stand-alone Volumes
     parent: latest-guides
     weight: 30
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/volumes/overview.md
+++ b/docs/guides/latest/volumes/overview.md
@@ -2,13 +2,13 @@
 title: Stand-alone Volume Backup Overview | Stash
 description: An overview on how stand-alone volume backup works in Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-backup-overview
     name: How does it work?
     parent: volume-backup
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumes/overview.md
+++ b/docs/guides/latest/volumes/overview.md
@@ -2,13 +2,13 @@
 title: Stand-alone Volume Backup Overview | Stash
 description: An overview on how stand-alone volume backup works in Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-backup-overview
     name: How does it work?
     parent: volume-backup
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumes/pvc.md
+++ b/docs/guides/latest/volumes/pvc.md
@@ -2,13 +2,13 @@
 title: Backup Stand-alone PVC | Stash
 description: A step by step guide on how to backup a stand-alone PVC using Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-backup-pvc
     name: Backup & Restore a Stand-alone PVC
     parent: volume-backup
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumes/pvc.md
+++ b/docs/guides/latest/volumes/pvc.md
@@ -2,13 +2,13 @@
 title: Backup Stand-alone PVC | Stash
 description: A step by step guide on how to backup a stand-alone PVC using Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-backup-pvc
     name: Backup & Restore a Stand-alone PVC
     parent: volume-backup
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/_index.md
+++ b/docs/guides/latest/volumesnapshot/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Volume Snapshot | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-snapshot
     name: Volume Snapshot
     parent: latest-guides
     weight: 70
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/volumesnapshot/_index.md
+++ b/docs/guides/latest/volumesnapshot/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Volume Snapshot | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-snapshot
     name: Volume Snapshot
     parent: latest-guides
     weight: 70
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/volumesnapshot/deployment.md
+++ b/docs/guides/latest/volumesnapshot/deployment.md
@@ -2,13 +2,13 @@
 title: Snapshot Deployment Volumes | Stash
 description: An step by step guide showing how to snapshot the volumes of a Deployment
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-snapshot-deployment
     name: Snapshot Deployment Volumes
     parent: volume-snapshot
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/deployment.md
+++ b/docs/guides/latest/volumesnapshot/deployment.md
@@ -2,13 +2,13 @@
 title: Snapshot Deployment Volumes | Stash
 description: An step by step guide showing how to snapshot the volumes of a Deployment
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-snapshot-deployment
     name: Snapshot Deployment Volumes
     parent: volume-snapshot
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/overview.md
+++ b/docs/guides/latest/volumesnapshot/overview.md
@@ -2,13 +2,13 @@
 title: VolumeSnapshot Overview | Stash
 description: An overview of how VolumeSnapshot works in Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-snapshot-overview
     name: How VolumeSnapshot works?
     parent: volume-snapshot
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/overview.md
+++ b/docs/guides/latest/volumesnapshot/overview.md
@@ -2,13 +2,13 @@
 title: VolumeSnapshot Overview | Stash
 description: An overview of how VolumeSnapshot works in Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-snapshot-overview
     name: How VolumeSnapshot works?
     parent: volume-snapshot
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/pvc.md
+++ b/docs/guides/latest/volumesnapshot/pvc.md
@@ -2,13 +2,13 @@
 title: Snapshot Stand-alone PVC | Stash
 description: An step by step guide showing how to snapshot a stand-alone PVC
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-snapshot-pvc
     name: Snapshot Stand-alone PVC
     parent: volume-snapshot
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/pvc.md
+++ b/docs/guides/latest/volumesnapshot/pvc.md
@@ -2,13 +2,13 @@
 title: Snapshot Stand-alone PVC | Stash
 description: An step by step guide showing how to snapshot a stand-alone PVC
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-snapshot-pvc
     name: Snapshot Stand-alone PVC
     parent: volume-snapshot
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/statefulset.md
+++ b/docs/guides/latest/volumesnapshot/statefulset.md
@@ -2,13 +2,13 @@
 title: Snapshot StatefulSet Volumes | Stash
 description: An step by step guide showing how to snapshot the volumes of a StatefulSet
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: volume-snapshot-statefulset
     name: Snapshot StatefulSet Volumes
     parent: volume-snapshot
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/volumesnapshot/statefulset.md
+++ b/docs/guides/latest/volumesnapshot/statefulset.md
@@ -2,13 +2,13 @@
 title: Snapshot StatefulSet Volumes | Stash
 description: An step by step guide showing how to snapshot the volumes of a StatefulSet
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: volume-snapshot-statefulset
     name: Snapshot StatefulSet Volumes
     parent: volume-snapshot
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/_index.md
+++ b/docs/guides/latest/workloads/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Backup & Restore Volumes of Workloads | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: workload
     name: Workload's Volumes
     parent: latest-guides
     weight: 20
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/latest/workloads/_index.md
+++ b/docs/guides/latest/workloads/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Backup & Restore Volumes of Workloads | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: workload
     name: Workload's Volumes
     parent: latest-guides
     weight: 20
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/latest/workloads/daemonset.md
+++ b/docs/guides/latest/workloads/daemonset.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Volumes of a DaemonSet | Stash
 description: A step by step guide showing how to backup and restore volumes of a DaemonSet.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: workload-daemonset
     name: Backup & Restore Volumes of a DaemonSet
     parent: workload
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/daemonset.md
+++ b/docs/guides/latest/workloads/daemonset.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Volumes of a DaemonSet | Stash
 description: A step by step guide showing how to backup and restore volumes of a DaemonSet.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: workload-daemonset
     name: Backup & Restore Volumes of a DaemonSet
     parent: workload
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/deployment.md
+++ b/docs/guides/latest/workloads/deployment.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Volumes of a Deployment | Stash
 description: A step by step guide showing how to backup and restore volumes of a Deployment.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: workload-deployment
     name: Backup & Restore Volumes of a Deployment
     parent: workload
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/deployment.md
+++ b/docs/guides/latest/workloads/deployment.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Volumes of a Deployment | Stash
 description: A step by step guide showing how to backup and restore volumes of a Deployment.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: workload-deployment
     name: Backup & Restore Volumes of a Deployment
     parent: workload
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/overview.md
+++ b/docs/guides/latest/workloads/overview.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Workload Data Overview | Stash
 description: An overview on how Backup and Restore of workload data works in Stash.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: workload-overview
     name: How Backup and Restore works?
     parent: workload
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/overview.md
+++ b/docs/guides/latest/workloads/overview.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Workload Data Overview | Stash
 description: An overview on how Backup and Restore of workload data works in Stash.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: workload-overview
     name: How Backup and Restore works?
     parent: workload
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/statefulset.md
+++ b/docs/guides/latest/workloads/statefulset.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Volumes of a StatefulSet | Stash
 description: A step by step guide showing how to backup and restore volumes of a StatefulSet.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: workload-statefulset
     name: Backup & Restore Volumes of a StatefulSet
     parent: workload
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/latest/workloads/statefulset.md
+++ b/docs/guides/latest/workloads/statefulset.md
@@ -2,13 +2,13 @@
 title: Backup and Restore Volumes of a StatefulSet | Stash
 description: A step by step guide showing how to backup and restore volumes of a StatefulSet.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: workload-statefulset
     name: Backup & Restore Volumes of a StatefulSet
     parent: workload
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/README.md
+++ b/docs/guides/v1alpha1/README.md
@@ -2,17 +2,17 @@
 title: Table of Contents | Guides
 description: Table of Contents | Guides
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-guides-readme
     name: Readme
     parent: v1alpha1-guides
     weight: -1
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
-url: /products/stash/{{ .Version }}/guides/v1alpha1/
+url: /products/stash/{{ .version }}/guides/v1alpha1/
 aliases:
-  - /products/stash/{{ .Version }}/guides/v1alpha1/README/
+  - /products/stash/{{ .version }}/guides/v1alpha1/README/
 ---
 # Guides
 

--- a/docs/guides/v1alpha1/README.md
+++ b/docs/guides/v1alpha1/README.md
@@ -2,17 +2,17 @@
 title: Table of Contents | Guides
 description: Table of Contents | Guides
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-guides-readme
     name: Readme
     parent: v1alpha1-guides
     weight: -1
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
-url: /products/stash/v0.9.0-rc.0/guides/v1alpha1/
+url: /products/stash/{{ .Version }}/guides/v1alpha1/
 aliases:
-  - /products/stash/v0.9.0-rc.0/guides/v1alpha1/README/
+  - /products/stash/{{ .Version }}/guides/v1alpha1/README/
 ---
 # Guides
 

--- a/docs/guides/v1alpha1/_index.md
+++ b/docs/guides/v1alpha1/_index.md
@@ -1,10 +1,10 @@
 ---
 title: v1alpha1 Guides
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-guides
     name: v1alpha1 Guides
     parent: guides
     weight: 20
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/v1alpha1/_index.md
+++ b/docs/guides/v1alpha1/_index.md
@@ -1,10 +1,10 @@
 ---
 title: v1alpha1 Guides
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-guides
     name: v1alpha1 Guides
     parent: guides
     weight: 20
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/v1alpha1/backends/_index.md
+++ b/docs/guides/v1alpha1/backends/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Backends | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend
     name: Supported Backends
     parent: v1alpha1-guides
     weight: 30
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/v1alpha1/backends/_index.md
+++ b/docs/guides/v1alpha1/backends/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Backends | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend
     name: Supported Backends
     parent: v1alpha1-guides
     weight: 30
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/v1alpha1/backends/azure.md
+++ b/docs/guides/v1alpha1/backends/azure.md
@@ -2,13 +2,13 @@
 title: Azure Backend | Stash
 description: Configure Stash to use Microsoft Azure Storage as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-azure
     name: Azure Blob Storage
     parent: v1alpha1-backend
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/azure.md
+++ b/docs/guides/v1alpha1/backends/azure.md
@@ -2,13 +2,13 @@
 title: Azure Backend | Stash
 description: Configure Stash to use Microsoft Azure Storage as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-azure
     name: Azure Blob Storage
     parent: v1alpha1-backend
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/b2.md
+++ b/docs/guides/v1alpha1/backends/b2.md
@@ -2,13 +2,13 @@
 title: Backblaze B2 Backend | Stash
 description: Configure Stash to use Backblaze B2 as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-b2
     name: Backblaze B2
     parent: v1alpha1-backend
     weight: 70
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/b2.md
+++ b/docs/guides/v1alpha1/backends/b2.md
@@ -2,13 +2,13 @@
 title: Backblaze B2 Backend | Stash
 description: Configure Stash to use Backblaze B2 as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-b2
     name: Backblaze B2
     parent: v1alpha1-backend
     weight: 70
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/gcs.md
+++ b/docs/guides/v1alpha1/backends/gcs.md
@@ -2,13 +2,13 @@
 title: GCS Backend | Stash
 description: Configure Stash to use Google Cloud Storage (GCS) as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-gcs
     name: Google Cloud Storage
     parent: v1alpha1-backend
     weight: 50
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/gcs.md
+++ b/docs/guides/v1alpha1/backends/gcs.md
@@ -2,13 +2,13 @@
 title: GCS Backend | Stash
 description: Configure Stash to use Google Cloud Storage (GCS) as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-gcs
     name: Google Cloud Storage
     parent: v1alpha1-backend
     weight: 50
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/local.md
+++ b/docs/guides/v1alpha1/backends/local.md
@@ -2,13 +2,13 @@
 title: Local Backend | Stash
 description: Configure Stash to Use Local Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-local
     name: Persistent Volumes
     parent: v1alpha1-backend
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/local.md
+++ b/docs/guides/v1alpha1/backends/local.md
@@ -2,13 +2,13 @@
 title: Local Backend | Stash
 description: Configure Stash to Use Local Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-local
     name: Persistent Volumes
     parent: v1alpha1-backend
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/overview.md
+++ b/docs/guides/v1alpha1/backends/overview.md
@@ -3,13 +3,13 @@
 title: Backend Overview | Stash
 description: An overview of backends used by Stash to store snapshot data.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-overview
     name: What is Backend?
     parent: v1alpha1-backend
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/overview.md
+++ b/docs/guides/v1alpha1/backends/overview.md
@@ -3,13 +3,13 @@
 title: Backend Overview | Stash
 description: An overview of backends used by Stash to store snapshot data.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-overview
     name: What is Backend?
     parent: v1alpha1-backend
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/s3.md
+++ b/docs/guides/v1alpha1/backends/s3.md
@@ -2,13 +2,13 @@
 title: AWS S3 Backend | Stash
 description: Configure Stash to use AWS S3 as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-s3
     name: AWS S3
     parent: v1alpha1-backend
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/s3.md
+++ b/docs/guides/v1alpha1/backends/s3.md
@@ -2,13 +2,13 @@
 title: AWS S3 Backend | Stash
 description: Configure Stash to use AWS S3 as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-s3
     name: AWS S3
     parent: v1alpha1-backend
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/swift.md
+++ b/docs/guides/v1alpha1/backends/swift.md
@@ -2,13 +2,13 @@
 title: Swift Backend | Stash
 description: Configure Stash to use OpenStack Swift as Backend.
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-backend-swift
     name: OpenStack Swift
     parent: v1alpha1-backend
     weight: 60
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backends/swift.md
+++ b/docs/guides/v1alpha1/backends/swift.md
@@ -2,13 +2,13 @@
 title: Swift Backend | Stash
 description: Configure Stash to use OpenStack Swift as Backend.
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-backend-swift
     name: OpenStack Swift
     parent: v1alpha1-backend
     weight: 60
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backup.md
+++ b/docs/guides/v1alpha1/backup.md
@@ -2,13 +2,13 @@
 title: Backup Volumes | Stash
 description: Backup Volumes using Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: backup-stash
     name: Backup Volumes
     parent: v1alpha1-guides
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/backup.md
+++ b/docs/guides/v1alpha1/backup.md
@@ -2,13 +2,13 @@
 title: Backup Volumes | Stash
 description: Backup Volumes using Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: backup-stash
     name: Backup Volumes
     parent: v1alpha1-guides
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/monitoring/_index.md
+++ b/docs/guides/v1alpha1/monitoring/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Monitoring | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-monitoring
     name: Monitoring
     parent: v1alpha1-guides
     weight: 40
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/v1alpha1/monitoring/_index.md
+++ b/docs/guides/v1alpha1/monitoring/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Monitoring | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-monitoring
     name: Monitoring
     parent: v1alpha1-guides
     weight: 40
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/v1alpha1/monitoring/builtin.md
+++ b/docs/guides/v1alpha1/monitoring/builtin.md
@@ -2,13 +2,13 @@
 title: Builtin Prometheus | Stash
 description: Monitor Stash using official Prometheus server
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-monitoring-builtin
     name: Builtin Prometheus
     parent: v1alpha1-monitoring
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -32,7 +32,7 @@ namespace/monitoring created
 Enable Prometheus monitoring using `prometheus.io/builtin` agent while installing Stash. To know details about how to enable monitoring see [here](/docs/guides/v1alpha1/monitoring/overview.md#how-to-enable-monitoring). Here, we are going to enable monitoring for both `backup & recovery` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/builtin \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -120,7 +120,7 @@ stash-apiserver-cert   kubernetes.io/tls   2      2m21s
 If you are using a RBAC enabled cluster, you have to give necessary RBAC permissions for Prometheus. Let's create necessary RBAC stuffs for Prometheus,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/monitoring/builtin/prom-rbac.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/builtin/prom-rbac.yaml
 clusterrole.rbac.authorization.k8s.io/stash-prometheus-server created
 serviceaccount/stash-prometheus-server created
 clusterrolebinding.rbac.authorization.k8s.io/stash-prometheus-server created
@@ -245,7 +245,7 @@ Also note that, we have provided a bearer-token file through `bearer_token_file`
 Let's create the ConfigMap we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/monitoring/builtin/prom-config.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/builtin/prom-config.yaml
 configmap/stash-prometheus-server-conf created
 ```
 
@@ -306,7 +306,7 @@ Notice that, we have mounted `stash-apiserver-cert` secret as a volume at `/etc/
 Now, let's create the deployment,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/monitoring/builtin/prom-deployment.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/builtin/prom-deployment.yaml
 deployment.apps/stash-prometheus-server created
 ```
 

--- a/docs/guides/v1alpha1/monitoring/builtin.md
+++ b/docs/guides/v1alpha1/monitoring/builtin.md
@@ -2,13 +2,13 @@
 title: Builtin Prometheus | Stash
 description: Monitor Stash using official Prometheus server
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-monitoring-builtin
     name: Builtin Prometheus
     parent: v1alpha1-monitoring
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/monitoring/builtin.md
+++ b/docs/guides/v1alpha1/monitoring/builtin.md
@@ -32,7 +32,7 @@ namespace/monitoring created
 Enable Prometheus monitoring using `prometheus.io/builtin` agent while installing Stash. To know details about how to enable monitoring see [here](/docs/guides/v1alpha1/monitoring/overview.md#how-to-enable-monitoring). Here, we are going to enable monitoring for both `backup & recovery` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/builtin \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -120,7 +120,7 @@ stash-apiserver-cert   kubernetes.io/tls   2      2m21s
 If you are using a RBAC enabled cluster, you have to give necessary RBAC permissions for Prometheus. Let's create necessary RBAC stuffs for Prometheus,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/builtin/prom-rbac.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/builtin/prom-rbac.yaml
 clusterrole.rbac.authorization.k8s.io/stash-prometheus-server created
 serviceaccount/stash-prometheus-server created
 clusterrolebinding.rbac.authorization.k8s.io/stash-prometheus-server created
@@ -245,7 +245,7 @@ Also note that, we have provided a bearer-token file through `bearer_token_file`
 Let's create the ConfigMap we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/builtin/prom-config.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/builtin/prom-config.yaml
 configmap/stash-prometheus-server-conf created
 ```
 
@@ -306,7 +306,7 @@ Notice that, we have mounted `stash-apiserver-cert` secret as a volume at `/etc/
 Now, let's create the deployment,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/builtin/prom-deployment.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/builtin/prom-deployment.yaml
 deployment.apps/stash-prometheus-server created
 ```
 

--- a/docs/guides/v1alpha1/monitoring/coreos.md
+++ b/docs/guides/v1alpha1/monitoring/coreos.md
@@ -2,13 +2,13 @@
 title: CoreOS Prometheus Operator | Stash
 description: Monitor Stash using CoreOS Prometheus operator
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-monitoring-coreos-operator
     name: Prometheus Operator
     parent: v1alpha1-monitoring
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -36,7 +36,7 @@ Enable Prometheus monitoring using `prometheus.io/coreos-operator` agent while i
 Here, we are going to enable monitoring for both `backup & recovery` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -135,7 +135,7 @@ Here, `spec.serviceMonitorSelector` is used to select the `ServiceMonitor` crd t
 Let's create the `Prometheus` object we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/monitoring/coreos/prometheus.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/coreos/prometheus.yaml
 prometheus.monitoring.coreos.com/prometheus created
 ```
 

--- a/docs/guides/v1alpha1/monitoring/coreos.md
+++ b/docs/guides/v1alpha1/monitoring/coreos.md
@@ -2,13 +2,13 @@
 title: CoreOS Prometheus Operator | Stash
 description: Monitor Stash using CoreOS Prometheus operator
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-monitoring-coreos-operator
     name: Prometheus Operator
     parent: v1alpha1-monitoring
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/monitoring/coreos.md
+++ b/docs/guides/v1alpha1/monitoring/coreos.md
@@ -36,7 +36,7 @@ Enable Prometheus monitoring using `prometheus.io/coreos-operator` agent while i
 Here, we are going to enable monitoring for both `backup & recovery` and `operator` metrics.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \
@@ -135,7 +135,7 @@ Here, `spec.serviceMonitorSelector` is used to select the `ServiceMonitor` crd t
 Let's create the `Prometheus` object we have shown above,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/coreos/prometheus.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/coreos/prometheus.yaml
 prometheus.monitoring.coreos.com/prometheus created
 ```
 

--- a/docs/guides/v1alpha1/monitoring/grafana.md
+++ b/docs/guides/v1alpha1/monitoring/grafana.md
@@ -2,13 +2,13 @@
 title: Use Grafana | Stash
 description: Using Grafana dashboard to visualize Stash monitoring data
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-monitoring-grafana
     name: Using Grafana
     parent: v1alpha1-monitoring
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -29,7 +29,7 @@ Grafana provides an elegant graphical user interface to visualize data. You can 
 We have to add our Prometheus server `prometheus-prometheus-0` as data source of grafana. We are going to use a `ClusterIP` service to connect Prometheus server with grafana. Let's create a service to select Prometheus server `prometheus-prometheus-0`,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/v0.9.0-rc.0/docs/examples/monitoring/coreos/prometheus-service.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/coreos/prometheus-service.yaml
 service/prometheus created
 ```
 

--- a/docs/guides/v1alpha1/monitoring/grafana.md
+++ b/docs/guides/v1alpha1/monitoring/grafana.md
@@ -29,7 +29,7 @@ Grafana provides an elegant graphical user interface to visualize data. You can 
 We have to add our Prometheus server `prometheus-prometheus-0` as data source of grafana. We are going to use a `ClusterIP` service to connect Prometheus server with grafana. Let's create a service to select Prometheus server `prometheus-prometheus-0`,
 
 ```console
-$ kubectl apply -f https://github.com/stashed/docs/raw/{{ .Version }}/docs/examples/monitoring/coreos/prometheus-service.yaml
+$ kubectl apply -f https://github.com/stashed/docs/raw/{{< param "info.version" >}}/docs/examples/monitoring/coreos/prometheus-service.yaml
 service/prometheus created
 ```
 

--- a/docs/guides/v1alpha1/monitoring/grafana.md
+++ b/docs/guides/v1alpha1/monitoring/grafana.md
@@ -2,13 +2,13 @@
 title: Use Grafana | Stash
 description: Using Grafana dashboard to visualize Stash monitoring data
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-monitoring-grafana
     name: Using Grafana
     parent: v1alpha1-monitoring
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/monitoring/overview.md
+++ b/docs/guides/v1alpha1/monitoring/overview.md
@@ -2,13 +2,13 @@
 title: Monitoring Overview | Stash
 description: A general overview of monitoring Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-monitoring-overview
     name: Overview
     parent: v1alpha1-monitoring
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -121,7 +121,7 @@ You have to provides these flags while installing or upgrading or updating Stash
 
 **Helm:**
 ```console
-$ helm install appscode/stash --name stash-operator --version v0.9.0-rc.0 --namespace kube-system \
+$ helm install appscode/stash --name stash-operator --version {{ .Version }} --namespace kube-system \
   --set monitoring.agent=prometheus.io/coreos-operator \
   --set monitoring.backup=true \
   --set monitoring.operator=true \
@@ -131,7 +131,7 @@ $ helm install appscode/stash --name stash-operator --version v0.9.0-rc.0 --name
 
 **Script:**
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh  | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh  | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \

--- a/docs/guides/v1alpha1/monitoring/overview.md
+++ b/docs/guides/v1alpha1/monitoring/overview.md
@@ -121,7 +121,7 @@ You have to provides these flags while installing or upgrading or updating Stash
 
 **Helm:**
 ```console
-$ helm install appscode/stash --name stash-operator --version {{ .Version }} --namespace kube-system \
+$ helm install appscode/stash --name stash-operator --version {{< param "info.version" >}} --namespace kube-system \
   --set monitoring.agent=prometheus.io/coreos-operator \
   --set monitoring.backup=true \
   --set monitoring.operator=true \
@@ -131,7 +131,7 @@ $ helm install appscode/stash --name stash-operator --version {{ .Version }} --n
 
 **Script:**
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh  | bash -s -- \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh  | bash -s -- \
   --monitoring-agent=prometheus.io/coreos-operator \
   --monitoring-backup=true \
   --monitoring-operator=true \

--- a/docs/guides/v1alpha1/monitoring/overview.md
+++ b/docs/guides/v1alpha1/monitoring/overview.md
@@ -2,13 +2,13 @@
 title: Monitoring Overview | Stash
 description: A general overview of monitoring Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-monitoring-overview
     name: Overview
     parent: v1alpha1-monitoring
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/offline_backup.md
+++ b/docs/guides/v1alpha1/offline_backup.md
@@ -2,13 +2,13 @@
 title: Offline Backup | Stash
 description: Offline Backup using Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: offline-stash
     name: Offline Backup
     parent: v1alpha1-guides
     weight: 15
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/offline_backup.md
+++ b/docs/guides/v1alpha1/offline_backup.md
@@ -2,13 +2,13 @@
 title: Offline Backup | Stash
 description: Offline Backup using Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: offline-stash
     name: Offline Backup
     parent: v1alpha1-guides
     weight: 15
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/_index.md
+++ b/docs/guides/v1alpha1/platforms/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Platforms | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-platforms
     name: Platforms
     parent: v1alpha1-guides
     weight: 35
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/guides/v1alpha1/platforms/_index.md
+++ b/docs/guides/v1alpha1/platforms/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Platforms | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-platforms
     name: Platforms
     parent: v1alpha1-guides
     weight: 35
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/guides/v1alpha1/platforms/aks.md
+++ b/docs/guides/v1alpha1/platforms/aks.md
@@ -2,13 +2,13 @@
 title: AKS | Stash
 description: Using Stash in Azure Kubernetes Service
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-platforms-aks
     name: AKS
     parent: v1alpha1-platforms
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/aks.md
+++ b/docs/guides/v1alpha1/platforms/aks.md
@@ -2,13 +2,13 @@
 title: AKS | Stash
 description: Using Stash in Azure Kubernetes Service
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-platforms-aks
     name: AKS
     parent: v1alpha1-platforms
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/eks.md
+++ b/docs/guides/v1alpha1/platforms/eks.md
@@ -2,13 +2,13 @@
 title: EKS | Stash
 description: Using Stash in Amazon EKS
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-platforms-eks
     name: EKS
     parent: v1alpha1-platforms
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/eks.md
+++ b/docs/guides/v1alpha1/platforms/eks.md
@@ -2,13 +2,13 @@
 title: EKS | Stash
 description: Using Stash in Amazon EKS
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-platforms-eks
     name: EKS
     parent: v1alpha1-platforms
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/gke.md
+++ b/docs/guides/v1alpha1/platforms/gke.md
@@ -2,13 +2,13 @@
 title: GKE | Stash
 description: Using Stash in Google Kubernetes Engine
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-platforms-gke
     name: GKE
     parent: v1alpha1-platforms
     weight: 30
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/gke.md
+++ b/docs/guides/v1alpha1/platforms/gke.md
@@ -2,13 +2,13 @@
 title: GKE | Stash
 description: Using Stash in Google Kubernetes Engine
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-platforms-gke
     name: GKE
     parent: v1alpha1-platforms
     weight: 30
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/minio.md
+++ b/docs/guides/v1alpha1/platforms/minio.md
@@ -2,13 +2,13 @@
 title: Minio | Stash
 description: Using Stash with TLS secured Minio Server
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-platforms-minio
     name: Minio
     parent: v1alpha1-platforms
     weight: 40
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/minio.md
+++ b/docs/guides/v1alpha1/platforms/minio.md
@@ -2,13 +2,13 @@
 title: Minio | Stash
 description: Using Stash with TLS secured Minio Server
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-platforms-minio
     name: Minio
     parent: v1alpha1-platforms
     weight: 40
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/rook.md
+++ b/docs/guides/v1alpha1/platforms/rook.md
@@ -2,13 +2,13 @@
 title: Rook | Stash
 description: Using Stash with Rook Storage Service
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: v1alpha1-platforms-rook
     name: Rook
     parent: v1alpha1-platforms
     weight: 50
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/platforms/rook.md
+++ b/docs/guides/v1alpha1/platforms/rook.md
@@ -2,13 +2,13 @@
 title: Rook | Stash
 description: Using Stash with Rook Storage Service
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: v1alpha1-platforms-rook
     name: Rook
     parent: v1alpha1-platforms
     weight: 50
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/rbac.md
+++ b/docs/guides/v1alpha1/rbac.md
@@ -2,13 +2,13 @@
 title: RBAC | Stash
 description: RBAC
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: rbac-stash
     name: RBAC
     parent: v1alpha1-guides
     weight: 45
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 > New to Stash? Please start [here](/docs/concepts/README.md).

--- a/docs/guides/v1alpha1/rbac.md
+++ b/docs/guides/v1alpha1/rbac.md
@@ -2,13 +2,13 @@
 title: RBAC | Stash
 description: RBAC
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: rbac-stash
     name: RBAC
     parent: v1alpha1-guides
     weight: 45
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 > New to Stash? Please start [here](/docs/concepts/README.md).

--- a/docs/guides/v1alpha1/restore.md
+++ b/docs/guides/v1alpha1/restore.md
@@ -2,13 +2,13 @@
 title: Restore Volumes | Stash
 description: Restore Volumes using Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: restore-stash
     name: Restore Volumes
     parent: v1alpha1-guides
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/restore.md
+++ b/docs/guides/v1alpha1/restore.md
@@ -2,13 +2,13 @@
 title: Restore Volumes | Stash
 description: Restore Volumes using Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: restore-stash
     name: Restore Volumes
     parent: v1alpha1-guides
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/workloads.md
+++ b/docs/guides/v1alpha1/workloads.md
@@ -64,7 +64,7 @@ spec:
         volumeMounts:
         - mountPath: /source/data
           name: source-data
-      - image: appscode/stash:{{ .Version }}
+      - image: appscode/stash:{{< param "info.version" >}}
         name: stash
         imagePullPolicy: IfNotPresent
         args:

--- a/docs/guides/v1alpha1/workloads.md
+++ b/docs/guides/v1alpha1/workloads.md
@@ -2,13 +2,13 @@
 title: Workloads | Stash
 description: workloads of Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: workloads-stash
     name: Workloads
     parent: v1alpha1-guides
     weight: 25
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: guides
 ---
 

--- a/docs/guides/v1alpha1/workloads.md
+++ b/docs/guides/v1alpha1/workloads.md
@@ -2,13 +2,13 @@
 title: Workloads | Stash
 description: workloads of Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: workloads-stash
     name: Workloads
     parent: v1alpha1-guides
     weight: 25
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: guides
 ---
 
@@ -64,7 +64,7 @@ spec:
         volumeMounts:
         - mountPath: /source/data
           name: source-data
-      - image: appscode/stash:v0.9.0-rc.0
+      - image: appscode/stash:{{ .Version }}
         name: stash
         imagePullPolicy: IfNotPresent
         args:

--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -2,10 +2,10 @@
 title: Reference
 description: Stash CLI Reference
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: reference
     name: Reference
     weight: 1000
     pre: dropdown
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/reference/_index.md
+++ b/docs/reference/_index.md
@@ -2,10 +2,10 @@
 title: Reference
 description: Stash CLI Reference
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: reference
     name: Reference
     weight: 1000
     pre: dropdown
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/reference/operator/_index.md
+++ b/docs/reference/operator/_index.md
@@ -2,10 +2,10 @@
 title: Stash Operator
 description: Stash Operator Reference
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: operator
     name: Stash Operator
     parent: reference
     weight: 20
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/reference/operator/_index.md
+++ b/docs/reference/operator/_index.md
@@ -2,10 +2,10 @@
 title: Stash Operator
 description: Stash Operator Reference
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: operator
     name: Stash Operator
     parent: reference
     weight: 20
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/reference/operator/stash.md
+++ b/docs/reference/operator/stash.md
@@ -1,7 +1,7 @@
 ---
 title: Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash
     name: Stash
     parent: operator
@@ -9,10 +9,10 @@ menu:
 
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
-url: /products/stash/{{ .Version }}/reference/operator/
+menu_name: product_stash_{{ .version }}
+url: /products/stash/{{ .version }}/reference/operator/
 aliases:
-  - /products/stash/{{ .Version }}/reference/operator/operator/
+  - /products/stash/{{ .version }}/reference/operator/operator/
 
 ---
 ## stash

--- a/docs/reference/operator/stash.md
+++ b/docs/reference/operator/stash.md
@@ -1,7 +1,7 @@
 ---
 title: Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash
     name: Stash
     parent: operator
@@ -9,10 +9,10 @@ menu:
 
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
-url: /products/stash/v0.9.0-rc.0/reference/operator/
+menu_name: product_stash_{{ .Version }}
+url: /products/stash/{{ .Version }}/reference/operator/
 aliases:
-  - /products/stash/v0.9.0-rc.0/reference/operator/operator/
+  - /products/stash/{{ .Version }}/reference/operator/operator/
 
 ---
 ## stash

--- a/docs/reference/operator/stash_backup-pvc.md
+++ b/docs/reference/operator/stash_backup-pvc.md
@@ -1,13 +1,13 @@
 ---
 title: Backup-Pvc
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-backup-pvc
     name: Backup-Pvc
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash backup-pvc
 

--- a/docs/reference/operator/stash_backup-pvc.md
+++ b/docs/reference/operator/stash_backup-pvc.md
@@ -1,13 +1,13 @@
 ---
 title: Backup-Pvc
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-backup-pvc
     name: Backup-Pvc
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash backup-pvc
 

--- a/docs/reference/operator/stash_backup.md
+++ b/docs/reference/operator/stash_backup.md
@@ -1,13 +1,13 @@
 ---
 title: Backup
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-backup
     name: Backup
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash backup
 

--- a/docs/reference/operator/stash_backup.md
+++ b/docs/reference/operator/stash_backup.md
@@ -1,13 +1,13 @@
 ---
 title: Backup
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-backup
     name: Backup
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash backup
 

--- a/docs/reference/operator/stash_check.md
+++ b/docs/reference/operator/stash_check.md
@@ -1,13 +1,13 @@
 ---
 title: Check
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-check
     name: Check
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash check
 

--- a/docs/reference/operator/stash_check.md
+++ b/docs/reference/operator/stash_check.md
@@ -1,13 +1,13 @@
 ---
 title: Check
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-check
     name: Check
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash check
 

--- a/docs/reference/operator/stash_create-backupsession.md
+++ b/docs/reference/operator/stash_create-backupsession.md
@@ -1,13 +1,13 @@
 ---
 title: Create-Backupsession
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-create-backupsession
     name: Create-Backupsession
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash create-backupsession
 

--- a/docs/reference/operator/stash_create-backupsession.md
+++ b/docs/reference/operator/stash_create-backupsession.md
@@ -1,13 +1,13 @@
 ---
 title: Create-Backupsession
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-create-backupsession
     name: Create-Backupsession
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash create-backupsession
 

--- a/docs/reference/operator/stash_create-vs.md
+++ b/docs/reference/operator/stash_create-vs.md
@@ -1,13 +1,13 @@
 ---
 title: Create-Vs
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-create-vs
     name: Create-Vs
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash create-vs
 

--- a/docs/reference/operator/stash_create-vs.md
+++ b/docs/reference/operator/stash_create-vs.md
@@ -1,13 +1,13 @@
 ---
 title: Create-Vs
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-create-vs
     name: Create-Vs
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash create-vs
 

--- a/docs/reference/operator/stash_forget.md
+++ b/docs/reference/operator/stash_forget.md
@@ -1,13 +1,13 @@
 ---
 title: Forget
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-forget
     name: Forget
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash forget
 

--- a/docs/reference/operator/stash_forget.md
+++ b/docs/reference/operator/stash_forget.md
@@ -1,13 +1,13 @@
 ---
 title: Forget
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-forget
     name: Forget
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash forget
 

--- a/docs/reference/operator/stash_recover.md
+++ b/docs/reference/operator/stash_recover.md
@@ -1,13 +1,13 @@
 ---
 title: Recover
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-recover
     name: Recover
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash recover
 

--- a/docs/reference/operator/stash_recover.md
+++ b/docs/reference/operator/stash_recover.md
@@ -1,13 +1,13 @@
 ---
 title: Recover
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-recover
     name: Recover
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash recover
 

--- a/docs/reference/operator/stash_restore-pvc.md
+++ b/docs/reference/operator/stash_restore-pvc.md
@@ -1,13 +1,13 @@
 ---
 title: Restore-Pvc
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-restore-pvc
     name: Restore-Pvc
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash restore-pvc
 

--- a/docs/reference/operator/stash_restore-pvc.md
+++ b/docs/reference/operator/stash_restore-pvc.md
@@ -1,13 +1,13 @@
 ---
 title: Restore-Pvc
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-restore-pvc
     name: Restore-Pvc
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash restore-pvc
 

--- a/docs/reference/operator/stash_restore-vs.md
+++ b/docs/reference/operator/stash_restore-vs.md
@@ -1,13 +1,13 @@
 ---
 title: Restore-Vs
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-restore-vs
     name: Restore-Vs
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash restore-vs
 

--- a/docs/reference/operator/stash_restore-vs.md
+++ b/docs/reference/operator/stash_restore-vs.md
@@ -1,13 +1,13 @@
 ---
 title: Restore-Vs
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-restore-vs
     name: Restore-Vs
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash restore-vs
 

--- a/docs/reference/operator/stash_restore.md
+++ b/docs/reference/operator/stash_restore.md
@@ -1,13 +1,13 @@
 ---
 title: Restore
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-restore
     name: Restore
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash restore
 

--- a/docs/reference/operator/stash_restore.md
+++ b/docs/reference/operator/stash_restore.md
@@ -1,13 +1,13 @@
 ---
 title: Restore
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-restore
     name: Restore
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash restore
 

--- a/docs/reference/operator/stash_run-backup.md
+++ b/docs/reference/operator/stash_run-backup.md
@@ -1,13 +1,13 @@
 ---
 title: Run-Backup
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-run-backup
     name: Run-Backup
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash run-backup
 

--- a/docs/reference/operator/stash_run-backup.md
+++ b/docs/reference/operator/stash_run-backup.md
@@ -1,13 +1,13 @@
 ---
 title: Run-Backup
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-run-backup
     name: Run-Backup
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash run-backup
 

--- a/docs/reference/operator/stash_run.md
+++ b/docs/reference/operator/stash_run.md
@@ -1,13 +1,13 @@
 ---
 title: Run
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-run
     name: Run
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash run
 

--- a/docs/reference/operator/stash_run.md
+++ b/docs/reference/operator/stash_run.md
@@ -1,13 +1,13 @@
 ---
 title: Run
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-run
     name: Run
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash run
 

--- a/docs/reference/operator/stash_scaledown.md
+++ b/docs/reference/operator/stash_scaledown.md
@@ -1,13 +1,13 @@
 ---
 title: Scaledown
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-scaledown
     name: Scaledown
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash scaledown
 

--- a/docs/reference/operator/stash_scaledown.md
+++ b/docs/reference/operator/stash_scaledown.md
@@ -1,13 +1,13 @@
 ---
 title: Scaledown
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-scaledown
     name: Scaledown
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash scaledown
 

--- a/docs/reference/operator/stash_snapshots.md
+++ b/docs/reference/operator/stash_snapshots.md
@@ -1,13 +1,13 @@
 ---
 title: Snapshots
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-snapshots
     name: Snapshots
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash snapshots
 

--- a/docs/reference/operator/stash_snapshots.md
+++ b/docs/reference/operator/stash_snapshots.md
@@ -1,13 +1,13 @@
 ---
 title: Snapshots
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-snapshots
     name: Snapshots
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash snapshots
 

--- a/docs/reference/operator/stash_update-status.md
+++ b/docs/reference/operator/stash_update-status.md
@@ -1,13 +1,13 @@
 ---
 title: Update-Status
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-update-status
     name: Update-Status
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash update-status
 

--- a/docs/reference/operator/stash_update-status.md
+++ b/docs/reference/operator/stash_update-status.md
@@ -1,13 +1,13 @@
 ---
 title: Update-Status
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-update-status
     name: Update-Status
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash update-status
 

--- a/docs/reference/operator/stash_version.md
+++ b/docs/reference/operator/stash_version.md
@@ -1,13 +1,13 @@
 ---
 title: Version
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: stash-version
     name: Version
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---
 ## stash version
 

--- a/docs/reference/operator/stash_version.md
+++ b/docs/reference/operator/stash_version.md
@@ -1,13 +1,13 @@
 ---
 title: Version
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: stash-version
     name: Version
     parent: operator
 product_name: stash
 section_menu_id: reference
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---
 ## stash version
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -2,17 +2,17 @@
 title: Table of Contents | Setup
 description: Table of Contents | Setup
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: setup-readme
     name: Readme
     parent: setup
     weight: -1
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: setup
-url: /products/stash/v0.9.0-rc.0/setup/
+url: /products/stash/{{ .Version }}/setup/
 aliases:
-  - /products/stash/v0.9.0-rc.0/setup/README/
+  - /products/stash/{{ .Version }}/setup/README/
 ---
 # Setup
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -2,17 +2,17 @@
 title: Table of Contents | Setup
 description: Table of Contents | Setup
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: setup-readme
     name: Readme
     parent: setup
     weight: -1
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: setup
-url: /products/stash/{{ .Version }}/setup/
+url: /products/stash/{{ .version }}/setup/
 aliases:
-  - /products/stash/{{ .Version }}/setup/README/
+  - /products/stash/{{ .version }}/setup/README/
 ---
 # Setup
 

--- a/docs/setup/_index.md
+++ b/docs/setup/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Setup | Stash
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: setup
     name: Setup
     weight: 30
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/setup/_index.md
+++ b/docs/setup/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Setup | Stash
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: setup
     name: Setup
     weight: 30
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/setup/developer-guide/_index.md
+++ b/docs/setup/developer-guide/_index.md
@@ -2,10 +2,10 @@
 title: Developer Guide | Stash
 description: Stash Developer Guide
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: developer-guide
     name: Developer Guide
     parent: setup
     weight: 40
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 ---

--- a/docs/setup/developer-guide/_index.md
+++ b/docs/setup/developer-guide/_index.md
@@ -2,10 +2,10 @@
 title: Developer Guide | Stash
 description: Stash Developer Guide
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: developer-guide
     name: Developer Guide
     parent: setup
     weight: 40
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 ---

--- a/docs/setup/developer-guide/overview.md
+++ b/docs/setup/developer-guide/overview.md
@@ -2,13 +2,13 @@
 title: Overview | Developer Guide
 description: Developer Guide Overview
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: developer-guide-readme
     name: Overview
     parent: developer-guide
     weight: 15
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: setup
 ---
 

--- a/docs/setup/developer-guide/overview.md
+++ b/docs/setup/developer-guide/overview.md
@@ -2,13 +2,13 @@
 title: Overview | Developer Guide
 description: Developer Guide Overview
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: developer-guide-readme
     name: Overview
     parent: developer-guide
     weight: 15
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: setup
 ---
 

--- a/docs/setup/developer-guide/release.md
+++ b/docs/setup/developer-guide/release.md
@@ -2,13 +2,13 @@
 title: Release | Stash
 description: Stash Release
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: release
     name: Release
     parent: developer-guide
     weight: 15
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: setup
 ---
 # Release Process

--- a/docs/setup/developer-guide/release.md
+++ b/docs/setup/developer-guide/release.md
@@ -2,13 +2,13 @@
 title: Release | Stash
 description: Stash Release
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: release
     name: Release
     parent: developer-guide
     weight: 15
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: setup
 ---
 # Release Process

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -2,13 +2,13 @@
 title: Install
 description: Stash Install
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: install-stash
     name: Install
     parent: setup
     weight: 10
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: setup
 ---
 
@@ -32,7 +32,7 @@ Stash operator can be installed via a script or as a Helm chart.
 To install Stash in your Kubernetes cluster, run the following command:
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh | bash
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash
 ```
 
 After successful installation, you should have a `stash-operator-***` pod running in the `kube-system` namespace.
@@ -44,10 +44,10 @@ stash-operator-846d47f489-jrb58       1/1       Running   0          48s
 
 #### Customizing Installer
 
-The installer script and associated yaml files can be found in the [/deploy](https://github.com/stashed/installer/tree/v0.9.0-rc.0/deploy) folder. You can see the full list of flags available to installer using `-h` flag.
+The installer script and associated yaml files can be found in the [/deploy](https://github.com/stashed/installer/tree/{{ .Version }}/deploy) folder. You can see the full list of flags available to installer using `-h` flag.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh | bash -s -- -h
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- -h
 
 stash.sh - install stash operator
 
@@ -78,7 +78,7 @@ options:
 If you would like to run Stash operator pod in `master` instances, pass the `--run-on-master` flag:
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
     | bash -s -- --run-on-master
 ```
 
@@ -86,7 +86,7 @@ Stash operator will be installed in a `kube-system` namespace by default. If you
 
 ```console
 $ kubectl create namespace stash
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
     | bash -s -- --namespace=stash [--run-on-master]
 ```
 
@@ -98,36 +98,36 @@ To pass the address of your private registry and optionally a image pull secret 
 
 ```console
 $ kubectl create namespace stash
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
     | bash -s -- --docker-registry=MY_REGISTRY [--image-pull-secret=SECRET_NAME]
 ```
 
 Stash implements [validating admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) to validate Stash CRDs and **mutating webhooks** for Kubernetes workload types. This is helpful when you create `Restic` before creating workload objects. This allows stash operator to initialize the target workloads by adding sidecar or, init-container before workload-pods are created. Thus stash operator does not need to delete workload pods for applying changes. This is particularly helpful for workload kind `StatefulSet`, since Kubernetes does not support adding sidecar / init containers to StatefulSets after they are created. This is enabled by default for Kubernetes 1.9.0 or later releases. To disable this feature, pass the `--enable-validating-webhook=false` and `--enable-mutating-webhook=false` flag respectively.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
     | bash -s -- --enable-validating-webhook=false --enable-mutating-webhook=false
 ```
 
-Stash v0.9.0-rc.0 or later releases can use status sub resource for CustomResourceDefintions. This is enabled by default for Kubernetes 1.11.0 or later releases. To disable this feature, pass the `--enable-status-subresource=false` flag.
+Stash {{ .Version }} or later releases can use status sub resource for CustomResourceDefintions. This is enabled by default for Kubernetes 1.11.0 or later releases. To disable this feature, pass the `--enable-status-subresource=false` flag.
 
 </div>
 <div class="tab-pane fade" id="helm" role="tabpanel" aria-labelledby="helm-tab">
 
 ## Using Helm
-Stash can be installed via [Helm](https://helm.sh/) using the [chart](https://github.com/stashed/installer/tree/v0.9.0-rc.0/chart/stash) from [AppsCode Charts Repository](https://github.com/appscode/charts). To install the chart with the release name `my-release`:
+Stash can be installed via [Helm](https://helm.sh/) using the [chart](https://github.com/stashed/installer/tree/{{ .Version }}/chart/stash) from [AppsCode Charts Repository](https://github.com/appscode/charts). To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
 $ helm search appscode/stash
 NAME            CHART VERSION APP VERSION DESCRIPTION
-appscode/stash  v0.9.0-rc.0    v0.9.0-rc.0  Stash by AppsCode - Backup your Kubernetes Volumes
+appscode/stash  {{ .Version }}    {{ .Version }}  Stash by AppsCode - Backup your Kubernetes Volumes
 
-$ helm install appscode/stash --name stash-operator --version v0.9.0-rc.0 --namespace kube-system
+$ helm install appscode/stash --name stash-operator --version {{ .Version }} --namespace kube-system
 ```
 
-To see the detailed configuration options, visit [here](https://github.com/stashed/installer/tree/v0.9.0-rc.0/chart/stash).
+To see the detailed configuration options, visit [here](https://github.com/stashed/installer/tree/{{ .Version }}/chart/stash).
 
 </div>
 </div>
@@ -220,13 +220,13 @@ $ POD_NAMESPACE=kube-system
 $ POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l app=stash -o jsonpath={.items[0].metadata.name})
 $ kubectl exec -it $POD_NAME -c operator -n $POD_NAMESPACE stash version
 
-Version = v0.9.0-rc.0
+Version = {{ .Version }}
 VersionStrategy = tag
 Os = alpine
 Arch = amd64
 CommitHash = 85b0f16ab1b915633e968aac0ee23f877808ef49
 GitBranch = release-0.5
-GitTag = v0.9.0-rc.0
+GitTag = {{ .Version }}
 CommitTimestamp = 2017-10-10T05:24:23
 
 $ kubectl exec -it $POD_NAME -c operator -n $POD_NAMESPACE restic version

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -32,7 +32,7 @@ Stash operator can be installed via a script or as a Helm chart.
 To install Stash in your Kubernetes cluster, run the following command:
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh | bash
 ```
 
 After successful installation, you should have a `stash-operator-***` pod running in the `kube-system` namespace.
@@ -44,10 +44,10 @@ stash-operator-846d47f489-jrb58       1/1       Running   0          48s
 
 #### Customizing Installer
 
-The installer script and associated yaml files can be found in the [/deploy](https://github.com/stashed/installer/tree/{{ .Version }}/deploy) folder. You can see the full list of flags available to installer using `-h` flag.
+The installer script and associated yaml files can be found in the [/deploy](https://github.com/stashed/installer/tree/{{< param "info.version" >}}/deploy) folder. You can see the full list of flags available to installer using `-h` flag.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh | bash -s -- -h
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh | bash -s -- -h
 
 stash.sh - install stash operator
 
@@ -78,7 +78,7 @@ options:
 If you would like to run Stash operator pod in `master` instances, pass the `--run-on-master` flag:
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh \
     | bash -s -- --run-on-master
 ```
 
@@ -86,7 +86,7 @@ Stash operator will be installed in a `kube-system` namespace by default. If you
 
 ```console
 $ kubectl create namespace stash
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh \
     | bash -s -- --namespace=stash [--run-on-master]
 ```
 
@@ -98,36 +98,36 @@ To pass the address of your private registry and optionally a image pull secret 
 
 ```console
 $ kubectl create namespace stash
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh \
     | bash -s -- --docker-registry=MY_REGISTRY [--image-pull-secret=SECRET_NAME]
 ```
 
 Stash implements [validating admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) to validate Stash CRDs and **mutating webhooks** for Kubernetes workload types. This is helpful when you create `Restic` before creating workload objects. This allows stash operator to initialize the target workloads by adding sidecar or, init-container before workload-pods are created. Thus stash operator does not need to delete workload pods for applying changes. This is particularly helpful for workload kind `StatefulSet`, since Kubernetes does not support adding sidecar / init containers to StatefulSets after they are created. This is enabled by default for Kubernetes 1.9.0 or later releases. To disable this feature, pass the `--enable-validating-webhook=false` and `--enable-mutating-webhook=false` flag respectively.
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh \
     | bash -s -- --enable-validating-webhook=false --enable-mutating-webhook=false
 ```
 
-Stash {{ .Version }} or later releases can use status sub resource for CustomResourceDefintions. This is enabled by default for Kubernetes 1.11.0 or later releases. To disable this feature, pass the `--enable-status-subresource=false` flag.
+Stash {{< param "info.version" >}} or later releases can use status sub resource for CustomResourceDefintions. This is enabled by default for Kubernetes 1.11.0 or later releases. To disable this feature, pass the `--enable-status-subresource=false` flag.
 
 </div>
 <div class="tab-pane fade" id="helm" role="tabpanel" aria-labelledby="helm-tab">
 
 ## Using Helm
-Stash can be installed via [Helm](https://helm.sh/) using the [chart](https://github.com/stashed/installer/tree/{{ .Version }}/chart/stash) from [AppsCode Charts Repository](https://github.com/appscode/charts). To install the chart with the release name `my-release`:
+Stash can be installed via [Helm](https://helm.sh/) using the [chart](https://github.com/stashed/installer/tree/{{< param "info.version" >}}/chart/stash) from [AppsCode Charts Repository](https://github.com/appscode/charts). To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
 $ helm search appscode/stash
 NAME            CHART VERSION APP VERSION DESCRIPTION
-appscode/stash  {{ .Version }}    {{ .Version }}  Stash by AppsCode - Backup your Kubernetes Volumes
+appscode/stash  {{< param "info.version" >}}    {{< param "info.version" >}}  Stash by AppsCode - Backup your Kubernetes Volumes
 
-$ helm install appscode/stash --name stash-operator --version {{ .Version }} --namespace kube-system
+$ helm install appscode/stash --name stash-operator --version {{< param "info.version" >}} --namespace kube-system
 ```
 
-To see the detailed configuration options, visit [here](https://github.com/stashed/installer/tree/{{ .Version }}/chart/stash).
+To see the detailed configuration options, visit [here](https://github.com/stashed/installer/tree/{{< param "info.version" >}}/chart/stash).
 
 </div>
 </div>
@@ -220,13 +220,13 @@ $ POD_NAMESPACE=kube-system
 $ POD_NAME=$(kubectl get pods -n $POD_NAMESPACE -l app=stash -o jsonpath={.items[0].metadata.name})
 $ kubectl exec -it $POD_NAME -c operator -n $POD_NAMESPACE stash version
 
-Version = {{ .Version }}
+Version = {{< param "info.version" >}}
 VersionStrategy = tag
 Os = alpine
 Arch = amd64
 CommitHash = 85b0f16ab1b915633e968aac0ee23f877808ef49
 GitBranch = release-0.5
-GitTag = {{ .Version }}
+GitTag = {{< param "info.version" >}}
 CommitTimestamp = 2017-10-10T05:24:23
 
 $ kubectl exec -it $POD_NAME -c operator -n $POD_NAMESPACE restic version

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -2,13 +2,13 @@
 title: Install
 description: Stash Install
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: install-stash
     name: Install
     parent: setup
     weight: 10
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: setup
 ---
 

--- a/docs/setup/uninstall.md
+++ b/docs/setup/uninstall.md
@@ -2,13 +2,13 @@
 title: Uninstall
 description: Stash Uninstall
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: uninstall-stash
     name: Uninstall
     parent: setup
     weight: 20
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: setup
 ---
 # Uninstall Stash

--- a/docs/setup/uninstall.md
+++ b/docs/setup/uninstall.md
@@ -16,7 +16,7 @@ section_menu_id: setup
 To uninstall Stash operator, run the following command:
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{< param "info.version" >}}/deploy/stash.sh \
     | bash -s -- --uninstall [--namespace=NAMESPACE]
 
 + kubectl delete deployment -l app=stash -n kube-system

--- a/docs/setup/uninstall.md
+++ b/docs/setup/uninstall.md
@@ -2,13 +2,13 @@
 title: Uninstall
 description: Stash Uninstall
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: uninstall-stash
     name: Uninstall
     parent: setup
     weight: 20
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: setup
 ---
 # Uninstall Stash
@@ -16,7 +16,7 @@ section_menu_id: setup
 To uninstall Stash operator, run the following command:
 
 ```console
-$ curl -fsSL https://github.com/stashed/installer/raw/v0.9.0-rc.0/deploy/stash.sh \
+$ curl -fsSL https://github.com/stashed/installer/raw/{{ .Version }}/deploy/stash.sh \
     | bash -s -- --uninstall [--namespace=NAMESPACE]
 
 + kubectl delete deployment -l app=stash -n kube-system

--- a/docs/setup/upgrade.md
+++ b/docs/setup/upgrade.md
@@ -2,13 +2,13 @@
 title: Upgrade | Stash
 description: Stash Upgrade
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: upgrade-stash
     name: Upgrade
     parent: setup
     weight: 15
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: setup
 ---
 

--- a/docs/setup/upgrade.md
+++ b/docs/setup/upgrade.md
@@ -2,13 +2,13 @@
 title: Upgrade | Stash
 description: Stash Upgrade
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: upgrade-stash
     name: Upgrade
     parent: setup
     weight: 15
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: setup
 ---
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -2,17 +2,17 @@
 title: Support | Stash
 description: Support
 menu:
-  product_stash_v0.9.0-rc.0:
+  product_stash_{{ .Version }}:
     identifier: support-stash
     name: Support
     parent: welcome
     weight: 1020
 product_name: stash
-menu_name: product_stash_v0.9.0-rc.0
+menu_name: product_stash_{{ .Version }}
 section_menu_id: welcome
-url: /products/stash/v0.9.0-rc.0/welcome/support/
+url: /products/stash/{{ .Version }}/welcome/support/
 aliases:
-  - /products/stash/v0.9.0-rc.0/support/
+  - /products/stash/{{ .Version }}/support/
 ---
 # Support
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -2,17 +2,17 @@
 title: Support | Stash
 description: Support
 menu:
-  product_stash_{{ .Version }}:
+  product_stash_{{ .version }}:
     identifier: support-stash
     name: Support
     parent: welcome
     weight: 1020
 product_name: stash
-menu_name: product_stash_{{ .Version }}
+menu_name: product_stash_{{ .version }}
 section_menu_id: welcome
-url: /products/stash/{{ .Version }}/welcome/support/
+url: /products/stash/{{ .version }}/welcome/support/
 aliases:
-  - /products/stash/{{ .Version }}/support/
+  - /products/stash/{{ .version }}/support/
 ---
 # Support
 


### PR DESCRIPTION
**Why?**

This allows us to template version part of a project in front-matter. Which will give us the following benefits:
- No more global search and replace for version filed before each release.
- Easy to test doc rendering of dev branch. Otherwise, we have to copy & replace the contents of dev branch to latest release branch then render it.

Require: https://github.com/appscodelabs/hugo-tools/pull/14