### PR TITLE
Remove `secretTransformations` part of `AppBinding` from concepts doc

### DIFF
--- a/docs/concepts/crds/appbinding.md
+++ b/docs/concepts/crds/appbinding.md
@@ -54,13 +54,6 @@ spec:
       port: 5432
       query: sslmode=disable
       scheme: postgresql
-  secretTransforms:
-    - renameKey:
-        from: POSTGRES_USER
-        to: username
-    - renameKey:
-        from: POSTGRES_PASSWORD
-        to: password
   version: 10.2
 ```
 

--- a/docs/examples/crds/appbinding.yaml
+++ b/docs/examples/crds/appbinding.yaml
@@ -22,11 +22,4 @@ spec:
       port: 5432
       query: sslmode=disable
       scheme: postgresql
-  secretTransforms:
-  - renameKey:
-      from: POSTGRES_USER
-      to: username
-  - renameKey:
-      from: POSTGRES_PASSWORD
-      to: password
   version: "10.2"


### PR DESCRIPTION
Stash does not use `secretTransformations` field yet. Hence, keeping this in concepts doc may mislead the users.