### PR TITLE
Prepare for release v2020.08.26-rc.1

### DIFF
--- a/docs/CHANGELOG-v2020.08.26-rc.1.md
+++ b/docs/CHANGELOG-v2020.08.26-rc.1.md
@@ -1,0 +1,1049 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.08.26-rc.1
+    name: Changelog-v2020.08.26-rc.1
+    parent: welcome
+    weight: 20200826
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.08.26-rc.1/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.08.26-rc.1/
+---
+
+# Stash v2020.08.26-rc.1 (2020-08-27)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.10.0-rc.1](https://github.com/appscode/stash-enterprise/releases/tag/v0.10.0-rc.1)
+
+- [dc0c6cf5](https://github.com/appscode/stash-enterprise/commit/dc0c6cf5) Prepare for release v0.10.0-rc.1 (#19)
+- [4836ebc0](https://github.com/appscode/stash-enterprise/commit/4836ebc0) Create GitHub release from release workflow
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.10.0-rc.1](https://github.com/stashed/apimachinery/releases/tag/v0.10.0-rc.1)
+
+- [7dbdff5f](https://github.com/stashed/apimachinery/commit/7dbdff5f) Update README.md
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.08.26-rc.1](https://github.com/stashed/catalog/releases/tag/v2020.08.26-rc.1)
+
+- [fe86886](https://github.com/stashed/catalog/commit/fe86886) Prepare for release v2020.08.26-rc.1 (#34)
+- [e7eb2e3](https://github.com/stashed/catalog/commit/e7eb2e3) Update issues link
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.10.0-rc.1](https://github.com/stashed/cli/releases/tag/v0.10.0-rc.1)
+
+- [43e0370](https://github.com/stashed/cli/commit/43e0370) Prepare for release v0.10.0-rc.1 (#39)
+- [2c90092](https://github.com/stashed/cli/commit/2c90092) Update README.md
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-rc.20200826)
+
+- [48d00db](https://github.com/stashed/elasticsearch/commit/48d00db) Prepare for release 5.6.4-rc.20200826 (#175)
+- [46c78a6](https://github.com/stashed/elasticsearch/commit/46c78a6) [cherry-pick] Update README.md (#167)
+- [df82b88](https://github.com/stashed/elasticsearch/commit/df82b88) Prepare for release 5.6.4-beta.20200826 (#158)
+- [465a9f0](https://github.com/stashed/elasticsearch/commit/465a9f0) [cherry-pick] Update Stash installation link (#149) (#150)
+- [4fd2af7](https://github.com/stashed/elasticsearch/commit/4fd2af7) [cherry-pick] Make image.tag in values.yaml file same as the $APP_VERSION (#132) (#141)
+- [f9f6ab1](https://github.com/stashed/elasticsearch/commit/f9f6ab1) [cherry-pick] Fix output format + Add PreBackupActions logic (#131) (#133)
+- [cf70698](https://github.com/stashed/elasticsearch/commit/cf70698) [cherry-pick] Update chart icon (#123)
+- [f1c9257](https://github.com/stashed/elasticsearch/commit/f1c9257) [cherry-pick] Make chart registry configurable (#114) (#115)
+- [4f6f04d](https://github.com/stashed/elasticsearch/commit/4f6f04d) Prepare for release 5.6.4-beta.20200709 (#105)
+- [c0b63a8](https://github.com/stashed/elasticsearch/commit/c0b63a8) [cherry-pick] Build docker image in release workflow (#96) (#97)
+- [7115da1](https://github.com/stashed/elasticsearch/commit/7115da1) Prepare for release 5.6.4-beta.20200708 (#87)
+- [f5ab33d](https://github.com/stashed/elasticsearch/commit/f5ab33d) [cherry-pick] Publish to testing dir for alpha/beta releases (#78) (#79)
+- [7d73d30](https://github.com/stashed/elasticsearch/commit/7d73d30) [cherry-pick] Update License (#69) (#70)
+- [04e8a63](https://github.com/stashed/elasticsearch/commit/04e8a63) Add commands to update chart version (#68)
+- [3a5cd78](https://github.com/stashed/elasticsearch/commit/3a5cd78) [cherry-pick] Update update-release-tracker.sh (#60)
+- [77bb76e](https://github.com/stashed/elasticsearch/commit/77bb76e) [cherry-pick] Update update-release-tracker.sh (#52)
+- [3b47ba6](https://github.com/stashed/elasticsearch/commit/3b47ba6) [cherry-pick] Update release.yml (#43) (#44)
+- [444cb3b](https://github.com/stashed/elasticsearch/commit/444cb3b) [cherry-pick] Add script to update release tracker on pr merge (#34) (#35)
+- [d349617](https://github.com/stashed/elasticsearch/commit/d349617) [cherry-pick] Add workflow to cherry pick commits to master (#25) (#26)
+- [4038abd](https://github.com/stashed/elasticsearch/commit/4038abd) Fix chart release process (#24)
+- [895a73f](https://github.com/stashed/elasticsearch/commit/895a73f) Update .kodiak.toml
+- [6b9451c](https://github.com/stashed/elasticsearch/commit/6b9451c) Allow overwriting secret key via SecretTransformation (#23)
+- [0fcb64e](https://github.com/stashed/elasticsearch/commit/0fcb64e) Make waitTimeout Configurable through flag (#22)
+- [b3859b9](https://github.com/stashed/elasticsearch/commit/b3859b9) Create .kodiak.toml
+- [c0f3b97](https://github.com/stashed/elasticsearch/commit/c0f3b97) Update to Kubernetes v1.18.3 (#21)
+- [210dd08](https://github.com/stashed/elasticsearch/commit/210dd08) Update crazy-max/ghaction-docker-buildx flag
+- [5c74a42](https://github.com/stashed/elasticsearch/commit/5c74a42) Trigger the workflow on push or pull request
+- [76424d0](https://github.com/stashed/elasticsearch/commit/76424d0) Auto generate chart readme file
+- [fc144c2](https://github.com/stashed/elasticsearch/commit/fc144c2) Correctly mark optional fields
+- [3559c2c](https://github.com/stashed/elasticsearch/commit/3559c2c) Add openapi v3 schema for values file (#18)
+- [46b8654](https://github.com/stashed/elasticsearch/commit/46b8654) Update CI configuration
+- [5c15319](https://github.com/stashed/elasticsearch/commit/5c15319) Add support for providing s3 region (#17)
+- [c1b75a9](https://github.com/stashed/elasticsearch/commit/c1b75a9) Make output.json file writable to all users + Fix Flag types (#16)
+- [f6d9709](https://github.com/stashed/elasticsearch/commit/f6d9709) Update hugo frontmatter for stash website
+- [5ef236a](https://github.com/stashed/elasticsearch/commit/5ef236a) Enable race detector in e2e tests
+- [1980a77](https://github.com/stashed/elasticsearch/commit/1980a77) Test installers (#14)
+- [63a8396](https://github.com/stashed/elasticsearch/commit/63a8396) Fix broken link and add AppBinding scheme field (#15)
+- [82d3e7c](https://github.com/stashed/elasticsearch/commit/82d3e7c) Add license header to files (#13)
+- [c0241d4](https://github.com/stashed/elasticsearch/commit/c0241d4) Enable make ci (#12)
+- [52f71de](https://github.com/stashed/elasticsearch/commit/52f71de) Fix BackupSession's Print Columns (#11)
+- [91964a5](https://github.com/stashed/elasticsearch/commit/91964a5) Enable make ci (#10)
+- [a804cb0](https://github.com/stashed/elasticsearch/commit/a804cb0) Remove --enable-status-subresource flag (#9)
+- [57c4898](https://github.com/stashed/elasticsearch/commit/57c4898) Fix argument passing (#8)
+- [15b1b3c](https://github.com/stashed/elasticsearch/commit/15b1b3c) Add release pipeline (#7)
+- [b02e1ad](https://github.com/stashed/elasticsearch/commit/b02e1ad) Prepare for 5.6.4 release
+- [7161616](https://github.com/stashed/elasticsearch/commit/7161616) Prepare for 5.6 release
+- [7baf065](https://github.com/stashed/elasticsearch/commit/7baf065) Update go.yml
+- [c8b18b0](https://github.com/stashed/elasticsearch/commit/c8b18b0) Fix typo (#6)
+- [32445a6](https://github.com/stashed/elasticsearch/commit/32445a6) Use InterimVolumeTemplate + Finalize doc template (#5)
+- [16d35ec](https://github.com/stashed/elasticsearch/commit/16d35ec) Enable GitHub actions
+- [acfb971](https://github.com/stashed/elasticsearch/commit/acfb971) Improve error handling + remove metrics handling part (#4)
+- [7e94690](https://github.com/stashed/elasticsearch/commit/7e94690) Use docker buildx to build docker image
+- [6e388ff](https://github.com/stashed/elasticsearch/commit/6e388ff) Use github.com/Azure/go-autorest/autorest@v0.7.0
+- [6a82a60](https://github.com/stashed/elasticsearch/commit/6a82a60) Fix version suffix (#3)
+- [2136ee6](https://github.com/stashed/elasticsearch/commit/2136ee6) Various fixes (#2)
+- [d98b25a](https://github.com/stashed/elasticsearch/commit/d98b25a) Update Chart.yaml
+- [806bf8c](https://github.com/stashed/elasticsearch/commit/806bf8c) Fixed elasticdump & added docs (#1)
+- [3c99f3c](https://github.com/stashed/elasticsearch/commit/3c99f3c) Reorganize repo
+- [1972a9a](https://github.com/stashed/elasticsearch/commit/1972a9a) VolumeSnapshot (#787)
+- [3f1f4cf](https://github.com/stashed/elasticsearch/commit/3f1f4cf) Remove importance of order of rule in RestoreSession (#795)
+- [86a4af0](https://github.com/stashed/elasticsearch/commit/86a4af0) Skip BackupSession creation if target does not exist + use timestamp … (#797)
+- [3abe6f6](https://github.com/stashed/elasticsearch/commit/3abe6f6) Use restic 0.9.5 (#789)
+- [85b21bf](https://github.com/stashed/elasticsearch/commit/85b21bf) Update concept doc (#739)
+- [ad5c8f2](https://github.com/stashed/elasticsearch/commit/ad5c8f2) Add support for backup cluster resources YAML (#721)
+- [2bb8ec3](https://github.com/stashed/elasticsearch/commit/2bb8ec3) Backup and restore Elasticsearch (#702)
+- [1f21268](https://github.com/stashed/elasticsearch/commit/1f21268) Update package path to stash.appscode.dev/stash (#776)
+- [e8fb571](https://github.com/stashed/elasticsearch/commit/e8fb571) Update to k8s 1.14.0 client libraries using go.mod (#775)
+- [eab0f8e](https://github.com/stashed/elasticsearch/commit/eab0f8e) Remove --rbac flag (#761)
+- [4c3e7ea](https://github.com/stashed/elasticsearch/commit/4c3e7ea) Skip creating/processing backup-session when backup-config is paused (#759)
+- [7905eff](https://github.com/stashed/elasticsearch/commit/7905eff) Stash v1beta1 E2E test for PVC (#753)
+- [2c44ee8](https://github.com/stashed/elasticsearch/commit/2c44ee8) Implement snapshots for v1beta1 api (#749)
+- [c88df7a](https://github.com/stashed/elasticsearch/commit/c88df7a) Run restic commands using docker (#754)
+- [8e24d32](https://github.com/stashed/elasticsearch/commit/8e24d32) Fixed scratch-dir, output-dir and hostname in functions/tasks yamls (#744)
+- [8d5944d](https://github.com/stashed/elasticsearch/commit/8d5944d) Add Stash CLI (#734)
+- [550ab37](https://github.com/stashed/elasticsearch/commit/550ab37) Apply nice/ionice settings from env (#746)
+- [42ed76b](https://github.com/stashed/elasticsearch/commit/42ed76b) Stash V1beta1 E2E test for Deployment (#710)
+- [d63f9e9](https://github.com/stashed/elasticsearch/commit/d63f9e9) Fix openapi path prefixes for validators and mutators (#732)
+- [c1347ed](https://github.com/stashed/elasticsearch/commit/c1347ed) Add max-connections for GCS, Azure, B2 backend (#730)
+- [859c4ee](https://github.com/stashed/elasticsearch/commit/859c4ee) Rename admission webhooks to avoid name collision (#725)
+- [d631bb9](https://github.com/stashed/elasticsearch/commit/d631bb9) Apply EmptyDir settings to TmpDir (#719)
+- [cc70068](https://github.com/stashed/elasticsearch/commit/cc70068) Add support for rest backend (#713)
+- [e4db000](https://github.com/stashed/elasticsearch/commit/e4db000) Add support for OpenShift DeploymentConfig (#714)
+- [3fa7bdb](https://github.com/stashed/elasticsearch/commit/3fa7bdb) Backup and restore Mongo DB (#699)
+- [4c39235](https://github.com/stashed/elasticsearch/commit/4c39235) Backup and restore MySQL DB (#696)
+- [3e89d32](https://github.com/stashed/elasticsearch/commit/3e89d32) Backup and restore Postgres DB (#695)
+- [03b95f3](https://github.com/stashed/elasticsearch/commit/03b95f3) Add BackupSession Controller for Sidecar (#701)
+- [cacbc7d](https://github.com/stashed/elasticsearch/commit/cacbc7d) Update workload controller for new design (#675)
+- [5c173e5](https://github.com/stashed/elasticsearch/commit/5c173e5)  Post backup/restore status update (#691)
+- [50bbb0a](https://github.com/stashed/elasticsearch/commit/50bbb0a) Backup and restore PVC (#676)
+- [d4a53e2](https://github.com/stashed/elasticsearch/commit/d4a53e2) Add BackupConfiguration Controller (#671)
+- [ef9a4ae](https://github.com/stashed/elasticsearch/commit/ef9a4ae) Update Kubernetes client libraries to 1.13.0 (#687)
+- [c48dbfc](https://github.com/stashed/elasticsearch/commit/c48dbfc) Separate type definitions into individual files (#646)
+- [77f2113](https://github.com/stashed/elasticsearch/commit/77f2113) Use flags.DumpAll to dump flags (#624)
+- [cb54d8c](https://github.com/stashed/elasticsearch/commit/cb54d8c) Set periodic analytics (#623)
+- [248a53a](https://github.com/stashed/elasticsearch/commit/248a53a) Add validation webhook xray (#618)
+- [2029bf4](https://github.com/stashed/elasticsearch/commit/2029bf4) Use dynamic pushgateway url (#614)
+- [bcf5926](https://github.com/stashed/elasticsearch/commit/bcf5926) Fix offline backup (#537)
+- [5049a63](https://github.com/stashed/elasticsearch/commit/5049a63) Fix extended apiserver issues with Kubernetes 1.11 (#536)
+- [9d31255](https://github.com/stashed/elasticsearch/commit/9d31255) Update client-go to v8.0.0 (#528)
+- [d872b4c](https://github.com/stashed/elasticsearch/commit/d872b4c) Enable status subresource for crds (#524)
+- [4795dba](https://github.com/stashed/elasticsearch/commit/4795dba) Remove ops-address port (#518)
+- [e95b151](https://github.com/stashed/elasticsearch/commit/e95b151) Add support for initial backoff to the apiserver call on recover (#476)
+- [120e5de](https://github.com/stashed/elasticsearch/commit/120e5de) Disable admission controllers for webhook server (#468)
+- [2f19545](https://github.com/stashed/elasticsearch/commit/2f19545) Update client-go to 7.0.0 (#463)
+- [e613ff5](https://github.com/stashed/elasticsearch/commit/e613ff5) Fixes RBAC issue in test (#449)
+- [56a3a74](https://github.com/stashed/elasticsearch/commit/56a3a74) Some cleanup (#446)
+- [02565bb](https://github.com/stashed/elasticsearch/commit/02565bb) Delete restic repository from backend if Repository CRD is deleted (#438)
+- [ea98067](https://github.com/stashed/elasticsearch/commit/ea98067) Fix go_vet error (#440)
+- [9d626eb](https://github.com/stashed/elasticsearch/commit/9d626eb) Increase qps and burst limits (#435)
+- [5c6713f](https://github.com/stashed/elasticsearch/commit/5c6713f) Show repository snapshot list (#417)
+- [6d8ef78](https://github.com/stashed/elasticsearch/commit/6d8ef78) Expose swagger.json (#420)
+- [8e04ca0](https://github.com/stashed/elasticsearch/commit/8e04ca0) Create repository crd for each Restic repository (#394)
+- [4c9a478](https://github.com/stashed/elasticsearch/commit/4c9a478) Rename --analytics to --enable-analytics (#384)
+- [7ea2220](https://github.com/stashed/elasticsearch/commit/7ea2220) Replace initializers with mutation webhook for workloads (#363)
+- [2770e6b](https://github.com/stashed/elasticsearch/commit/2770e6b) Use admission hook helpers from kutil (#360)
+- [d3754d7](https://github.com/stashed/elasticsearch/commit/d3754d7) Implement offline backup for multiple replica (#335)
+- [13a2d14](https://github.com/stashed/elasticsearch/commit/13a2d14) Use official code generator scripts (#336)
+- [90642ce](https://github.com/stashed/elasticsearch/commit/90642ce) Fix e2e tests after webhook merger (#333)
+- [2fc3239](https://github.com/stashed/elasticsearch/commit/2fc3239) Leave secure port unset
+- [7cb52b2](https://github.com/stashed/elasticsearch/commit/7cb52b2) Merge admission webhook and operator into one binary (#329)
+- [3306427](https://github.com/stashed/elasticsearch/commit/3306427) Implement informer factory for backup scheduler (#325)
+- [7bb027b](https://github.com/stashed/elasticsearch/commit/7bb027b) Cleanup apiserver
+- [fb8c1e4](https://github.com/stashed/elasticsearch/commit/fb8c1e4) Copy generic-admission-server into pkg (#318)
+- [5a5093f](https://github.com/stashed/elasticsearch/commit/5a5093f) Use shared infromer factory (#317)
+- [0ccb948](https://github.com/stashed/elasticsearch/commit/0ccb948) Use GetBaseVersion method from kutil (#316)
+- [8c5e6ff](https://github.com/stashed/elasticsearch/commit/8c5e6ff) Fix webhook command description (#314)
+- [775a2b6](https://github.com/stashed/elasticsearch/commit/775a2b6) Merge webhook plugins into one. (#311)
+- [a8659fe](https://github.com/stashed/elasticsearch/commit/a8659fe) Add ValidatingAdmissionWebhook for Stash CRDs (#299)
+- [c3e177c](https://github.com/stashed/elasticsearch/commit/c3e177c) Added support for private docker registry (#300)
+- [62ec42e](https://github.com/stashed/elasticsearch/commit/62ec42e) Update dependencies to Kubernetes 1.9 (#297)
+- [cf3ea7c](https://github.com/stashed/elasticsearch/commit/cf3ea7c) Update appscode/go log wrapper (#287)
+- [470cc31](https://github.com/stashed/elasticsearch/commit/470cc31) Pass --pushgateway-url for injected containers. (#284)
+- [e2e79c6](https://github.com/stashed/elasticsearch/commit/e2e79c6) Fix kubectl version parsing generation in GKE (#267)
+- [326aea4](https://github.com/stashed/elasticsearch/commit/326aea4) Detect analytics client id using env vars (#265)
+- [4a5912c](https://github.com/stashed/elasticsearch/commit/4a5912c) Prepare docs for 0.6.0 release (#264)
+- [f75d5df](https://github.com/stashed/elasticsearch/commit/f75d5df) Remove restic-dependency from recovery (#258)
+- [86f01f3](https://github.com/stashed/elasticsearch/commit/86f01f3) Log operator version on start (#253)
+- [4e29b70](https://github.com/stashed/elasticsearch/commit/4e29b70) Simplify clientID generation for analytics (#247)
+- [a45937f](https://github.com/stashed/elasticsearch/commit/a45937f) Set analytics clientID (#246)
+- [ea53cea](https://github.com/stashed/elasticsearch/commit/ea53cea) Enable Restic cahce-dir flag (#241)
+- [dc0030d](https://github.com/stashed/elasticsearch/commit/dc0030d) Implement offline backup (#229)
+- [ae40f35](https://github.com/stashed/elasticsearch/commit/ae40f35) Revendor kutil (#230)
+- [d68a34d](https://github.com/stashed/elasticsearch/commit/d68a34d) Record recovery status for individual FileGroup (#222)
+- [15a24b7](https://github.com/stashed/elasticsearch/commit/15a24b7) Leader election for deployment, replica set and rc (#206)
+- [4a75689](https://github.com/stashed/elasticsearch/commit/4a75689) Implement Recovery for Restic Backup (#202)
+- [78b3942](https://github.com/stashed/elasticsearch/commit/78b3942) Use typed versioned client for CRD
+- [b857b05](https://github.com/stashed/elasticsearch/commit/b857b05) Change `k8s.io/api/core/v1` pkg alias to core (#204)
+- [e52f848](https://github.com/stashed/elasticsearch/commit/e52f848) Use client-go 5.x
+- [4f376ad](https://github.com/stashed/elasticsearch/commit/4f376ad) Set hostname based on resource type (#198)
+- [e530116](https://github.com/stashed/elasticsearch/commit/e530116) Manage RoleBinding for rbac enabled cluster (#197)
+- [e28c13f](https://github.com/stashed/elasticsearch/commit/e28c13f) Use workqueue for scheduler (#194)
+- [2719cbd](https://github.com/stashed/elasticsearch/commit/2719cbd) Fix e2e tests (#183)
+- [9c1cc43](https://github.com/stashed/elasticsearch/commit/9c1cc43) Use workqueue (#182)
+- [b3ee076](https://github.com/stashed/elasticsearch/commit/b3ee076) Only watch apps/v1beta1 Deployment (#178)
+- [4f92ca6](https://github.com/stashed/elasticsearch/commit/4f92ca6) Use Namespace() method from kutil.
+- [78f1e7f](https://github.com/stashed/elasticsearch/commit/78f1e7f) Update kutil (#170)
+- [29a8a1f](https://github.com/stashed/elasticsearch/commit/29a8a1f) Use apis/v1alpha1 instead of internal version (#167)
+- [da3eb2e](https://github.com/stashed/elasticsearch/commit/da3eb2e) Use kubernetes/code-generator (#163)
+- [3b1d6bf](https://github.com/stashed/elasticsearch/commit/3b1d6bf) Expose resync-period as flag
+- [35d8dc6](https://github.com/stashed/elasticsearch/commit/35d8dc6) Move analytics collector to root command (#164)
+- [6a55694](https://github.com/stashed/elasticsearch/commit/6a55694) Migrate TPR to CRD (#160)
+- [91f678f](https://github.com/stashed/elasticsearch/commit/91f678f) Rename RepositorySecretName to StorageSecretName (#135)
+- [d666c81](https://github.com/stashed/elasticsearch/commit/d666c81) Change mount path for labels to /etc/stash
+- [1177d60](https://github.com/stashed/elasticsearch/commit/1177d60) Part 6 - Update docs (#121)
+- [a15689d](https://github.com/stashed/elasticsearch/commit/a15689d) Various bug fixes (#118)
+- [d8a5771](https://github.com/stashed/elasticsearch/commit/d8a5771) Set TMPDIR env var for restic (#115)
+- [60ed8f7](https://github.com/stashed/elasticsearch/commit/60ed8f7) Update user guide (#94)
+
+
+### [6.2.4-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-rc.20200826)
+
+
+
+### [6.3.0-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-rc.20200826)
+
+
+
+### [6.4.0-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-rc.20200826)
+
+
+
+### [6.5.3-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-rc.20200826)
+
+
+
+### [6.8.0-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-rc.20200826)
+
+
+
+### [7.2.0-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-rc.20200826)
+
+
+
+### [7.3.2-rc.20200826](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-rc.20200826)
+
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.10.0-rc.1](https://github.com/stashed/installer/releases/tag/v0.10.0-rc.1)
+
+- [037a349](https://github.com/stashed/installer/commit/037a349) Prepare for release v0.10.0-rc.1 (#90)
+- [f94e175](https://github.com/stashed/installer/commit/f94e175) Correctly pass license to CI workflow
+- [9f6539d](https://github.com/stashed/installer/commit/9f6539d) Update stash-enterprise chart version
+- [5904e2c](https://github.com/stashed/installer/commit/5904e2c) Update README.md
+- [d3d30cc](https://github.com/stashed/installer/commit/d3d30cc) Add link to the steps to get a license (#89)
+- [1fb05d9](https://github.com/stashed/installer/commit/1fb05d9) Issue license for testing enterprise charts (#88)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.1-rc.20200826](https://github.com/stashed/mongodb/releases/tag/3.4.1-rc.20200826)
+
+- [1d2811c](https://github.com/stashed/mongodb/commit/1d2811c) Prepare for release 3.4.1-rc.20200826 (#208)
+- [b3501fb](https://github.com/stashed/mongodb/commit/b3501fb) [cherry-pick] Update README.md (#197)
+- [1c08dfd](https://github.com/stashed/mongodb/commit/1c08dfd) Prepare for release 3.4.1-beta.20200826 (#185)
+- [a4d2b49](https://github.com/stashed/mongodb/commit/a4d2b49) [cherry-pick] Update Stash installation link (#173) (#174)
+- [3ae949e](https://github.com/stashed/mongodb/commit/3ae949e) [cherry-pick] Fix output format + Add PreBackupActions logic (#149) (#162)
+- [75ebc36](https://github.com/stashed/mongodb/commit/75ebc36) [cherry-pick] Make image.tag in values.yaml same as $APP_VERSION (#150) (#151)
+- [c261899](https://github.com/stashed/mongodb/commit/c261899) [cherry-pick] Update chart icon (#138)
+- [465f36c](https://github.com/stashed/mongodb/commit/465f36c) [cherry-pick] Make chart registry configurable (#126) (#127)
+- [a354b6c](https://github.com/stashed/mongodb/commit/a354b6c) Prepare for release 3.4.1-beta.20200709 (#114)
+- [2269fa6](https://github.com/stashed/mongodb/commit/2269fa6) [cherry-pick] Build docker image in release workflow (#102) (#103)
+- [47b1d72](https://github.com/stashed/mongodb/commit/47b1d72) Prepare for release 3.4.1-beta.20200708 (#90)
+- [67b293a](https://github.com/stashed/mongodb/commit/67b293a) [cherry-pick] Publish to testing dir for alpha/beta releases (#78) (#79)
+- [d8c9489](https://github.com/stashed/mongodb/commit/d8c9489) [cherry-pick] Update License (#66) (#67)
+- [13f91cd](https://github.com/stashed/mongodb/commit/13f91cd) Add commands to update chart version (#65)
+- [5ec5c3c](https://github.com/stashed/mongodb/commit/5ec5c3c) [cherry-pick] Update update-release-tracker.sh (#54)
+- [409301c](https://github.com/stashed/mongodb/commit/409301c) Add script to update release tracker on pr merge (#41)
+- [deed415](https://github.com/stashed/mongodb/commit/deed415) [cherry-pick] Update release.yml (#42) (#43)
+- [7efcffb](https://github.com/stashed/mongodb/commit/7efcffb) [cherry-pick] Add workflow to cherry pick commits to master (#29) (#30)
+- [2ed8277](https://github.com/stashed/mongodb/commit/2ed8277) Fix chart release process (#28)
+- [b7b3bc6](https://github.com/stashed/mongodb/commit/b7b3bc6) Update .kodiak.toml
+- [33abf73](https://github.com/stashed/mongodb/commit/33abf73) Allow overwriting secret key via SecretTransformation (#27)
+- [ad30b7d](https://github.com/stashed/mongodb/commit/ad30b7d) Make waitTimeout configurable through flag (#26)
+- [80f62d1](https://github.com/stashed/mongodb/commit/80f62d1) Create .kodiak.toml
+- [d8e7b86](https://github.com/stashed/mongodb/commit/d8e7b86) Fix typos
+- [f5dfaea](https://github.com/stashed/mongodb/commit/f5dfaea) Update to Kubernetes v1.18.3 (#25)
+- [4a462cb](https://github.com/stashed/mongodb/commit/4a462cb) Update crazy-max/ghaction-docker-buildx flag
+- [961fad3](https://github.com/stashed/mongodb/commit/961fad3) Fix typos
+- [14024ab](https://github.com/stashed/mongodb/commit/14024ab) Trigger the workflow on push or pull request
+- [c80a723](https://github.com/stashed/mongodb/commit/c80a723) Auto generate chart readme file
+- [223dbfd](https://github.com/stashed/mongodb/commit/223dbfd) Correctly mark optional fields
+- [8b3b75d](https://github.com/stashed/mongodb/commit/8b3b75d) Add openapi v3 schema for values file (#21)
+- [6229815](https://github.com/stashed/mongodb/commit/6229815) Update CI configuration
+- [3f2f090](https://github.com/stashed/mongodb/commit/3f2f090) Add support for specifying S3 region (#20)
+- [55f007d](https://github.com/stashed/mongodb/commit/55f007d) Make output.json file writable to all users + Fix Flag types (#19)
+- [93643f3](https://github.com/stashed/mongodb/commit/93643f3) Fix with arguments to mongorestore (#14)
+- [0d9595c](https://github.com/stashed/mongodb/commit/0d9595c) Update hugo frontmatter for stash website
+- [cb27f47](https://github.com/stashed/mongodb/commit/cb27f47) Added --nsExclude=config.changelog to standalone
+- [a941eb0](https://github.com/stashed/mongodb/commit/a941eb0) Enable race detector in e2e tests
+- [2ed387f](https://github.com/stashed/mongodb/commit/2ed387f) Fix broken link and add AppBinding scheme field (#13)
+- [8dd0ea1](https://github.com/stashed/mongodb/commit/8dd0ea1) Test installers (#12)
+- [5199d20](https://github.com/stashed/mongodb/commit/5199d20) Add license header to files (#11)
+- [f89adec](https://github.com/stashed/mongodb/commit/f89adec) Split imports into 3 parts (#10)
+- [1c447f4](https://github.com/stashed/mongodb/commit/1c447f4) Fix BackupSession's Print Columns (#9)
+- [201a06e](https://github.com/stashed/mongodb/commit/201a06e) Enable make ci (#8)
+- [613feea](https://github.com/stashed/mongodb/commit/613feea) Remove --enable-status-subresource flag (#7)
+- [95c3974](https://github.com/stashed/mongodb/commit/95c3974) Update totalHosts from backup/restore process (#6)
+- [3097a67](https://github.com/stashed/mongodb/commit/3097a67) Fix argument passing (#5)
+- [ccdf81f](https://github.com/stashed/mongodb/commit/ccdf81f) Remove support for arm and arm64 architecture
+- [f0b8e87](https://github.com/stashed/mongodb/commit/f0b8e87) Prepare for 3.4.17 release
+- [16ad538](https://github.com/stashed/mongodb/commit/16ad538) Prepare for 3.4 release
+- [c4eb920](https://github.com/stashed/mongodb/commit/c4eb920) Add release pipeline (#4)
+- [02b9a9f](https://github.com/stashed/mongodb/commit/02b9a9f) Update go.yml
+- [7ede5fd](https://github.com/stashed/mongodb/commit/7ede5fd) Finalize doc template (#3)
+- [bb3b7fd](https://github.com/stashed/mongodb/commit/bb3b7fd) Enable GitHub actions
+- [6874298](https://github.com/stashed/mongodb/commit/6874298) Improve error handling + remove metrics handling part (#2)
+- [000f2c6](https://github.com/stashed/mongodb/commit/000f2c6) Use docker buildx to build docker image
+- [867a620](https://github.com/stashed/mongodb/commit/867a620) Use github.com/Azure/go-autorest/autorest@v0.7.0
+- [ecb6143](https://github.com/stashed/mongodb/commit/ecb6143) run `go fmt`
+- [618886d](https://github.com/stashed/mongodb/commit/618886d)  Improve Mongodump for sharded and replicaset cluster && Chart and documentation (#1)
+- [4a7d5c8](https://github.com/stashed/mongodb/commit/4a7d5c8) Reorganize repo
+- [1972a9a](https://github.com/stashed/mongodb/commit/1972a9a) VolumeSnapshot (#787)
+- [3f1f4cf](https://github.com/stashed/mongodb/commit/3f1f4cf) Remove importance of order of rule in RestoreSession (#795)
+- [86a4af0](https://github.com/stashed/mongodb/commit/86a4af0) Skip BackupSession creation if target does not exist + use timestamp … (#797)
+- [3abe6f6](https://github.com/stashed/mongodb/commit/3abe6f6) Use restic 0.9.5 (#789)
+- [85b21bf](https://github.com/stashed/mongodb/commit/85b21bf) Update concept doc (#739)
+- [ad5c8f2](https://github.com/stashed/mongodb/commit/ad5c8f2) Add support for backup cluster resources YAML (#721)
+- [2bb8ec3](https://github.com/stashed/mongodb/commit/2bb8ec3) Backup and restore Elasticsearch (#702)
+- [1f21268](https://github.com/stashed/mongodb/commit/1f21268) Update package path to stash.appscode.dev/stash (#776)
+- [e8fb571](https://github.com/stashed/mongodb/commit/e8fb571) Update to k8s 1.14.0 client libraries using go.mod (#775)
+- [eab0f8e](https://github.com/stashed/mongodb/commit/eab0f8e) Remove --rbac flag (#761)
+- [4c3e7ea](https://github.com/stashed/mongodb/commit/4c3e7ea) Skip creating/processing backup-session when backup-config is paused (#759)
+- [7905eff](https://github.com/stashed/mongodb/commit/7905eff) Stash v1beta1 E2E test for PVC (#753)
+- [2c44ee8](https://github.com/stashed/mongodb/commit/2c44ee8) Implement snapshots for v1beta1 api (#749)
+- [c88df7a](https://github.com/stashed/mongodb/commit/c88df7a) Run restic commands using docker (#754)
+- [8e24d32](https://github.com/stashed/mongodb/commit/8e24d32) Fixed scratch-dir, output-dir and hostname in functions/tasks yamls (#744)
+- [8d5944d](https://github.com/stashed/mongodb/commit/8d5944d) Add Stash CLI (#734)
+- [550ab37](https://github.com/stashed/mongodb/commit/550ab37) Apply nice/ionice settings from env (#746)
+- [42ed76b](https://github.com/stashed/mongodb/commit/42ed76b) Stash V1beta1 E2E test for Deployment (#710)
+- [d63f9e9](https://github.com/stashed/mongodb/commit/d63f9e9) Fix openapi path prefixes for validators and mutators (#732)
+- [c1347ed](https://github.com/stashed/mongodb/commit/c1347ed) Add max-connections for GCS, Azure, B2 backend (#730)
+- [859c4ee](https://github.com/stashed/mongodb/commit/859c4ee) Rename admission webhooks to avoid name collision (#725)
+- [d631bb9](https://github.com/stashed/mongodb/commit/d631bb9) Apply EmptyDir settings to TmpDir (#719)
+- [cc70068](https://github.com/stashed/mongodb/commit/cc70068) Add support for rest backend (#713)
+- [e4db000](https://github.com/stashed/mongodb/commit/e4db000) Add support for OpenShift DeploymentConfig (#714)
+- [3fa7bdb](https://github.com/stashed/mongodb/commit/3fa7bdb) Backup and restore Mongo DB (#699)
+- [4c39235](https://github.com/stashed/mongodb/commit/4c39235) Backup and restore MySQL DB (#696)
+- [3e89d32](https://github.com/stashed/mongodb/commit/3e89d32) Backup and restore Postgres DB (#695)
+- [03b95f3](https://github.com/stashed/mongodb/commit/03b95f3) Add BackupSession Controller for Sidecar (#701)
+- [cacbc7d](https://github.com/stashed/mongodb/commit/cacbc7d) Update workload controller for new design (#675)
+- [5c173e5](https://github.com/stashed/mongodb/commit/5c173e5)  Post backup/restore status update (#691)
+- [50bbb0a](https://github.com/stashed/mongodb/commit/50bbb0a) Backup and restore PVC (#676)
+- [d4a53e2](https://github.com/stashed/mongodb/commit/d4a53e2) Add BackupConfiguration Controller (#671)
+- [ef9a4ae](https://github.com/stashed/mongodb/commit/ef9a4ae) Update Kubernetes client libraries to 1.13.0 (#687)
+- [c48dbfc](https://github.com/stashed/mongodb/commit/c48dbfc) Separate type definitions into individual files (#646)
+- [77f2113](https://github.com/stashed/mongodb/commit/77f2113) Use flags.DumpAll to dump flags (#624)
+- [cb54d8c](https://github.com/stashed/mongodb/commit/cb54d8c) Set periodic analytics (#623)
+- [248a53a](https://github.com/stashed/mongodb/commit/248a53a) Add validation webhook xray (#618)
+- [2029bf4](https://github.com/stashed/mongodb/commit/2029bf4) Use dynamic pushgateway url (#614)
+- [bcf5926](https://github.com/stashed/mongodb/commit/bcf5926) Fix offline backup (#537)
+- [5049a63](https://github.com/stashed/mongodb/commit/5049a63) Fix extended apiserver issues with Kubernetes 1.11 (#536)
+- [9d31255](https://github.com/stashed/mongodb/commit/9d31255) Update client-go to v8.0.0 (#528)
+- [d872b4c](https://github.com/stashed/mongodb/commit/d872b4c) Enable status subresource for crds (#524)
+- [4795dba](https://github.com/stashed/mongodb/commit/4795dba) Remove ops-address port (#518)
+- [e95b151](https://github.com/stashed/mongodb/commit/e95b151) Add support for initial backoff to the apiserver call on recover (#476)
+- [120e5de](https://github.com/stashed/mongodb/commit/120e5de) Disable admission controllers for webhook server (#468)
+- [2f19545](https://github.com/stashed/mongodb/commit/2f19545) Update client-go to 7.0.0 (#463)
+- [e613ff5](https://github.com/stashed/mongodb/commit/e613ff5) Fixes RBAC issue in test (#449)
+- [56a3a74](https://github.com/stashed/mongodb/commit/56a3a74) Some cleanup (#446)
+- [02565bb](https://github.com/stashed/mongodb/commit/02565bb) Delete restic repository from backend if Repository CRD is deleted (#438)
+- [ea98067](https://github.com/stashed/mongodb/commit/ea98067) Fix go_vet error (#440)
+- [9d626eb](https://github.com/stashed/mongodb/commit/9d626eb) Increase qps and burst limits (#435)
+- [5c6713f](https://github.com/stashed/mongodb/commit/5c6713f) Show repository snapshot list (#417)
+- [6d8ef78](https://github.com/stashed/mongodb/commit/6d8ef78) Expose swagger.json (#420)
+- [8e04ca0](https://github.com/stashed/mongodb/commit/8e04ca0) Create repository crd for each Restic repository (#394)
+- [4c9a478](https://github.com/stashed/mongodb/commit/4c9a478) Rename --analytics to --enable-analytics (#384)
+- [7ea2220](https://github.com/stashed/mongodb/commit/7ea2220) Replace initializers with mutation webhook for workloads (#363)
+- [2770e6b](https://github.com/stashed/mongodb/commit/2770e6b) Use admission hook helpers from kutil (#360)
+- [d3754d7](https://github.com/stashed/mongodb/commit/d3754d7) Implement offline backup for multiple replica (#335)
+- [13a2d14](https://github.com/stashed/mongodb/commit/13a2d14) Use official code generator scripts (#336)
+- [90642ce](https://github.com/stashed/mongodb/commit/90642ce) Fix e2e tests after webhook merger (#333)
+- [2fc3239](https://github.com/stashed/mongodb/commit/2fc3239) Leave secure port unset
+- [7cb52b2](https://github.com/stashed/mongodb/commit/7cb52b2) Merge admission webhook and operator into one binary (#329)
+- [3306427](https://github.com/stashed/mongodb/commit/3306427) Implement informer factory for backup scheduler (#325)
+- [7bb027b](https://github.com/stashed/mongodb/commit/7bb027b) Cleanup apiserver
+- [fb8c1e4](https://github.com/stashed/mongodb/commit/fb8c1e4) Copy generic-admission-server into pkg (#318)
+- [5a5093f](https://github.com/stashed/mongodb/commit/5a5093f) Use shared infromer factory (#317)
+- [0ccb948](https://github.com/stashed/mongodb/commit/0ccb948) Use GetBaseVersion method from kutil (#316)
+- [8c5e6ff](https://github.com/stashed/mongodb/commit/8c5e6ff) Fix webhook command description (#314)
+- [775a2b6](https://github.com/stashed/mongodb/commit/775a2b6) Merge webhook plugins into one. (#311)
+- [a8659fe](https://github.com/stashed/mongodb/commit/a8659fe) Add ValidatingAdmissionWebhook for Stash CRDs (#299)
+- [c3e177c](https://github.com/stashed/mongodb/commit/c3e177c) Added support for private docker registry (#300)
+- [62ec42e](https://github.com/stashed/mongodb/commit/62ec42e) Update dependencies to Kubernetes 1.9 (#297)
+- [cf3ea7c](https://github.com/stashed/mongodb/commit/cf3ea7c) Update appscode/go log wrapper (#287)
+- [470cc31](https://github.com/stashed/mongodb/commit/470cc31) Pass --pushgateway-url for injected containers. (#284)
+- [e2e79c6](https://github.com/stashed/mongodb/commit/e2e79c6) Fix kubectl version parsing generation in GKE (#267)
+- [326aea4](https://github.com/stashed/mongodb/commit/326aea4) Detect analytics client id using env vars (#265)
+- [4a5912c](https://github.com/stashed/mongodb/commit/4a5912c) Prepare docs for 0.6.0 release (#264)
+- [f75d5df](https://github.com/stashed/mongodb/commit/f75d5df) Remove restic-dependency from recovery (#258)
+- [86f01f3](https://github.com/stashed/mongodb/commit/86f01f3) Log operator version on start (#253)
+- [4e29b70](https://github.com/stashed/mongodb/commit/4e29b70) Simplify clientID generation for analytics (#247)
+- [a45937f](https://github.com/stashed/mongodb/commit/a45937f) Set analytics clientID (#246)
+- [ea53cea](https://github.com/stashed/mongodb/commit/ea53cea) Enable Restic cahce-dir flag (#241)
+- [dc0030d](https://github.com/stashed/mongodb/commit/dc0030d) Implement offline backup (#229)
+- [ae40f35](https://github.com/stashed/mongodb/commit/ae40f35) Revendor kutil (#230)
+- [d68a34d](https://github.com/stashed/mongodb/commit/d68a34d) Record recovery status for individual FileGroup (#222)
+- [15a24b7](https://github.com/stashed/mongodb/commit/15a24b7) Leader election for deployment, replica set and rc (#206)
+- [4a75689](https://github.com/stashed/mongodb/commit/4a75689) Implement Recovery for Restic Backup (#202)
+- [78b3942](https://github.com/stashed/mongodb/commit/78b3942) Use typed versioned client for CRD
+- [b857b05](https://github.com/stashed/mongodb/commit/b857b05) Change `k8s.io/api/core/v1` pkg alias to core (#204)
+- [e52f848](https://github.com/stashed/mongodb/commit/e52f848) Use client-go 5.x
+- [4f376ad](https://github.com/stashed/mongodb/commit/4f376ad) Set hostname based on resource type (#198)
+- [e530116](https://github.com/stashed/mongodb/commit/e530116) Manage RoleBinding for rbac enabled cluster (#197)
+- [e28c13f](https://github.com/stashed/mongodb/commit/e28c13f) Use workqueue for scheduler (#194)
+- [2719cbd](https://github.com/stashed/mongodb/commit/2719cbd) Fix e2e tests (#183)
+- [9c1cc43](https://github.com/stashed/mongodb/commit/9c1cc43) Use workqueue (#182)
+- [b3ee076](https://github.com/stashed/mongodb/commit/b3ee076) Only watch apps/v1beta1 Deployment (#178)
+- [4f92ca6](https://github.com/stashed/mongodb/commit/4f92ca6) Use Namespace() method from kutil.
+- [78f1e7f](https://github.com/stashed/mongodb/commit/78f1e7f) Update kutil (#170)
+- [29a8a1f](https://github.com/stashed/mongodb/commit/29a8a1f) Use apis/v1alpha1 instead of internal version (#167)
+- [da3eb2e](https://github.com/stashed/mongodb/commit/da3eb2e) Use kubernetes/code-generator (#163)
+- [3b1d6bf](https://github.com/stashed/mongodb/commit/3b1d6bf) Expose resync-period as flag
+- [35d8dc6](https://github.com/stashed/mongodb/commit/35d8dc6) Move analytics collector to root command (#164)
+- [6a55694](https://github.com/stashed/mongodb/commit/6a55694) Migrate TPR to CRD (#160)
+- [91f678f](https://github.com/stashed/mongodb/commit/91f678f) Rename RepositorySecretName to StorageSecretName (#135)
+- [d666c81](https://github.com/stashed/mongodb/commit/d666c81) Change mount path for labels to /etc/stash
+- [1177d60](https://github.com/stashed/mongodb/commit/1177d60) Part 6 - Update docs (#121)
+- [a15689d](https://github.com/stashed/mongodb/commit/a15689d) Various bug fixes (#118)
+- [d8a5771](https://github.com/stashed/mongodb/commit/d8a5771) Set TMPDIR env var for restic (#115)
+- [60ed8f7](https://github.com/stashed/mongodb/commit/60ed8f7) Update user guide (#94)
+
+
+### [3.4.2-rc.20200826](https://github.com/stashed/mongodb/releases/tag/3.4.2-rc.20200826)
+
+
+
+### [3.6.1-rc.20200826](https://github.com/stashed/mongodb/releases/tag/3.6.1-rc.20200826)
+
+
+
+### [3.6.8-rc.20200826](https://github.com/stashed/mongodb/releases/tag/3.6.8-rc.20200826)
+
+
+
+### [4.0.3-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.0.3-rc.20200826)
+
+
+
+### [4.0.5-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.0.5-rc.20200826)
+
+
+
+### [4.0.11-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.0.11-rc.20200826)
+
+
+
+### [4.1.1-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.1.1-rc.20200826)
+
+
+
+### [4.1.4-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.1.4-rc.20200826)
+
+
+
+### [4.1.7-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.1.7-rc.20200826)
+
+
+
+### [4.2.3-rc.20200826](https://github.com/stashed/mongodb/releases/tag/4.2.3-rc.20200826)
+
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-rc.20200826](https://github.com/stashed/mysql/releases/tag/5.7.25-rc.20200826)
+
+- [3cb98d3](https://github.com/stashed/mysql/commit/3cb98d3) Prepare for release 5.7.25-rc.20200826 (#92)
+- [d5b1978](https://github.com/stashed/mysql/commit/d5b1978) [cherry-pick] Update README.md (#89)
+- [813ee01](https://github.com/stashed/mysql/commit/813ee01) Prepare for release 5.7.25-beta.20200826 (#85)
+- [e646be7](https://github.com/stashed/mysql/commit/e646be7) [cherry-pick] Update Stash installation link (#81) (#82)
+- [ecc7d0c](https://github.com/stashed/mysql/commit/ecc7d0c) [cherry-pick] Fix output format (#46) (#78)
+- [7fcbd24](https://github.com/stashed/mysql/commit/7fcbd24) [cherry-pick] Pass image tag in values.yaml file (#74) (#75)
+- [3188584](https://github.com/stashed/mysql/commit/3188584) [cherry-pick] Update chart icon (#71)
+- [9060c7a](https://github.com/stashed/mysql/commit/9060c7a) [cherry-pick] Make chart registry configurable (#67) (#68)
+- [422a411](https://github.com/stashed/mysql/commit/422a411) Prepare for release 5.7.25-beta.20200709 (#63)
+- [e345110](https://github.com/stashed/mysql/commit/e345110) [cherry-pick] Build docker image in release workflow (#59) (#60)
+- [3a44b41](https://github.com/stashed/mysql/commit/3a44b41) Prepare for release 5.7.25-beta.20200708 (#55)
+- [7e2984b](https://github.com/stashed/mysql/commit/7e2984b) [cherry-pick] Publish to testing dir for alpha/beta releases (#51) (#52)
+- [aa1eac2](https://github.com/stashed/mysql/commit/aa1eac2) [cherry-pick] Update License (#47) (#48)
+- [d4370c9](https://github.com/stashed/mysql/commit/d4370c9) Add commands to update chart version (#45)
+- [38fb308](https://github.com/stashed/mysql/commit/38fb308) [cherry-pick] Update update-release-tracker.sh (#42)
+- [f3bfd48](https://github.com/stashed/mysql/commit/f3bfd48) [cherry-pick] Update update-release-tracker.sh (#39)
+- [56e92c4](https://github.com/stashed/mysql/commit/56e92c4) [cherry-pick] Update release.yml (#36)
+- [be341e7](https://github.com/stashed/mysql/commit/be341e7) [cherry-pick] Add script to update release tracker on pr merge (#32) (#33)
+- [96504a7](https://github.com/stashed/mysql/commit/96504a7) [cherry-pick] Add workflow to cherry pick commits to master (#28) (#29)
+- [fcbe891](https://github.com/stashed/mysql/commit/fcbe891) Fix chart release process (#27)
+- [c012edf](https://github.com/stashed/mysql/commit/c012edf) Update .kodiak.toml
+- [0d22657](https://github.com/stashed/mysql/commit/0d22657) Allow overwriting secret key via SecretTransformation (#26)
+- [f717a19](https://github.com/stashed/mysql/commit/f717a19) Fix unit tests (#25)
+- [d4f5c4c](https://github.com/stashed/mysql/commit/d4f5c4c) Create .kodiak.toml
+- [2bfa098](https://github.com/stashed/mysql/commit/2bfa098) Fix typos
+- [5c1a53d](https://github.com/stashed/mysql/commit/5c1a53d) mend
+- [9eb402f](https://github.com/stashed/mysql/commit/9eb402f) Update to Kubernetes v1.18.3 (#24)
+- [4d4afa2](https://github.com/stashed/mysql/commit/4d4afa2) Fix waitForDBReady() logic + Make timeout configurable (#23)
+- [4548802](https://github.com/stashed/mysql/commit/4548802) Update crazy-max/ghaction-docker-buildx flag
+- [ce1fa72](https://github.com/stashed/mysql/commit/ce1fa72) Trigger the workflow on push or pull request
+- [dad10df](https://github.com/stashed/mysql/commit/dad10df) Auto generate chart readme file
+- [462eecf](https://github.com/stashed/mysql/commit/462eecf) Correctly mark optional fields
+- [424ec5a](https://github.com/stashed/mysql/commit/424ec5a) Add openapi v3 schema for values file (#20)
+- [4755987](https://github.com/stashed/mysql/commit/4755987) Update CI configuration
+- [22e8141](https://github.com/stashed/mysql/commit/22e8141) Add support for providing s3 region (#18)
+- [793e5e4](https://github.com/stashed/mysql/commit/793e5e4) Make output.json file writable to all users + Fix Flag types (#17)
+- [7d65a07](https://github.com/stashed/mysql/commit/7d65a07) Update hugo frontmatter for stash website
+- [9392ce0](https://github.com/stashed/mysql/commit/9392ce0) Enable race detector in e2e tests
+- [111bbfe](https://github.com/stashed/mysql/commit/111bbfe) Test installers (#15)
+- [6eb327f](https://github.com/stashed/mysql/commit/6eb327f) Fix broken link and add AppBinding scheme field (#16)
+- [292afdc](https://github.com/stashed/mysql/commit/292afdc) Add license header to files (#14)
+- [35bd620](https://github.com/stashed/mysql/commit/35bd620) Split imports into 3 parts (#13)
+- [799ee9b](https://github.com/stashed/mysql/commit/799ee9b) Fix BackupSession's Print Columns (#12)
+- [6d62faa](https://github.com/stashed/mysql/commit/6d62faa) Enable make ci (#11)
+- [9f5d50e](https://github.com/stashed/mysql/commit/9f5d50e) Remove --enable-status-subresource flag (#10)
+- [fb1cedd](https://github.com/stashed/mysql/commit/fb1cedd) Fix argument passing (#9)
+- [56f9fdb](https://github.com/stashed/mysql/commit/56f9fdb) Only build x86-64 images
+- [a2bcae7](https://github.com/stashed/mysql/commit/a2bcae7) Add release pipeline (#8)
+- [36eb1be](https://github.com/stashed/mysql/commit/36eb1be) Prepare 5.7.25 release
+- [09896d9](https://github.com/stashed/mysql/commit/09896d9) Update go.yml
+- [eed5d07](https://github.com/stashed/mysql/commit/eed5d07) Fix link (#7)
+- [8278413](https://github.com/stashed/mysql/commit/8278413) Finalize doc template (#6)
+- [4ef23ee](https://github.com/stashed/mysql/commit/4ef23ee) Enable GitHub actions
+- [5454aac](https://github.com/stashed/mysql/commit/5454aac) Improve error handling + remove metrics handling part (#5)
+- [be8e2b6](https://github.com/stashed/mysql/commit/be8e2b6) Use docker buildx to build docker image
+- [3d169a2](https://github.com/stashed/mysql/commit/3d169a2) Use github.com/Azure/go-autorest/autorest@v0.7.0
+- [bd920eb](https://github.com/stashed/mysql/commit/bd920eb) Backup and Restore for MySQL-8.0.14 (#3)
+- [de01833](https://github.com/stashed/mysql/commit/de01833) Add License headers to make files (#2)
+- [cc3ee32](https://github.com/stashed/mysql/commit/cc3ee32) Reorganize repo (#1)
+- [1972a9a](https://github.com/stashed/mysql/commit/1972a9a) VolumeSnapshot (#787)
+- [3f1f4cf](https://github.com/stashed/mysql/commit/3f1f4cf) Remove importance of order of rule in RestoreSession (#795)
+- [86a4af0](https://github.com/stashed/mysql/commit/86a4af0) Skip BackupSession creation if target does not exist + use timestamp … (#797)
+- [3abe6f6](https://github.com/stashed/mysql/commit/3abe6f6) Use restic 0.9.5 (#789)
+- [85b21bf](https://github.com/stashed/mysql/commit/85b21bf) Update concept doc (#739)
+- [ad5c8f2](https://github.com/stashed/mysql/commit/ad5c8f2) Add support for backup cluster resources YAML (#721)
+- [2bb8ec3](https://github.com/stashed/mysql/commit/2bb8ec3) Backup and restore Elasticsearch (#702)
+- [1f21268](https://github.com/stashed/mysql/commit/1f21268) Update package path to stash.appscode.dev/stash (#776)
+- [e8fb571](https://github.com/stashed/mysql/commit/e8fb571) Update to k8s 1.14.0 client libraries using go.mod (#775)
+- [eab0f8e](https://github.com/stashed/mysql/commit/eab0f8e) Remove --rbac flag (#761)
+- [4c3e7ea](https://github.com/stashed/mysql/commit/4c3e7ea) Skip creating/processing backup-session when backup-config is paused (#759)
+- [7905eff](https://github.com/stashed/mysql/commit/7905eff) Stash v1beta1 E2E test for PVC (#753)
+- [2c44ee8](https://github.com/stashed/mysql/commit/2c44ee8) Implement snapshots for v1beta1 api (#749)
+- [c88df7a](https://github.com/stashed/mysql/commit/c88df7a) Run restic commands using docker (#754)
+- [8e24d32](https://github.com/stashed/mysql/commit/8e24d32) Fixed scratch-dir, output-dir and hostname in functions/tasks yamls (#744)
+- [8d5944d](https://github.com/stashed/mysql/commit/8d5944d) Add Stash CLI (#734)
+- [550ab37](https://github.com/stashed/mysql/commit/550ab37) Apply nice/ionice settings from env (#746)
+- [42ed76b](https://github.com/stashed/mysql/commit/42ed76b) Stash V1beta1 E2E test for Deployment (#710)
+- [d63f9e9](https://github.com/stashed/mysql/commit/d63f9e9) Fix openapi path prefixes for validators and mutators (#732)
+- [c1347ed](https://github.com/stashed/mysql/commit/c1347ed) Add max-connections for GCS, Azure, B2 backend (#730)
+- [859c4ee](https://github.com/stashed/mysql/commit/859c4ee) Rename admission webhooks to avoid name collision (#725)
+- [d631bb9](https://github.com/stashed/mysql/commit/d631bb9) Apply EmptyDir settings to TmpDir (#719)
+- [cc70068](https://github.com/stashed/mysql/commit/cc70068) Add support for rest backend (#713)
+- [e4db000](https://github.com/stashed/mysql/commit/e4db000) Add support for OpenShift DeploymentConfig (#714)
+- [3fa7bdb](https://github.com/stashed/mysql/commit/3fa7bdb) Backup and restore Mongo DB (#699)
+- [4c39235](https://github.com/stashed/mysql/commit/4c39235) Backup and restore MySQL DB (#696)
+- [3e89d32](https://github.com/stashed/mysql/commit/3e89d32) Backup and restore Postgres DB (#695)
+- [03b95f3](https://github.com/stashed/mysql/commit/03b95f3) Add BackupSession Controller for Sidecar (#701)
+- [cacbc7d](https://github.com/stashed/mysql/commit/cacbc7d) Update workload controller for new design (#675)
+- [5c173e5](https://github.com/stashed/mysql/commit/5c173e5)  Post backup/restore status update (#691)
+- [50bbb0a](https://github.com/stashed/mysql/commit/50bbb0a) Backup and restore PVC (#676)
+- [d4a53e2](https://github.com/stashed/mysql/commit/d4a53e2) Add BackupConfiguration Controller (#671)
+- [ef9a4ae](https://github.com/stashed/mysql/commit/ef9a4ae) Update Kubernetes client libraries to 1.13.0 (#687)
+- [c48dbfc](https://github.com/stashed/mysql/commit/c48dbfc) Separate type definitions into individual files (#646)
+- [77f2113](https://github.com/stashed/mysql/commit/77f2113) Use flags.DumpAll to dump flags (#624)
+- [cb54d8c](https://github.com/stashed/mysql/commit/cb54d8c) Set periodic analytics (#623)
+- [248a53a](https://github.com/stashed/mysql/commit/248a53a) Add validation webhook xray (#618)
+- [2029bf4](https://github.com/stashed/mysql/commit/2029bf4) Use dynamic pushgateway url (#614)
+- [bcf5926](https://github.com/stashed/mysql/commit/bcf5926) Fix offline backup (#537)
+- [5049a63](https://github.com/stashed/mysql/commit/5049a63) Fix extended apiserver issues with Kubernetes 1.11 (#536)
+- [9d31255](https://github.com/stashed/mysql/commit/9d31255) Update client-go to v8.0.0 (#528)
+- [d872b4c](https://github.com/stashed/mysql/commit/d872b4c) Enable status subresource for crds (#524)
+- [4795dba](https://github.com/stashed/mysql/commit/4795dba) Remove ops-address port (#518)
+- [e95b151](https://github.com/stashed/mysql/commit/e95b151) Add support for initial backoff to the apiserver call on recover (#476)
+- [120e5de](https://github.com/stashed/mysql/commit/120e5de) Disable admission controllers for webhook server (#468)
+- [2f19545](https://github.com/stashed/mysql/commit/2f19545) Update client-go to 7.0.0 (#463)
+- [e613ff5](https://github.com/stashed/mysql/commit/e613ff5) Fixes RBAC issue in test (#449)
+- [56a3a74](https://github.com/stashed/mysql/commit/56a3a74) Some cleanup (#446)
+- [02565bb](https://github.com/stashed/mysql/commit/02565bb) Delete restic repository from backend if Repository CRD is deleted (#438)
+- [ea98067](https://github.com/stashed/mysql/commit/ea98067) Fix go_vet error (#440)
+- [9d626eb](https://github.com/stashed/mysql/commit/9d626eb) Increase qps and burst limits (#435)
+- [5c6713f](https://github.com/stashed/mysql/commit/5c6713f) Show repository snapshot list (#417)
+- [6d8ef78](https://github.com/stashed/mysql/commit/6d8ef78) Expose swagger.json (#420)
+- [8e04ca0](https://github.com/stashed/mysql/commit/8e04ca0) Create repository crd for each Restic repository (#394)
+- [4c9a478](https://github.com/stashed/mysql/commit/4c9a478) Rename --analytics to --enable-analytics (#384)
+- [7ea2220](https://github.com/stashed/mysql/commit/7ea2220) Replace initializers with mutation webhook for workloads (#363)
+- [2770e6b](https://github.com/stashed/mysql/commit/2770e6b) Use admission hook helpers from kutil (#360)
+- [d3754d7](https://github.com/stashed/mysql/commit/d3754d7) Implement offline backup for multiple replica (#335)
+- [13a2d14](https://github.com/stashed/mysql/commit/13a2d14) Use official code generator scripts (#336)
+- [90642ce](https://github.com/stashed/mysql/commit/90642ce) Fix e2e tests after webhook merger (#333)
+- [2fc3239](https://github.com/stashed/mysql/commit/2fc3239) Leave secure port unset
+- [7cb52b2](https://github.com/stashed/mysql/commit/7cb52b2) Merge admission webhook and operator into one binary (#329)
+- [3306427](https://github.com/stashed/mysql/commit/3306427) Implement informer factory for backup scheduler (#325)
+- [7bb027b](https://github.com/stashed/mysql/commit/7bb027b) Cleanup apiserver
+- [fb8c1e4](https://github.com/stashed/mysql/commit/fb8c1e4) Copy generic-admission-server into pkg (#318)
+- [5a5093f](https://github.com/stashed/mysql/commit/5a5093f) Use shared infromer factory (#317)
+- [0ccb948](https://github.com/stashed/mysql/commit/0ccb948) Use GetBaseVersion method from kutil (#316)
+- [8c5e6ff](https://github.com/stashed/mysql/commit/8c5e6ff) Fix webhook command description (#314)
+- [775a2b6](https://github.com/stashed/mysql/commit/775a2b6) Merge webhook plugins into one. (#311)
+- [a8659fe](https://github.com/stashed/mysql/commit/a8659fe) Add ValidatingAdmissionWebhook for Stash CRDs (#299)
+- [c3e177c](https://github.com/stashed/mysql/commit/c3e177c) Added support for private docker registry (#300)
+- [62ec42e](https://github.com/stashed/mysql/commit/62ec42e) Update dependencies to Kubernetes 1.9 (#297)
+- [cf3ea7c](https://github.com/stashed/mysql/commit/cf3ea7c) Update appscode/go log wrapper (#287)
+- [470cc31](https://github.com/stashed/mysql/commit/470cc31) Pass --pushgateway-url for injected containers. (#284)
+- [e2e79c6](https://github.com/stashed/mysql/commit/e2e79c6) Fix kubectl version parsing generation in GKE (#267)
+- [326aea4](https://github.com/stashed/mysql/commit/326aea4) Detect analytics client id using env vars (#265)
+- [4a5912c](https://github.com/stashed/mysql/commit/4a5912c) Prepare docs for 0.6.0 release (#264)
+- [f75d5df](https://github.com/stashed/mysql/commit/f75d5df) Remove restic-dependency from recovery (#258)
+- [86f01f3](https://github.com/stashed/mysql/commit/86f01f3) Log operator version on start (#253)
+- [4e29b70](https://github.com/stashed/mysql/commit/4e29b70) Simplify clientID generation for analytics (#247)
+- [a45937f](https://github.com/stashed/mysql/commit/a45937f) Set analytics clientID (#246)
+- [ea53cea](https://github.com/stashed/mysql/commit/ea53cea) Enable Restic cahce-dir flag (#241)
+- [dc0030d](https://github.com/stashed/mysql/commit/dc0030d) Implement offline backup (#229)
+- [ae40f35](https://github.com/stashed/mysql/commit/ae40f35) Revendor kutil (#230)
+- [d68a34d](https://github.com/stashed/mysql/commit/d68a34d) Record recovery status for individual FileGroup (#222)
+- [15a24b7](https://github.com/stashed/mysql/commit/15a24b7) Leader election for deployment, replica set and rc (#206)
+- [4a75689](https://github.com/stashed/mysql/commit/4a75689) Implement Recovery for Restic Backup (#202)
+- [78b3942](https://github.com/stashed/mysql/commit/78b3942) Use typed versioned client for CRD
+- [b857b05](https://github.com/stashed/mysql/commit/b857b05) Change `k8s.io/api/core/v1` pkg alias to core (#204)
+- [e52f848](https://github.com/stashed/mysql/commit/e52f848) Use client-go 5.x
+- [4f376ad](https://github.com/stashed/mysql/commit/4f376ad) Set hostname based on resource type (#198)
+- [e530116](https://github.com/stashed/mysql/commit/e530116) Manage RoleBinding for rbac enabled cluster (#197)
+- [e28c13f](https://github.com/stashed/mysql/commit/e28c13f) Use workqueue for scheduler (#194)
+- [2719cbd](https://github.com/stashed/mysql/commit/2719cbd) Fix e2e tests (#183)
+- [9c1cc43](https://github.com/stashed/mysql/commit/9c1cc43) Use workqueue (#182)
+- [b3ee076](https://github.com/stashed/mysql/commit/b3ee076) Only watch apps/v1beta1 Deployment (#178)
+- [4f92ca6](https://github.com/stashed/mysql/commit/4f92ca6) Use Namespace() method from kutil.
+- [78f1e7f](https://github.com/stashed/mysql/commit/78f1e7f) Update kutil (#170)
+- [29a8a1f](https://github.com/stashed/mysql/commit/29a8a1f) Use apis/v1alpha1 instead of internal version (#167)
+- [da3eb2e](https://github.com/stashed/mysql/commit/da3eb2e) Use kubernetes/code-generator (#163)
+- [3b1d6bf](https://github.com/stashed/mysql/commit/3b1d6bf) Expose resync-period as flag
+- [35d8dc6](https://github.com/stashed/mysql/commit/35d8dc6) Move analytics collector to root command (#164)
+- [6a55694](https://github.com/stashed/mysql/commit/6a55694) Migrate TPR to CRD (#160)
+- [91f678f](https://github.com/stashed/mysql/commit/91f678f) Rename RepositorySecretName to StorageSecretName (#135)
+- [d666c81](https://github.com/stashed/mysql/commit/d666c81) Change mount path for labels to /etc/stash
+- [1177d60](https://github.com/stashed/mysql/commit/1177d60) Part 6 - Update docs (#121)
+- [a15689d](https://github.com/stashed/mysql/commit/a15689d) Various bug fixes (#118)
+- [d8a5771](https://github.com/stashed/mysql/commit/d8a5771) Set TMPDIR env var for restic (#115)
+- [60ed8f7](https://github.com/stashed/mysql/commit/60ed8f7) Update user guide (#94)
+
+
+### [8.0.3-rc.20200826](https://github.com/stashed/mysql/releases/tag/8.0.3-rc.20200826)
+
+
+
+### [8.0.14-rc.20200826](https://github.com/stashed/mysql/releases/tag/8.0.14-rc.20200826)
+
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-rc.20200826](https://github.com/stashed/percona-xtradb/releases/tag/5.7-rc.20200826)
+
+- [416d7d8](https://github.com/stashed/percona-xtradb/commit/416d7d8) Prepare for release 5.7-rc.20200826 (#52)
+- [b390913](https://github.com/stashed/percona-xtradb/commit/b390913) [cherry-pick] Update issues link (#51)
+- [10b9a66](https://github.com/stashed/percona-xtradb/commit/10b9a66) Prepare for release 5.7-beta.20200826 (#49)
+- [53f26da](https://github.com/stashed/percona-xtradb/commit/53f26da) [cherry-pick] Update Stash installation link (#47) (#48)
+- [3eae3d3](https://github.com/stashed/percona-xtradb/commit/3eae3d3) [cherry-pick] Fix output format + Add PreBackupActions logic (#43) (#46)
+- [0fa2765](https://github.com/stashed/percona-xtradb/commit/0fa2765) [cherry-pick] Make image.tag in values.yaml file as same as $APP_VERSION (#44) (#45)
+- [7ad46c0](https://github.com/stashed/percona-xtradb/commit/7ad46c0) [cherry-pick] Update chart icon (#42)
+- [97f7e6d](https://github.com/stashed/percona-xtradb/commit/97f7e6d) [cherry-pick] Make chart registry configurable (#40) (#41)
+- [7fc07cc](https://github.com/stashed/percona-xtradb/commit/7fc07cc) Prepare for release 5.7-beta.20200709 (#38)
+- [ca32b31](https://github.com/stashed/percona-xtradb/commit/ca32b31) [cherry-pick] Build docker image in release workflow (#36) (#37)
+- [efb98e4](https://github.com/stashed/percona-xtradb/commit/efb98e4) [cherry-pick] Publish to testing dir for alpha/beta releases (#32) (#35)
+- [0535469](https://github.com/stashed/percona-xtradb/commit/0535469) Prepare for release 5.7-beta.20200708 (#33)
+- [6aac98e](https://github.com/stashed/percona-xtradb/commit/6aac98e) Add commands to update chart version (#30)
+- [24431c1](https://github.com/stashed/percona-xtradb/commit/24431c1) [cherry-pick] Update update-release-tracker.sh (#29)
+- [89c2a37](https://github.com/stashed/percona-xtradb/commit/89c2a37) [cherry-pick] Update update-release-tracker.sh (#28)
+- [4163a9c](https://github.com/stashed/percona-xtradb/commit/4163a9c) [cherry-pick] Update release.yml (#27)
+- [66d54d2](https://github.com/stashed/percona-xtradb/commit/66d54d2) [cherry-pick] Add script to update release tracker on pr merge (#25) (#26)
+- [f280602](https://github.com/stashed/percona-xtradb/commit/f280602) [cherry-pick] Add workflow to cherry pick commits to master (#23) (#24)
+- [7ca441c](https://github.com/stashed/percona-xtradb/commit/7ca441c) Fix chart release process (#21)
+- [76fca67](https://github.com/stashed/percona-xtradb/commit/76fca67) Update .kodiak.toml
+- [ecbd60c](https://github.com/stashed/percona-xtradb/commit/ecbd60c) Allow overwriting secret key via SecretTransformation (#20)
+- [8404948](https://github.com/stashed/percona-xtradb/commit/8404948) Make waitTimeout configurable through flag (#19)
+- [110985a](https://github.com/stashed/percona-xtradb/commit/110985a) Create .kodiak.toml
+- [70ed4b2](https://github.com/stashed/percona-xtradb/commit/70ed4b2) Update to Kubernetes v1.18.3 (#18)
+- [75efdb9](https://github.com/stashed/percona-xtradb/commit/75efdb9) Update crazy-max/ghaction-docker-buildx flag
+- [56b5472](https://github.com/stashed/percona-xtradb/commit/56b5472) Trigger the workflow on push or pull request
+- [14e9f5a](https://github.com/stashed/percona-xtradb/commit/14e9f5a) Auto generate chart readme file
+- [31ff6c4](https://github.com/stashed/percona-xtradb/commit/31ff6c4) Correctly mark optional fields
+- [3676857](https://github.com/stashed/percona-xtradb/commit/3676857) Add openapi v3 schema for values file (#15)
+- [9b32ca9](https://github.com/stashed/percona-xtradb/commit/9b32ca9) Update CI configuration
+- [9ba20af](https://github.com/stashed/percona-xtradb/commit/9ba20af) Add support for providing s3 region (#14)
+- [2ee6c3b](https://github.com/stashed/percona-xtradb/commit/2ee6c3b) Update percona standalone backup-restore (#13)
+- [af1a30b](https://github.com/stashed/percona-xtradb/commit/af1a30b) Update PerconaXtraDB version for percona xtradb cluster (#12)
+- [7ddb43a](https://github.com/stashed/percona-xtradb/commit/7ddb43a) Make output.json file writable to all users + Fix Flag types (#11)
+- [06aa5c3](https://github.com/stashed/percona-xtradb/commit/06aa5c3) Update hugo frontmatter for stash website
+- [4171676](https://github.com/stashed/percona-xtradb/commit/4171676) Enable race detector in e2e tests
+- [9ab6f35](https://github.com/stashed/percona-xtradb/commit/9ab6f35) Added scheme field in AppBinding (#10)
+- [a4262ea](https://github.com/stashed/percona-xtradb/commit/a4262ea) Test installers (#9)
+- [72be668](https://github.com/stashed/percona-xtradb/commit/72be668) Don't build docker image for arm64
+- [2974e8b](https://github.com/stashed/percona-xtradb/commit/2974e8b) Update license file templates
+- [dd96199](https://github.com/stashed/percona-xtradb/commit/dd96199) Add license header to files (#8)
+- [93e37a6](https://github.com/stashed/percona-xtradb/commit/93e37a6) Backup and restore doc for Percona XtraDB 5.7 (#7)
+- [aafee30](https://github.com/stashed/percona-xtradb/commit/aafee30) Fix percona-xtradb backup & restore (#6)
+- [06cbe89](https://github.com/stashed/percona-xtradb/commit/06cbe89) Fix Docker image badge (#5)
+- [2e6c4c6](https://github.com/stashed/percona-xtradb/commit/2e6c4c6) Update Makefile (#4)
+- [11da7a1](https://github.com/stashed/percona-xtradb/commit/11da7a1) Add release pipeline (#3)
+- [75ca782](https://github.com/stashed/percona-xtradb/commit/75ca782) Update go.yml
+- [998acad](https://github.com/stashed/percona-xtradb/commit/998acad) Enable GitHub actions
+- [a32083a](https://github.com/stashed/percona-xtradb/commit/a32083a) Improve error handling + remove metrics handling part (#2)
+- [87b38a5](https://github.com/stashed/percona-xtradb/commit/87b38a5) Backup & Restore PerconaXtraDB using Stash (#1)
+- [a4485ab](https://github.com/stashed/percona-xtradb/commit/a4485ab) Reorganize repo
+- [1972a9a](https://github.com/stashed/percona-xtradb/commit/1972a9a) VolumeSnapshot (#787)
+- [3f1f4cf](https://github.com/stashed/percona-xtradb/commit/3f1f4cf) Remove importance of order of rule in RestoreSession (#795)
+- [86a4af0](https://github.com/stashed/percona-xtradb/commit/86a4af0) Skip BackupSession creation if target does not exist + use timestamp … (#797)
+- [3abe6f6](https://github.com/stashed/percona-xtradb/commit/3abe6f6) Use restic 0.9.5 (#789)
+- [85b21bf](https://github.com/stashed/percona-xtradb/commit/85b21bf) Update concept doc (#739)
+- [ad5c8f2](https://github.com/stashed/percona-xtradb/commit/ad5c8f2) Add support for backup cluster resources YAML (#721)
+- [2bb8ec3](https://github.com/stashed/percona-xtradb/commit/2bb8ec3) Backup and restore Elasticsearch (#702)
+- [1f21268](https://github.com/stashed/percona-xtradb/commit/1f21268) Update package path to stash.appscode.dev/stash (#776)
+- [e8fb571](https://github.com/stashed/percona-xtradb/commit/e8fb571) Update to k8s 1.14.0 client libraries using go.mod (#775)
+- [eab0f8e](https://github.com/stashed/percona-xtradb/commit/eab0f8e) Remove --rbac flag (#761)
+- [4c3e7ea](https://github.com/stashed/percona-xtradb/commit/4c3e7ea) Skip creating/processing backup-session when backup-config is paused (#759)
+- [7905eff](https://github.com/stashed/percona-xtradb/commit/7905eff) Stash v1beta1 E2E test for PVC (#753)
+- [2c44ee8](https://github.com/stashed/percona-xtradb/commit/2c44ee8) Implement snapshots for v1beta1 api (#749)
+- [c88df7a](https://github.com/stashed/percona-xtradb/commit/c88df7a) Run restic commands using docker (#754)
+- [8e24d32](https://github.com/stashed/percona-xtradb/commit/8e24d32) Fixed scratch-dir, output-dir and hostname in functions/tasks yamls (#744)
+- [8d5944d](https://github.com/stashed/percona-xtradb/commit/8d5944d) Add Stash CLI (#734)
+- [550ab37](https://github.com/stashed/percona-xtradb/commit/550ab37) Apply nice/ionice settings from env (#746)
+- [42ed76b](https://github.com/stashed/percona-xtradb/commit/42ed76b) Stash V1beta1 E2E test for Deployment (#710)
+- [d63f9e9](https://github.com/stashed/percona-xtradb/commit/d63f9e9) Fix openapi path prefixes for validators and mutators (#732)
+- [c1347ed](https://github.com/stashed/percona-xtradb/commit/c1347ed) Add max-connections for GCS, Azure, B2 backend (#730)
+- [859c4ee](https://github.com/stashed/percona-xtradb/commit/859c4ee) Rename admission webhooks to avoid name collision (#725)
+- [d631bb9](https://github.com/stashed/percona-xtradb/commit/d631bb9) Apply EmptyDir settings to TmpDir (#719)
+- [cc70068](https://github.com/stashed/percona-xtradb/commit/cc70068) Add support for rest backend (#713)
+- [e4db000](https://github.com/stashed/percona-xtradb/commit/e4db000) Add support for OpenShift DeploymentConfig (#714)
+- [3fa7bdb](https://github.com/stashed/percona-xtradb/commit/3fa7bdb) Backup and restore Mongo DB (#699)
+- [4c39235](https://github.com/stashed/percona-xtradb/commit/4c39235) Backup and restore MySQL DB (#696)
+- [3e89d32](https://github.com/stashed/percona-xtradb/commit/3e89d32) Backup and restore Postgres DB (#695)
+- [03b95f3](https://github.com/stashed/percona-xtradb/commit/03b95f3) Add BackupSession Controller for Sidecar (#701)
+- [cacbc7d](https://github.com/stashed/percona-xtradb/commit/cacbc7d) Update workload controller for new design (#675)
+- [5c173e5](https://github.com/stashed/percona-xtradb/commit/5c173e5)  Post backup/restore status update (#691)
+- [50bbb0a](https://github.com/stashed/percona-xtradb/commit/50bbb0a) Backup and restore PVC (#676)
+- [d4a53e2](https://github.com/stashed/percona-xtradb/commit/d4a53e2) Add BackupConfiguration Controller (#671)
+- [ef9a4ae](https://github.com/stashed/percona-xtradb/commit/ef9a4ae) Update Kubernetes client libraries to 1.13.0 (#687)
+- [c48dbfc](https://github.com/stashed/percona-xtradb/commit/c48dbfc) Separate type definitions into individual files (#646)
+- [77f2113](https://github.com/stashed/percona-xtradb/commit/77f2113) Use flags.DumpAll to dump flags (#624)
+- [cb54d8c](https://github.com/stashed/percona-xtradb/commit/cb54d8c) Set periodic analytics (#623)
+- [248a53a](https://github.com/stashed/percona-xtradb/commit/248a53a) Add validation webhook xray (#618)
+- [2029bf4](https://github.com/stashed/percona-xtradb/commit/2029bf4) Use dynamic pushgateway url (#614)
+- [bcf5926](https://github.com/stashed/percona-xtradb/commit/bcf5926) Fix offline backup (#537)
+- [5049a63](https://github.com/stashed/percona-xtradb/commit/5049a63) Fix extended apiserver issues with Kubernetes 1.11 (#536)
+- [9d31255](https://github.com/stashed/percona-xtradb/commit/9d31255) Update client-go to v8.0.0 (#528)
+- [d872b4c](https://github.com/stashed/percona-xtradb/commit/d872b4c) Enable status subresource for crds (#524)
+- [4795dba](https://github.com/stashed/percona-xtradb/commit/4795dba) Remove ops-address port (#518)
+- [e95b151](https://github.com/stashed/percona-xtradb/commit/e95b151) Add support for initial backoff to the apiserver call on recover (#476)
+- [120e5de](https://github.com/stashed/percona-xtradb/commit/120e5de) Disable admission controllers for webhook server (#468)
+- [2f19545](https://github.com/stashed/percona-xtradb/commit/2f19545) Update client-go to 7.0.0 (#463)
+- [e613ff5](https://github.com/stashed/percona-xtradb/commit/e613ff5) Fixes RBAC issue in test (#449)
+- [56a3a74](https://github.com/stashed/percona-xtradb/commit/56a3a74) Some cleanup (#446)
+- [02565bb](https://github.com/stashed/percona-xtradb/commit/02565bb) Delete restic repository from backend if Repository CRD is deleted (#438)
+- [ea98067](https://github.com/stashed/percona-xtradb/commit/ea98067) Fix go_vet error (#440)
+- [9d626eb](https://github.com/stashed/percona-xtradb/commit/9d626eb) Increase qps and burst limits (#435)
+- [5c6713f](https://github.com/stashed/percona-xtradb/commit/5c6713f) Show repository snapshot list (#417)
+- [6d8ef78](https://github.com/stashed/percona-xtradb/commit/6d8ef78) Expose swagger.json (#420)
+- [8e04ca0](https://github.com/stashed/percona-xtradb/commit/8e04ca0) Create repository crd for each Restic repository (#394)
+- [4c9a478](https://github.com/stashed/percona-xtradb/commit/4c9a478) Rename --analytics to --enable-analytics (#384)
+- [7ea2220](https://github.com/stashed/percona-xtradb/commit/7ea2220) Replace initializers with mutation webhook for workloads (#363)
+- [2770e6b](https://github.com/stashed/percona-xtradb/commit/2770e6b) Use admission hook helpers from kutil (#360)
+- [d3754d7](https://github.com/stashed/percona-xtradb/commit/d3754d7) Implement offline backup for multiple replica (#335)
+- [13a2d14](https://github.com/stashed/percona-xtradb/commit/13a2d14) Use official code generator scripts (#336)
+- [90642ce](https://github.com/stashed/percona-xtradb/commit/90642ce) Fix e2e tests after webhook merger (#333)
+- [2fc3239](https://github.com/stashed/percona-xtradb/commit/2fc3239) Leave secure port unset
+- [7cb52b2](https://github.com/stashed/percona-xtradb/commit/7cb52b2) Merge admission webhook and operator into one binary (#329)
+- [3306427](https://github.com/stashed/percona-xtradb/commit/3306427) Implement informer factory for backup scheduler (#325)
+- [7bb027b](https://github.com/stashed/percona-xtradb/commit/7bb027b) Cleanup apiserver
+- [fb8c1e4](https://github.com/stashed/percona-xtradb/commit/fb8c1e4) Copy generic-admission-server into pkg (#318)
+- [5a5093f](https://github.com/stashed/percona-xtradb/commit/5a5093f) Use shared infromer factory (#317)
+- [0ccb948](https://github.com/stashed/percona-xtradb/commit/0ccb948) Use GetBaseVersion method from kutil (#316)
+- [8c5e6ff](https://github.com/stashed/percona-xtradb/commit/8c5e6ff) Fix webhook command description (#314)
+- [775a2b6](https://github.com/stashed/percona-xtradb/commit/775a2b6) Merge webhook plugins into one. (#311)
+- [a8659fe](https://github.com/stashed/percona-xtradb/commit/a8659fe) Add ValidatingAdmissionWebhook for Stash CRDs (#299)
+- [c3e177c](https://github.com/stashed/percona-xtradb/commit/c3e177c) Added support for private docker registry (#300)
+- [62ec42e](https://github.com/stashed/percona-xtradb/commit/62ec42e) Update dependencies to Kubernetes 1.9 (#297)
+- [cf3ea7c](https://github.com/stashed/percona-xtradb/commit/cf3ea7c) Update appscode/go log wrapper (#287)
+- [470cc31](https://github.com/stashed/percona-xtradb/commit/470cc31) Pass --pushgateway-url for injected containers. (#284)
+- [e2e79c6](https://github.com/stashed/percona-xtradb/commit/e2e79c6) Fix kubectl version parsing generation in GKE (#267)
+- [326aea4](https://github.com/stashed/percona-xtradb/commit/326aea4) Detect analytics client id using env vars (#265)
+- [4a5912c](https://github.com/stashed/percona-xtradb/commit/4a5912c) Prepare docs for 0.6.0 release (#264)
+- [f75d5df](https://github.com/stashed/percona-xtradb/commit/f75d5df) Remove restic-dependency from recovery (#258)
+- [86f01f3](https://github.com/stashed/percona-xtradb/commit/86f01f3) Log operator version on start (#253)
+- [4e29b70](https://github.com/stashed/percona-xtradb/commit/4e29b70) Simplify clientID generation for analytics (#247)
+- [a45937f](https://github.com/stashed/percona-xtradb/commit/a45937f) Set analytics clientID (#246)
+- [ea53cea](https://github.com/stashed/percona-xtradb/commit/ea53cea) Enable Restic cahce-dir flag (#241)
+- [dc0030d](https://github.com/stashed/percona-xtradb/commit/dc0030d) Implement offline backup (#229)
+- [ae40f35](https://github.com/stashed/percona-xtradb/commit/ae40f35) Revendor kutil (#230)
+- [d68a34d](https://github.com/stashed/percona-xtradb/commit/d68a34d) Record recovery status for individual FileGroup (#222)
+- [15a24b7](https://github.com/stashed/percona-xtradb/commit/15a24b7) Leader election for deployment, replica set and rc (#206)
+- [4a75689](https://github.com/stashed/percona-xtradb/commit/4a75689) Implement Recovery for Restic Backup (#202)
+- [78b3942](https://github.com/stashed/percona-xtradb/commit/78b3942) Use typed versioned client for CRD
+- [b857b05](https://github.com/stashed/percona-xtradb/commit/b857b05) Change `k8s.io/api/core/v1` pkg alias to core (#204)
+- [e52f848](https://github.com/stashed/percona-xtradb/commit/e52f848) Use client-go 5.x
+- [4f376ad](https://github.com/stashed/percona-xtradb/commit/4f376ad) Set hostname based on resource type (#198)
+- [e530116](https://github.com/stashed/percona-xtradb/commit/e530116) Manage RoleBinding for rbac enabled cluster (#197)
+- [e28c13f](https://github.com/stashed/percona-xtradb/commit/e28c13f) Use workqueue for scheduler (#194)
+- [2719cbd](https://github.com/stashed/percona-xtradb/commit/2719cbd) Fix e2e tests (#183)
+- [9c1cc43](https://github.com/stashed/percona-xtradb/commit/9c1cc43) Use workqueue (#182)
+- [b3ee076](https://github.com/stashed/percona-xtradb/commit/b3ee076) Only watch apps/v1beta1 Deployment (#178)
+- [4f92ca6](https://github.com/stashed/percona-xtradb/commit/4f92ca6) Use Namespace() method from kutil.
+- [78f1e7f](https://github.com/stashed/percona-xtradb/commit/78f1e7f) Update kutil (#170)
+- [29a8a1f](https://github.com/stashed/percona-xtradb/commit/29a8a1f) Use apis/v1alpha1 instead of internal version (#167)
+- [da3eb2e](https://github.com/stashed/percona-xtradb/commit/da3eb2e) Use kubernetes/code-generator (#163)
+- [3b1d6bf](https://github.com/stashed/percona-xtradb/commit/3b1d6bf) Expose resync-period as flag
+- [35d8dc6](https://github.com/stashed/percona-xtradb/commit/35d8dc6) Move analytics collector to root command (#164)
+- [6a55694](https://github.com/stashed/percona-xtradb/commit/6a55694) Migrate TPR to CRD (#160)
+- [91f678f](https://github.com/stashed/percona-xtradb/commit/91f678f) Rename RepositorySecretName to StorageSecretName (#135)
+- [d666c81](https://github.com/stashed/percona-xtradb/commit/d666c81) Change mount path for labels to /etc/stash
+- [1177d60](https://github.com/stashed/percona-xtradb/commit/1177d60) Part 6 - Update docs (#121)
+- [a15689d](https://github.com/stashed/percona-xtradb/commit/a15689d) Various bug fixes (#118)
+- [d8a5771](https://github.com/stashed/percona-xtradb/commit/d8a5771) Set TMPDIR env var for restic (#115)
+- [60ed8f7](https://github.com/stashed/percona-xtradb/commit/60ed8f7) Update user guide (#94)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6-rc.20200826](https://github.com/stashed/postgres/releases/tag/9.6-rc.20200826)
+
+- [5715456](https://github.com/stashed/postgres/commit/5715456) Prepare for release 9.6-rc.20200826 (#152)
+- [0442f99](https://github.com/stashed/postgres/commit/0442f99) [cherry-pick] Update README.md (#147)
+- [61c4425](https://github.com/stashed/postgres/commit/61c4425) Prepare for release 9.6-beta.20200826 (#141)
+- [b313c2c](https://github.com/stashed/postgres/commit/b313c2c) Update Stash installation link (#131) (#136)
+- [d73595e](https://github.com/stashed/postgres/commit/d73595e) [cherry-pick] Update twitter handle (#125) (#130)
+- [875edd5](https://github.com/stashed/postgres/commit/875edd5) [cherry-pick] Use image tag same as the $APP_VERSION (#114) (#124)
+- [5a9a784](https://github.com/stashed/postgres/commit/5a9a784) [cherry-pick] Fix output format + Add PreBackupActions logic (#113) (#119)
+- [ce47f3a](https://github.com/stashed/postgres/commit/ce47f3a) [cherry-pick] Update chart icon (#112)
+- [decfbb0](https://github.com/stashed/postgres/commit/decfbb0) [cherry-pick] Make chart registry configurable (#102) (#107)
+- [5befa82](https://github.com/stashed/postgres/commit/5befa82) Prepare for release 9.6-beta.20200709 (#100)
+- [52fab57](https://github.com/stashed/postgres/commit/52fab57) [cherry-pick] Build docker images in release workflow (#90) (#95)
+- [d85fc80](https://github.com/stashed/postgres/commit/d85fc80) Prepare for release 9.6-beta.20200708 (#88)
+- [fbd6766](https://github.com/stashed/postgres/commit/fbd6766) [cherry-pick] Publish to testing dir for alpha/beta releases (#78) (#83)
+- [1b32879](https://github.com/stashed/postgres/commit/1b32879) [cherry-pick] Update License (#72) (#77)
+- [388ddee](https://github.com/stashed/postgres/commit/388ddee) Add commands to update chart version (#71)
+- [875c1f0](https://github.com/stashed/postgres/commit/875c1f0) [cherry-pick] Update update-release-tracker.sh (#70)
+- [0e71e2d](https://github.com/stashed/postgres/commit/0e71e2d) [cherry-pick] Update update-release-tracker.sh (#65)
+- [bbfac61](https://github.com/stashed/postgres/commit/bbfac61) [cherry-pick] Update release.yml (#55) (#60)
+- [986d0a7](https://github.com/stashed/postgres/commit/986d0a7) [cherry-pick] Add script to update release tracker on pr merge (#49) (#54)
+- [6edaf36](https://github.com/stashed/postgres/commit/6edaf36) [cherry-pick] Remove /cherry-pick from cherry picked prs (#43) (#48)
+- [6743dbe](https://github.com/stashed/postgres/commit/6743dbe) [cherry-pick] Add workflow to cherry pick commits to master (#37) (#42)
+- [fb4f222](https://github.com/stashed/postgres/commit/fb4f222) Fix chart release process (#36)
+- [b5ddf5f](https://github.com/stashed/postgres/commit/b5ddf5f) Update .kodiak.toml
+- [7951787](https://github.com/stashed/postgres/commit/7951787) Fix waitForDBReady() logic + Make timeout configurable (#35)
+- [e7bb18f](https://github.com/stashed/postgres/commit/e7bb18f) Create .kodiak.toml
+- [60acc09](https://github.com/stashed/postgres/commit/60acc09) Merge pull request Allow overriding secret keys from AppBinding #33
+- [aaff7fb](https://github.com/stashed/postgres/commit/aaff7fb) Fix typos (#32)
+- [568f584](https://github.com/stashed/postgres/commit/568f584) Update to Kubernetes v1.18.3 (#34)
+- [098bb78](https://github.com/stashed/postgres/commit/098bb78) Update crazy-max/ghaction-docker-buildx flag
+- [4385362](https://github.com/stashed/postgres/commit/4385362) function-args: add pg-back-cmd option
+- [7cd065c](https://github.com/stashed/postgres/commit/7cd065c) Trigger the workflow on push or pull request
+- [b63e3e5](https://github.com/stashed/postgres/commit/b63e3e5) Auto generate chart readme file
+- [dea1a41](https://github.com/stashed/postgres/commit/dea1a41) Correctly mark optional fields
+- [efc4283](https://github.com/stashed/postgres/commit/efc4283) Add openapi v3 schema for values file (#27)
+- [99a417e](https://github.com/stashed/postgres/commit/99a417e) Update CI configuration
+- [712aabb](https://github.com/stashed/postgres/commit/712aabb) Add support for providing s3 region (#26)
+- [111a3fe](https://github.com/stashed/postgres/commit/111a3fe) Make output.json file writable to all users + Fix Flag types (#25)
+- [1694bb7](https://github.com/stashed/postgres/commit/1694bb7) Update hugo frontmatter for stash website
+- [ab592bd](https://github.com/stashed/postgres/commit/ab592bd) Enable race detector in e2e tests
+- [6df8761](https://github.com/stashed/postgres/commit/6df8761) Fixed broken link, Added AppBinding scheme field (#24)
+- [e3f4905](https://github.com/stashed/postgres/commit/e3f4905) Test installers (#23)
+- [a3c2d0f](https://github.com/stashed/postgres/commit/a3c2d0f) Add license header to files (#22)
+- [320def8](https://github.com/stashed/postgres/commit/320def8) Enable make ci (#21)
+- [9a7b843](https://github.com/stashed/postgres/commit/9a7b843) Fix BackupSession's Print Columns (#20)
+- [73d7b1c](https://github.com/stashed/postgres/commit/73d7b1c) Enable make ci (#19)
+- [46d5ae8](https://github.com/stashed/postgres/commit/46d5ae8) Remove --enable-status-subresource flag (#18)
+- [08067ca](https://github.com/stashed/postgres/commit/08067ca) Fix arguments passing (#17)
+- [0c1db21](https://github.com/stashed/postgres/commit/0c1db21) Add release pipeline (#16)
+- [3d33fd4](https://github.com/stashed/postgres/commit/3d33fd4) adjust frontmatter weight
+- [41e3555](https://github.com/stashed/postgres/commit/41e3555) Update resources for 9.6
+- [775ffab](https://github.com/stashed/postgres/commit/775ffab) Update go.yml
+- [67cb695](https://github.com/stashed/postgres/commit/67cb695) Fix BackupConfiguration retention policy (#11)
+- [9228437](https://github.com/stashed/postgres/commit/9228437) Fix link + grammar (#10)
+- [bddb9cd](https://github.com/stashed/postgres/commit/bddb9cd) Enable GitHub actions
+- [f42ada5](https://github.com/stashed/postgres/commit/f42ada5) Fix menu id in frontmatter
+- [a59bed1](https://github.com/stashed/postgres/commit/a59bed1) Finalize doc template (#9)
+- [08274c9](https://github.com/stashed/postgres/commit/08274c9) Fix typo (#8)
+- [afad5db](https://github.com/stashed/postgres/commit/afad5db) Refactor error + metric handling (#7)
+- [248d0ea](https://github.com/stashed/postgres/commit/248d0ea) Use Endpoint for REST server URL (remove --rest-server-url flag) (#6)
+- [41d2a53](https://github.com/stashed/postgres/commit/41d2a53) Remove metrics options from function (#5)
+- [d276da0](https://github.com/stashed/postgres/commit/d276da0) Use docker buildx to build docker image
+- [3c0e71d](https://github.com/stashed/postgres/commit/3c0e71d) Use github.com/Azure/go-autorest/autorest@v0.7.0
+- [5eab8f5](https://github.com/stashed/postgres/commit/5eab8f5) Update postgres.md
+- [0f37446](https://github.com/stashed/postgres/commit/0f37446) Rename Functions and Tasks (#4)
+- [b1b3e80](https://github.com/stashed/postgres/commit/b1b3e80) Update Chart.yaml
+- [a1bee9b](https://github.com/stashed/postgres/commit/a1bee9b) Update README.md
+- [904549a](https://github.com/stashed/postgres/commit/904549a) Update postgres.md
+- [1c99280](https://github.com/stashed/postgres/commit/1c99280) Add Chart and documentation (#2)
+- [0238497](https://github.com/stashed/postgres/commit/0238497) Add ca-certificates package in Docker image (#3)
+- [b0e6b2b](https://github.com/stashed/postgres/commit/b0e6b2b) Reorganize repo (#1)
+- [1972a9a](https://github.com/stashed/postgres/commit/1972a9a) VolumeSnapshot (#787)
+- [3f1f4cf](https://github.com/stashed/postgres/commit/3f1f4cf) Remove importance of order of rule in RestoreSession (#795)
+- [86a4af0](https://github.com/stashed/postgres/commit/86a4af0) Skip BackupSession creation if target does not exist + use timestamp … (#797)
+- [3abe6f6](https://github.com/stashed/postgres/commit/3abe6f6) Use restic 0.9.5 (#789)
+- [85b21bf](https://github.com/stashed/postgres/commit/85b21bf) Update concept doc (#739)
+- [ad5c8f2](https://github.com/stashed/postgres/commit/ad5c8f2) Add support for backup cluster resources YAML (#721)
+- [2bb8ec3](https://github.com/stashed/postgres/commit/2bb8ec3) Backup and restore Elasticsearch (#702)
+- [1f21268](https://github.com/stashed/postgres/commit/1f21268) Update package path to stash.appscode.dev/stash (#776)
+- [e8fb571](https://github.com/stashed/postgres/commit/e8fb571) Update to k8s 1.14.0 client libraries using go.mod (#775)
+- [eab0f8e](https://github.com/stashed/postgres/commit/eab0f8e) Remove --rbac flag (#761)
+- [4c3e7ea](https://github.com/stashed/postgres/commit/4c3e7ea) Skip creating/processing backup-session when backup-config is paused (#759)
+- [7905eff](https://github.com/stashed/postgres/commit/7905eff) Stash v1beta1 E2E test for PVC (#753)
+- [2c44ee8](https://github.com/stashed/postgres/commit/2c44ee8) Implement snapshots for v1beta1 api (#749)
+- [c88df7a](https://github.com/stashed/postgres/commit/c88df7a) Run restic commands using docker (#754)
+- [8e24d32](https://github.com/stashed/postgres/commit/8e24d32) Fixed scratch-dir, output-dir and hostname in functions/tasks yamls (#744)
+- [8d5944d](https://github.com/stashed/postgres/commit/8d5944d) Add Stash CLI (#734)
+- [550ab37](https://github.com/stashed/postgres/commit/550ab37) Apply nice/ionice settings from env (#746)
+- [42ed76b](https://github.com/stashed/postgres/commit/42ed76b) Stash V1beta1 E2E test for Deployment (#710)
+- [d63f9e9](https://github.com/stashed/postgres/commit/d63f9e9) Fix openapi path prefixes for validators and mutators (#732)
+- [c1347ed](https://github.com/stashed/postgres/commit/c1347ed) Add max-connections for GCS, Azure, B2 backend (#730)
+- [859c4ee](https://github.com/stashed/postgres/commit/859c4ee) Rename admission webhooks to avoid name collision (#725)
+- [d631bb9](https://github.com/stashed/postgres/commit/d631bb9) Apply EmptyDir settings to TmpDir (#719)
+- [cc70068](https://github.com/stashed/postgres/commit/cc70068) Add support for rest backend (#713)
+- [e4db000](https://github.com/stashed/postgres/commit/e4db000) Add support for OpenShift DeploymentConfig (#714)
+- [3fa7bdb](https://github.com/stashed/postgres/commit/3fa7bdb) Backup and restore Mongo DB (#699)
+- [4c39235](https://github.com/stashed/postgres/commit/4c39235) Backup and restore MySQL DB (#696)
+- [3e89d32](https://github.com/stashed/postgres/commit/3e89d32) Backup and restore Postgres DB (#695)
+- [03b95f3](https://github.com/stashed/postgres/commit/03b95f3) Add BackupSession Controller for Sidecar (#701)
+- [cacbc7d](https://github.com/stashed/postgres/commit/cacbc7d) Update workload controller for new design (#675)
+- [5c173e5](https://github.com/stashed/postgres/commit/5c173e5)  Post backup/restore status update (#691)
+- [50bbb0a](https://github.com/stashed/postgres/commit/50bbb0a) Backup and restore PVC (#676)
+- [d4a53e2](https://github.com/stashed/postgres/commit/d4a53e2) Add BackupConfiguration Controller (#671)
+- [ef9a4ae](https://github.com/stashed/postgres/commit/ef9a4ae) Update Kubernetes client libraries to 1.13.0 (#687)
+- [c48dbfc](https://github.com/stashed/postgres/commit/c48dbfc) Separate type definitions into individual files (#646)
+- [77f2113](https://github.com/stashed/postgres/commit/77f2113) Use flags.DumpAll to dump flags (#624)
+- [cb54d8c](https://github.com/stashed/postgres/commit/cb54d8c) Set periodic analytics (#623)
+- [248a53a](https://github.com/stashed/postgres/commit/248a53a) Add validation webhook xray (#618)
+- [2029bf4](https://github.com/stashed/postgres/commit/2029bf4) Use dynamic pushgateway url (#614)
+- [bcf5926](https://github.com/stashed/postgres/commit/bcf5926) Fix offline backup (#537)
+- [5049a63](https://github.com/stashed/postgres/commit/5049a63) Fix extended apiserver issues with Kubernetes 1.11 (#536)
+- [9d31255](https://github.com/stashed/postgres/commit/9d31255) Update client-go to v8.0.0 (#528)
+- [d872b4c](https://github.com/stashed/postgres/commit/d872b4c) Enable status subresource for crds (#524)
+- [4795dba](https://github.com/stashed/postgres/commit/4795dba) Remove ops-address port (#518)
+- [e95b151](https://github.com/stashed/postgres/commit/e95b151) Add support for initial backoff to the apiserver call on recover (#476)
+- [120e5de](https://github.com/stashed/postgres/commit/120e5de) Disable admission controllers for webhook server (#468)
+- [2f19545](https://github.com/stashed/postgres/commit/2f19545) Update client-go to 7.0.0 (#463)
+- [e613ff5](https://github.com/stashed/postgres/commit/e613ff5) Fixes RBAC issue in test (#449)
+- [56a3a74](https://github.com/stashed/postgres/commit/56a3a74) Some cleanup (#446)
+- [02565bb](https://github.com/stashed/postgres/commit/02565bb) Delete restic repository from backend if Repository CRD is deleted (#438)
+- [ea98067](https://github.com/stashed/postgres/commit/ea98067) Fix go_vet error (#440)
+- [9d626eb](https://github.com/stashed/postgres/commit/9d626eb) Increase qps and burst limits (#435)
+- [5c6713f](https://github.com/stashed/postgres/commit/5c6713f) Show repository snapshot list (#417)
+- [6d8ef78](https://github.com/stashed/postgres/commit/6d8ef78) Expose swagger.json (#420)
+- [8e04ca0](https://github.com/stashed/postgres/commit/8e04ca0) Create repository crd for each Restic repository (#394)
+- [4c9a478](https://github.com/stashed/postgres/commit/4c9a478) Rename --analytics to --enable-analytics (#384)
+- [7ea2220](https://github.com/stashed/postgres/commit/7ea2220) Replace initializers with mutation webhook for workloads (#363)
+- [2770e6b](https://github.com/stashed/postgres/commit/2770e6b) Use admission hook helpers from kutil (#360)
+- [d3754d7](https://github.com/stashed/postgres/commit/d3754d7) Implement offline backup for multiple replica (#335)
+- [13a2d14](https://github.com/stashed/postgres/commit/13a2d14) Use official code generator scripts (#336)
+- [90642ce](https://github.com/stashed/postgres/commit/90642ce) Fix e2e tests after webhook merger (#333)
+- [2fc3239](https://github.com/stashed/postgres/commit/2fc3239) Leave secure port unset
+- [7cb52b2](https://github.com/stashed/postgres/commit/7cb52b2) Merge admission webhook and operator into one binary (#329)
+- [3306427](https://github.com/stashed/postgres/commit/3306427) Implement informer factory for backup scheduler (#325)
+- [7bb027b](https://github.com/stashed/postgres/commit/7bb027b) Cleanup apiserver
+- [fb8c1e4](https://github.com/stashed/postgres/commit/fb8c1e4) Copy generic-admission-server into pkg (#318)
+- [5a5093f](https://github.com/stashed/postgres/commit/5a5093f) Use shared infromer factory (#317)
+- [0ccb948](https://github.com/stashed/postgres/commit/0ccb948) Use GetBaseVersion method from kutil (#316)
+- [8c5e6ff](https://github.com/stashed/postgres/commit/8c5e6ff) Fix webhook command description (#314)
+- [775a2b6](https://github.com/stashed/postgres/commit/775a2b6) Merge webhook plugins into one. (#311)
+- [a8659fe](https://github.com/stashed/postgres/commit/a8659fe) Add ValidatingAdmissionWebhook for Stash CRDs (#299)
+- [c3e177c](https://github.com/stashed/postgres/commit/c3e177c) Added support for private docker registry (#300)
+- [62ec42e](https://github.com/stashed/postgres/commit/62ec42e) Update dependencies to Kubernetes 1.9 (#297)
+- [cf3ea7c](https://github.com/stashed/postgres/commit/cf3ea7c) Update appscode/go log wrapper (#287)
+- [470cc31](https://github.com/stashed/postgres/commit/470cc31) Pass --pushgateway-url for injected containers. (#284)
+- [e2e79c6](https://github.com/stashed/postgres/commit/e2e79c6) Fix kubectl version parsing generation in GKE (#267)
+- [326aea4](https://github.com/stashed/postgres/commit/326aea4) Detect analytics client id using env vars (#265)
+- [4a5912c](https://github.com/stashed/postgres/commit/4a5912c) Prepare docs for 0.6.0 release (#264)
+- [f75d5df](https://github.com/stashed/postgres/commit/f75d5df) Remove restic-dependency from recovery (#258)
+- [86f01f3](https://github.com/stashed/postgres/commit/86f01f3) Log operator version on start (#253)
+- [4e29b70](https://github.com/stashed/postgres/commit/4e29b70) Simplify clientID generation for analytics (#247)
+- [a45937f](https://github.com/stashed/postgres/commit/a45937f) Set analytics clientID (#246)
+- [ea53cea](https://github.com/stashed/postgres/commit/ea53cea) Enable Restic cahce-dir flag (#241)
+- [dc0030d](https://github.com/stashed/postgres/commit/dc0030d) Implement offline backup (#229)
+- [ae40f35](https://github.com/stashed/postgres/commit/ae40f35) Revendor kutil (#230)
+- [d68a34d](https://github.com/stashed/postgres/commit/d68a34d) Record recovery status for individual FileGroup (#222)
+- [15a24b7](https://github.com/stashed/postgres/commit/15a24b7) Leader election for deployment, replica set and rc (#206)
+- [4a75689](https://github.com/stashed/postgres/commit/4a75689) Implement Recovery for Restic Backup (#202)
+- [78b3942](https://github.com/stashed/postgres/commit/78b3942) Use typed versioned client for CRD
+- [b857b05](https://github.com/stashed/postgres/commit/b857b05) Change `k8s.io/api/core/v1` pkg alias to core (#204)
+- [e52f848](https://github.com/stashed/postgres/commit/e52f848) Use client-go 5.x
+- [4f376ad](https://github.com/stashed/postgres/commit/4f376ad) Set hostname based on resource type (#198)
+- [e530116](https://github.com/stashed/postgres/commit/e530116) Manage RoleBinding for rbac enabled cluster (#197)
+- [e28c13f](https://github.com/stashed/postgres/commit/e28c13f) Use workqueue for scheduler (#194)
+- [2719cbd](https://github.com/stashed/postgres/commit/2719cbd) Fix e2e tests (#183)
+- [9c1cc43](https://github.com/stashed/postgres/commit/9c1cc43) Use workqueue (#182)
+- [b3ee076](https://github.com/stashed/postgres/commit/b3ee076) Only watch apps/v1beta1 Deployment (#178)
+- [4f92ca6](https://github.com/stashed/postgres/commit/4f92ca6) Use Namespace() method from kutil.
+- [78f1e7f](https://github.com/stashed/postgres/commit/78f1e7f) Update kutil (#170)
+- [29a8a1f](https://github.com/stashed/postgres/commit/29a8a1f) Use apis/v1alpha1 instead of internal version (#167)
+- [da3eb2e](https://github.com/stashed/postgres/commit/da3eb2e) Use kubernetes/code-generator (#163)
+- [3b1d6bf](https://github.com/stashed/postgres/commit/3b1d6bf) Expose resync-period as flag
+- [35d8dc6](https://github.com/stashed/postgres/commit/35d8dc6) Move analytics collector to root command (#164)
+- [6a55694](https://github.com/stashed/postgres/commit/6a55694) Migrate TPR to CRD (#160)
+- [91f678f](https://github.com/stashed/postgres/commit/91f678f) Rename RepositorySecretName to StorageSecretName (#135)
+- [d666c81](https://github.com/stashed/postgres/commit/d666c81) Change mount path for labels to /etc/stash
+- [1177d60](https://github.com/stashed/postgres/commit/1177d60) Part 6 - Update docs (#121)
+- [a15689d](https://github.com/stashed/postgres/commit/a15689d) Various bug fixes (#118)
+- [d8a5771](https://github.com/stashed/postgres/commit/d8a5771) Set TMPDIR env var for restic (#115)
+- [60ed8f7](https://github.com/stashed/postgres/commit/60ed8f7) Update user guide (#94)
+
+
+### [10.2-rc.20200826](https://github.com/stashed/postgres/releases/tag/10.2-rc.20200826)
+
+
+
+### [10.6-rc.20200826](https://github.com/stashed/postgres/releases/tag/10.6-rc.20200826)
+
+
+
+### [11.1-rc.20200826](https://github.com/stashed/postgres/releases/tag/11.1-rc.20200826)
+
+
+
+### [11.2-rc.20200826](https://github.com/stashed/postgres/releases/tag/11.2-rc.20200826)
+
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.10.0-rc.1](https://github.com/stashed/stash/releases/tag/v0.10.0-rc.1)
+
+- [20d585f4](https://github.com/stashed/stash/commit/20d585f4) Prepare for release v0.10.0-rc.1 (#1180)
+- [76fe3ebd](https://github.com/stashed/stash/commit/76fe3ebd) Create GitHub release from release workflow
+- [f3e5cccc](https://github.com/stashed/stash/commit/f3e5cccc) Fix installation link
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.08.26-rc.1
Release-tracker: https://github.com/stashed/CHANGELOG/pull/5
Signed-off-by: 1gtm <1gtm@appscode.com>