### PR TITLE
Prepare for release v2020.07.09-beta.0

### DIFF
--- a/docs/CHANGELOG-v2020.07.09-beta.0.md
+++ b/docs/CHANGELOG-v2020.07.09-beta.0.md
@@ -1,0 +1,243 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.07.09-beta.0
+    name: Changelog-v2020.07.09-beta.0
+    parent: welcome
+    weight: 20200709
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.07.09-beta.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.07.09-beta.0/
+---
+
+# Stash v2020.07.09-beta.0 (2020-07-09)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.10.0-beta.1](https://github.com/stashed/apimachinery/releases/tag/v0.10.0-beta.1)
+
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.07.09-beta.0](https://github.com/stashed/catalog/releases/tag/v2020.07.09-beta.0)
+
+- [e822d2a](https://github.com/stashed/catalog/commit/e822d2a) Prepare for release v2020.07.09-beta.0 (#32)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.10.0-beta.1](https://github.com/stashed/cli/releases/tag/v0.10.0-beta.1)
+
+- [250372c](https://github.com/stashed/cli/commit/250372c) Prepare for release v0.10.0-beta.1 (#27)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-beta.20200709)
+
+- [4f6f04d](https://github.com/stashed/elasticsearch/commit/4f6f04d) Prepare for release 5.6.4-beta.20200709 (#105)
+- [c0b63a8](https://github.com/stashed/elasticsearch/commit/c0b63a8) [cherry-pick] Build docker image in release workflow (#96) (#97)
+
+
+### [6.2.4-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-beta.20200709)
+
+- [eb90a4d](https://github.com/stashed/elasticsearch/commit/eb90a4d) Prepare for release 6.2.4-beta.20200709 (#106)
+- [341d4ad](https://github.com/stashed/elasticsearch/commit/341d4ad) [cherry-pick] Build docker image in release workflow (#96) (#98)
+
+
+### [6.3.0-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-beta.20200709)
+
+- [ba97538](https://github.com/stashed/elasticsearch/commit/ba97538) Prepare for release 6.3.0-beta.20200709 (#107)
+- [fe8fad4](https://github.com/stashed/elasticsearch/commit/fe8fad4) [cherry-pick] Build docker image in release workflow (#96) (#99)
+
+
+### [6.4.0-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-beta.20200709)
+
+- [223de60](https://github.com/stashed/elasticsearch/commit/223de60) Prepare for release 6.4.0-beta.20200709 (#108)
+- [3eb01b0](https://github.com/stashed/elasticsearch/commit/3eb01b0) [cherry-pick] Build docker image in release workflow (#96) (#100)
+
+
+### [6.5.3-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-beta.20200709)
+
+- [27ca5d7](https://github.com/stashed/elasticsearch/commit/27ca5d7) Prepare for release 6.5.3-beta.20200709 (#109)
+- [cfc95c6](https://github.com/stashed/elasticsearch/commit/cfc95c6) [cherry-pick] Build docker image in release workflow (#96) (#101)
+
+
+### [6.8.0-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-beta.20200709)
+
+- [ebff50b](https://github.com/stashed/elasticsearch/commit/ebff50b) Prepare for release 6.8.0-beta.20200709 (#110)
+- [c4322e7](https://github.com/stashed/elasticsearch/commit/c4322e7) [cherry-pick] Build docker image in release workflow (#96) (#102)
+
+
+### [7.2.0-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-beta.20200709)
+
+- [bf94d4d](https://github.com/stashed/elasticsearch/commit/bf94d4d) Prepare for release 7.2.0-beta.20200709 (#111)
+- [d1cdabd](https://github.com/stashed/elasticsearch/commit/d1cdabd) [cherry-pick] Build docker image in release workflow (#96) (#103)
+
+
+### [7.3.2-beta.20200709](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-beta.20200709)
+
+- [d0e8ff7](https://github.com/stashed/elasticsearch/commit/d0e8ff7) Prepare for release 7.3.2-beta.20200709 (#112)
+- [0b0df2e](https://github.com/stashed/elasticsearch/commit/0b0df2e) [cherry-pick] Build docker image in release workflow (#96) (#104)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.10.0-beta.1](https://github.com/stashed/installer/releases/tag/v0.10.0-beta.1)
+
+- [bed8319](https://github.com/stashed/installer/commit/bed8319) Prepare for release v0.10.0-beta.1 (#76)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.1-beta.20200709](https://github.com/stashed/mongodb/releases/tag/3.4.1-beta.20200709)
+
+- [a354b6c](https://github.com/stashed/mongodb/commit/a354b6c) Prepare for release 3.4.1-beta.20200709 (#114)
+- [2269fa6](https://github.com/stashed/mongodb/commit/2269fa6) [cherry-pick] Build docker image in release workflow (#102) (#103)
+
+
+### [3.4.2-beta.20200709](https://github.com/stashed/mongodb/releases/tag/3.4.2-beta.20200709)
+
+- [735aea9](https://github.com/stashed/mongodb/commit/735aea9) Prepare for release 3.4.2-beta.20200709 (#115)
+- [b871884](https://github.com/stashed/mongodb/commit/b871884) [cherry-pick] Build docker image in release workflow (#102) (#104)
+
+
+### [3.6.1-beta.20200709](https://github.com/stashed/mongodb/releases/tag/3.6.1-beta.20200709)
+
+- [38ec877](https://github.com/stashed/mongodb/commit/38ec877) Prepare for release 3.6.1-beta.20200709 (#116)
+- [6fd28b2](https://github.com/stashed/mongodb/commit/6fd28b2) [cherry-pick] Build docker image in release workflow (#102) (#105)
+
+
+### [3.6.8-beta.20200709](https://github.com/stashed/mongodb/releases/tag/3.6.8-beta.20200709)
+
+- [a95f051](https://github.com/stashed/mongodb/commit/a95f051) Prepare for release 3.6.8-beta.20200709 (#117)
+- [8f74e62](https://github.com/stashed/mongodb/commit/8f74e62) [cherry-pick] Build docker image in release workflow (#102) (#106)
+
+
+### [4.0.1-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.0.1-beta.20200709)
+
+- [4168a4b](https://github.com/stashed/mongodb/commit/4168a4b) Prepare for release 4.0.1-beta.20200709 (#118)
+- [90723f4](https://github.com/stashed/mongodb/commit/90723f4) [cherry-pick] Build docker image in release workflow (#102) (#107)
+
+
+### [4.0.3-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.0.3-beta.20200709)
+
+- [b7719bd](https://github.com/stashed/mongodb/commit/b7719bd) Prepare for release 4.0.3-beta.20200709 (#119)
+- [7c9074d](https://github.com/stashed/mongodb/commit/7c9074d) [cherry-pick] Build docker image in release workflow (#102) (#108)
+
+
+### [4.0.5-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.0.5-beta.20200709)
+
+- [78ab8d2](https://github.com/stashed/mongodb/commit/78ab8d2) Prepare for release 4.0.5-beta.20200709 (#120)
+- [12af669](https://github.com/stashed/mongodb/commit/12af669) [cherry-pick] Build docker image in release workflow (#102) (#109)
+
+
+### [4.1.1-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.1.1-beta.20200709)
+
+- [923bd88](https://github.com/stashed/mongodb/commit/923bd88) Prepare for release 4.1.1-beta.20200709 (#121)
+- [2bae7f7](https://github.com/stashed/mongodb/commit/2bae7f7) [cherry-pick] Build docker image in release workflow (#102) (#110)
+
+
+### [4.1.4-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.1.4-beta.20200709)
+
+- [e3cd383](https://github.com/stashed/mongodb/commit/e3cd383) Prepare for release 4.1.4-beta.20200709 (#122)
+- [a310c43](https://github.com/stashed/mongodb/commit/a310c43) [cherry-pick] Build docker image in release workflow (#102) (#111)
+
+
+### [4.1.7-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.1.7-beta.20200709)
+
+- [3eccd08](https://github.com/stashed/mongodb/commit/3eccd08) Prepare for release 4.1.7-beta.20200709 (#123)
+- [6377c55](https://github.com/stashed/mongodb/commit/6377c55) [cherry-pick] Build docker image in release workflow (#102) (#112)
+
+
+### [4.2.3-beta.20200709](https://github.com/stashed/mongodb/releases/tag/4.2.3-beta.20200709)
+
+- [149e6ba](https://github.com/stashed/mongodb/commit/149e6ba) Prepare for release 4.2.3-beta.20200709 (#124)
+- [47879da](https://github.com/stashed/mongodb/commit/47879da) [cherry-pick] Build docker image in release workflow (#102) (#113)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-beta.20200709](https://github.com/stashed/mysql/releases/tag/5.7.25-beta.20200709)
+
+- [422a411](https://github.com/stashed/mysql/commit/422a411) Prepare for release 5.7.25-beta.20200709 (#63)
+- [e345110](https://github.com/stashed/mysql/commit/e345110) [cherry-pick] Build docker image in release workflow (#59) (#60)
+
+
+### [8.0.3-beta.20200709](https://github.com/stashed/mysql/releases/tag/8.0.3-beta.20200709)
+
+- [ced3feb](https://github.com/stashed/mysql/commit/ced3feb) Prepare for release 8.0.3-beta.20200709 (#65)
+- [8299693](https://github.com/stashed/mysql/commit/8299693) [cherry-pick] Build docker image in release workflow (#59) (#62)
+
+
+### [8.0.14-beta.20200709](https://github.com/stashed/mysql/releases/tag/8.0.14-beta.20200709)
+
+- [bf2dd2d](https://github.com/stashed/mysql/commit/bf2dd2d) Prepare for release 8.0.14-beta.20200709 (#64)
+- [226b3a9](https://github.com/stashed/mysql/commit/226b3a9) [cherry-pick] Build docker image in release workflow (#59) (#61)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-beta.20200709](https://github.com/stashed/percona-xtradb/releases/tag/5.7-beta.20200709)
+
+- [7fc07cc](https://github.com/stashed/percona-xtradb/commit/7fc07cc) Prepare for release 5.7-beta.20200709 (#38)
+- [ca32b31](https://github.com/stashed/percona-xtradb/commit/ca32b31) [cherry-pick] Build docker image in release workflow (#36) (#37)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6-beta.20200709](https://github.com/stashed/postgres/releases/tag/9.6-beta.20200709)
+
+- [5befa82](https://github.com/stashed/postgres/commit/5befa82) Prepare for release 9.6-beta.20200709 (#100)
+- [52fab57](https://github.com/stashed/postgres/commit/52fab57) [cherry-pick] Build docker images in release workflow (#90) (#95)
+
+
+### [10.2-beta.20200709](https://github.com/stashed/postgres/releases/tag/10.2-beta.20200709)
+
+- [d8a2be0](https://github.com/stashed/postgres/commit/d8a2be0) Prepare for release 10.2-beta.20200709 (#96)
+- [0bba297](https://github.com/stashed/postgres/commit/0bba297) [cherry-pick] Build docker images in release workflow (#90) (#91)
+
+
+### [10.6-beta.20200709](https://github.com/stashed/postgres/releases/tag/10.6-beta.20200709)
+
+- [78fdd94](https://github.com/stashed/postgres/commit/78fdd94) Prepare for release 10.6-beta.20200709 (#97)
+- [c70d2d9](https://github.com/stashed/postgres/commit/c70d2d9) [cherry-pick] Build docker images in release workflow (#90) (#92)
+
+
+### [11.1-beta.20200709](https://github.com/stashed/postgres/releases/tag/11.1-beta.20200709)
+
+- [81b21f0](https://github.com/stashed/postgres/commit/81b21f0) Prepare for release 11.1-beta.20200709 (#98)
+- [4fc87ef](https://github.com/stashed/postgres/commit/4fc87ef) [cherry-pick] Build docker images in release workflow (#90) (#93)
+
+
+### [11.2-beta.20200709](https://github.com/stashed/postgres/releases/tag/11.2-beta.20200709)
+
+- [a3efd1a](https://github.com/stashed/postgres/commit/a3efd1a) Prepare for release 11.2-beta.20200709 (#99)
+- [c0a32e5](https://github.com/stashed/postgres/commit/c0a32e5) [cherry-pick] Build docker images in release workflow (#90) (#94)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.10.0-beta.1](https://github.com/stashed/stash/releases/tag/v0.10.0-beta.1)
+
+- [3b717aac](https://github.com/stashed/stash/commit/3b717aac) Prepare for release v0.10.0-beta.1 (#1146)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.07.09-beta.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/2
Signed-off-by: 1gtm <1gtm@appscode.com>