### PR TITLE
Prepare for release v2020.08.27-rc.0

### DIFF
--- a/docs/CHANGELOG-v2020.08.27-rc.0.md
+++ b/docs/CHANGELOG-v2020.08.27-rc.0.md
@@ -1,0 +1,253 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.08.27-rc.0
+    name: Changelog-v2020.08.27-rc.0
+    parent: welcome
+    weight: 20200827
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.08.27-rc.0/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.08.27-rc.0/
+---
+
+# Stash v2020.08.27-rc.0 (2020-08-27)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.10.0-rc.2](https://github.com/appscode/stash-enterprise/releases/tag/v0.10.0-rc.2)
+
+- [be8d7f35](https://github.com/appscode/stash-enterprise/commit/be8d7f35) Prepare for release v0.10.0-rc.2 (#20)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.10.0-rc.2](https://github.com/stashed/apimachinery/releases/tag/v0.10.0-rc.2)
+
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.08.27-rc.0](https://github.com/stashed/catalog/releases/tag/v2020.08.27-rc.0)
+
+- [131d570](https://github.com/stashed/catalog/commit/131d570) Prepare for release v2020.08.27-rc.0 (#35)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.10.0-rc.2](https://github.com/stashed/cli/releases/tag/v0.10.0-rc.2)
+
+- [bcff194](https://github.com/stashed/cli/commit/bcff194) Prepare for release v0.10.0-rc.2 (#40)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-rc.20200827)
+
+- [51262cc](https://github.com/stashed/elasticsearch/commit/51262cc) Prepare for release 5.6.4-rc.20200827 (#192)
+- [bcba1e7](https://github.com/stashed/elasticsearch/commit/bcba1e7) [cherry-pick] Upload charts without updating index (#184)
+
+
+### [6.2.4-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-rc.20200827)
+
+- [00cc0e7](https://github.com/stashed/elasticsearch/commit/00cc0e7) Prepare for release 6.2.4-rc.20200827 (#193)
+- [54bab71](https://github.com/stashed/elasticsearch/commit/54bab71) [cherry-pick] Upload charts without updating index (#185)
+
+
+### [6.3.0-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-rc.20200827)
+
+- [4bf05ac](https://github.com/stashed/elasticsearch/commit/4bf05ac) Prepare for release 6.3.0-rc.20200827 (#194)
+- [16053f8](https://github.com/stashed/elasticsearch/commit/16053f8) [cherry-pick] Upload charts without updating index (#186)
+
+
+### [6.4.0-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-rc.20200827)
+
+- [c37a5b5](https://github.com/stashed/elasticsearch/commit/c37a5b5) Prepare for release 6.4.0-rc.20200827 (#195)
+- [6a44a65](https://github.com/stashed/elasticsearch/commit/6a44a65) [cherry-pick] Upload charts without updating index (#187)
+
+
+### [6.5.3-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-rc.20200827)
+
+- [68b5356](https://github.com/stashed/elasticsearch/commit/68b5356) Prepare for release 6.5.3-rc.20200827 (#196)
+- [babe6ed](https://github.com/stashed/elasticsearch/commit/babe6ed) [cherry-pick] Upload charts without updating index (#188)
+
+
+### [6.8.0-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-rc.20200827)
+
+- [74bcf84](https://github.com/stashed/elasticsearch/commit/74bcf84) Prepare for release 6.8.0-rc.20200827 (#197)
+- [a836713](https://github.com/stashed/elasticsearch/commit/a836713) [cherry-pick] Upload charts without updating index (#189)
+
+
+### [7.2.0-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-rc.20200827)
+
+- [036e850](https://github.com/stashed/elasticsearch/commit/036e850) Prepare for release 7.2.0-rc.20200827 (#198)
+- [54fd94d](https://github.com/stashed/elasticsearch/commit/54fd94d) [cherry-pick] Upload charts without updating index (#190)
+
+
+### [7.3.2-rc.20200827](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-rc.20200827)
+
+- [c6f8b5d](https://github.com/stashed/elasticsearch/commit/c6f8b5d) Prepare for release 7.3.2-rc.20200827 (#199)
+- [0f8ba19](https://github.com/stashed/elasticsearch/commit/0f8ba19) [cherry-pick] Upload charts without updating index (#191)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.10.0-rc.2](https://github.com/stashed/installer/releases/tag/v0.10.0-rc.2)
+
+- [7d5e440](https://github.com/stashed/installer/commit/7d5e440) Prepare for release v0.10.0-rc.2 (#92)
+- [f4cae9f](https://github.com/stashed/installer/commit/f4cae9f) Upload charts without updating index
+- [90d9c52](https://github.com/stashed/installer/commit/90d9c52) Update Kubernetes v1.18.3 dependencies (#91)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.1-rc.20200827](https://github.com/stashed/mongodb/releases/tag/3.4.1-rc.20200827)
+
+- [9890353](https://github.com/stashed/mongodb/commit/9890353) Prepare for release 3.4.1-rc.20200827 (#231)
+- [d941a98](https://github.com/stashed/mongodb/commit/d941a98) [cherry-pick] Upload charts without updating index (#220)
+
+
+### [3.4.2-rc.20200827](https://github.com/stashed/mongodb/releases/tag/3.4.2-rc.20200827)
+
+- [fe63b2a](https://github.com/stashed/mongodb/commit/fe63b2a) Prepare for release 3.4.2-rc.20200827 (#232)
+- [80c8ad0](https://github.com/stashed/mongodb/commit/80c8ad0) [cherry-pick] Upload charts without updating index (#221)
+
+
+### [3.6.1-rc.20200827](https://github.com/stashed/mongodb/releases/tag/3.6.1-rc.20200827)
+
+- [c3b738a](https://github.com/stashed/mongodb/commit/c3b738a) Prepare for release 3.6.1-rc.20200827 (#233)
+- [451d4c9](https://github.com/stashed/mongodb/commit/451d4c9) [cherry-pick] Upload charts without updating index (#222)
+
+
+### [3.6.8-rc.20200827](https://github.com/stashed/mongodb/releases/tag/3.6.8-rc.20200827)
+
+- [fae0fa3](https://github.com/stashed/mongodb/commit/fae0fa3) Prepare for release 3.6.8-rc.20200827 (#234)
+- [59da835](https://github.com/stashed/mongodb/commit/59da835) [cherry-pick] Upload charts without updating index (#223)
+
+
+### [4.0.3-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.0.3-rc.20200827)
+
+- [e6669a9](https://github.com/stashed/mongodb/commit/e6669a9) Prepare for release 4.0.3-rc.20200827 (#236)
+- [7a1efc6](https://github.com/stashed/mongodb/commit/7a1efc6) [cherry-pick] Upload charts without updating index (#225)
+
+
+### [4.0.5-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.0.5-rc.20200827)
+
+- [8bded32](https://github.com/stashed/mongodb/commit/8bded32) Prepare for release 4.0.5-rc.20200827 (#237)
+- [58fa99e](https://github.com/stashed/mongodb/commit/58fa99e) [cherry-pick] Upload charts without updating index (#226)
+
+
+### [4.0.11-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.0.11-rc.20200827)
+
+- [2dfe220](https://github.com/stashed/mongodb/commit/2dfe220) Prepare for release 4.0.11-rc.20200827 (#235)
+- [7ccf88d](https://github.com/stashed/mongodb/commit/7ccf88d) [cherry-pick] Upload charts without updating index (#224)
+
+
+### [4.1.1-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.1.1-rc.20200827)
+
+- [f5a95fc](https://github.com/stashed/mongodb/commit/f5a95fc) Prepare for release 4.1.1-rc.20200827 (#238)
+- [a68fafc](https://github.com/stashed/mongodb/commit/a68fafc) [cherry-pick] Upload charts without updating index (#227)
+
+
+### [4.1.4-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.1.4-rc.20200827)
+
+- [84e97a4](https://github.com/stashed/mongodb/commit/84e97a4) Prepare for release 4.1.4-rc.20200827 (#239)
+- [3a168e8](https://github.com/stashed/mongodb/commit/3a168e8) [cherry-pick] Upload charts without updating index (#228)
+
+
+### [4.1.7-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.1.7-rc.20200827)
+
+- [df9852f](https://github.com/stashed/mongodb/commit/df9852f) Prepare for release 4.1.7-rc.20200827 (#240)
+- [b22a028](https://github.com/stashed/mongodb/commit/b22a028) [cherry-pick] Upload charts without updating index (#229)
+
+
+### [4.2.3-rc.20200827](https://github.com/stashed/mongodb/releases/tag/4.2.3-rc.20200827)
+
+- [e4c8466](https://github.com/stashed/mongodb/commit/e4c8466) Prepare for release 4.2.3-rc.20200827 (#241)
+- [b45397b](https://github.com/stashed/mongodb/commit/b45397b) [cherry-pick] Upload charts without updating index (#230)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-rc.20200827](https://github.com/stashed/mysql/releases/tag/5.7.25-rc.20200827)
+
+- [263f795](https://github.com/stashed/mysql/commit/263f795) Prepare for release 5.7.25-rc.20200827 (#99)
+- [96023d1](https://github.com/stashed/mysql/commit/96023d1) [cherry-pick] Upload charts without updating index (#96)
+
+
+### [8.0.3-rc.20200827](https://github.com/stashed/mysql/releases/tag/8.0.3-rc.20200827)
+
+- [7d02720](https://github.com/stashed/mysql/commit/7d02720) Prepare for release 8.0.3-rc.20200827 (#101)
+- [dc8e2b5](https://github.com/stashed/mysql/commit/dc8e2b5) [cherry-pick] Upload charts without updating index (#98)
+
+
+### [8.0.14-rc.20200827](https://github.com/stashed/mysql/releases/tag/8.0.14-rc.20200827)
+
+- [720aa02](https://github.com/stashed/mysql/commit/720aa02) Prepare for release 8.0.14-rc.20200827 (#100)
+- [7019c00](https://github.com/stashed/mysql/commit/7019c00) [cherry-pick] Upload charts without updating index (#97)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-rc.20200827](https://github.com/stashed/percona-xtradb/releases/tag/5.7-rc.20200827)
+
+- [c854199](https://github.com/stashed/percona-xtradb/commit/c854199) Prepare for release 5.7-rc.20200827 (#55)
+- [e798257](https://github.com/stashed/percona-xtradb/commit/e798257) [cherry-pick] Upload charts without updating index (#54)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6-rc.20200827](https://github.com/stashed/postgres/releases/tag/9.6-rc.20200827)
+
+- [e9febb8](https://github.com/stashed/postgres/commit/e9febb8) Prepare for release 9.6-rc.20200827 (#163)
+- [3f724ee](https://github.com/stashed/postgres/commit/3f724ee) [cherry-pick] Upload charts without updating index (#158)
+
+
+### [10.2-rc.20200827](https://github.com/stashed/postgres/releases/tag/10.2-rc.20200827)
+
+- [fd9fc7a](https://github.com/stashed/postgres/commit/fd9fc7a) Prepare for release 10.2-rc.20200827 (#159)
+- [7d1033a](https://github.com/stashed/postgres/commit/7d1033a) [cherry-pick] Upload charts without updating index (#154)
+
+
+### [10.6-rc.20200827](https://github.com/stashed/postgres/releases/tag/10.6-rc.20200827)
+
+- [4724218](https://github.com/stashed/postgres/commit/4724218) Prepare for release 10.6-rc.20200827 (#160)
+- [1167129](https://github.com/stashed/postgres/commit/1167129) [cherry-pick] Upload charts without updating index (#155)
+
+
+### [11.1-rc.20200827](https://github.com/stashed/postgres/releases/tag/11.1-rc.20200827)
+
+- [0fbd548](https://github.com/stashed/postgres/commit/0fbd548) Prepare for release 11.1-rc.20200827 (#161)
+- [fc8cb58](https://github.com/stashed/postgres/commit/fc8cb58) [cherry-pick] Upload charts without updating index (#156)
+
+
+### [11.2-rc.20200827](https://github.com/stashed/postgres/releases/tag/11.2-rc.20200827)
+
+- [342b6bb](https://github.com/stashed/postgres/commit/342b6bb) Prepare for release 11.2-rc.20200827 (#162)
+- [4688cde](https://github.com/stashed/postgres/commit/4688cde) [cherry-pick] Upload charts without updating index (#157)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.10.0-rc.2](https://github.com/stashed/stash/releases/tag/v0.10.0-rc.2)
+
+- [485f80c6](https://github.com/stashed/stash/commit/485f80c6) Prepare for release v0.10.0-rc.2 (#1181)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.08.27-rc.0
Release-tracker: https://github.com/stashed/CHANGELOG/pull/6
Signed-off-by: 1gtm <1gtm@appscode.com>