### PR TITLE
Prepare for release v2020.09.16

### DIFF
--- a/docs/CHANGELOG-v2020.09.16.md
+++ b/docs/CHANGELOG-v2020.09.16.md
@@ -1,0 +1,367 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.09.16
+    name: Changelog-v2020.09.16
+    parent: welcome
+    weight: 20200916
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.09.16/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.09.16/
+---
+
+# Stash v2020.09.16 (2020-09-16)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.0](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.0)
+
+- [8add0e83](https://github.com/appscode/stash-enterprise/commit/8add0e83) Prepare for release v0.11.0 (#24)
+- [0b689384](https://github.com/appscode/stash-enterprise/commit/0b689384) Install license handler to operator webhook server (#23)
+- [19e8313d](https://github.com/appscode/stash-enterprise/commit/19e8313d) Update Prometheus client version (#22)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.0](https://github.com/stashed/apimachinery/releases/tag/v0.11.0)
+
+- [0189ba36](https://github.com/stashed/apimachinery/commit/0189ba36) Add license related constants (#47)
+- [de630b13](https://github.com/stashed/apimachinery/commit/de630b13) Update Kubernetes v1.18.3 dependencies (#48)
+- [546ceea9](https://github.com/stashed/apimachinery/commit/546ceea9) Update Prometheus client version (#44)
+- [88df3b0c](https://github.com/stashed/apimachinery/commit/88df3b0c) Update Kubernetes v1.18.3 dependencies (#46)
+- [8608f5c5](https://github.com/stashed/apimachinery/commit/8608f5c5) Update Kubernetes v1.18.3 dependencies (#45)
+- [41eca8e8](https://github.com/stashed/apimachinery/commit/41eca8e8) Update Kubernetes v1.18.3 dependencies (#43)
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.09.16](https://github.com/stashed/catalog/releases/tag/v2020.09.16)
+
+- [1f44b9a](https://github.com/stashed/catalog/commit/1f44b9a) Prepare for release v2020.09.16 (#38)
+- [c49f66f](https://github.com/stashed/catalog/commit/c49f66f) Use AppsCode Community License (#37)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.0](https://github.com/stashed/cli/releases/tag/v0.11.0)
+
+- [28f863f](https://github.com/stashed/cli/commit/28f863f) Prepare for release v0.11.0 (#48)
+- [fe90a5a](https://github.com/stashed/cli/commit/fe90a5a) Update Kubernetes v1.18.3 dependencies (#47)
+- [bdc2eb8](https://github.com/stashed/cli/commit/bdc2eb8) Use github.com/prometheus/client_golang@v1.7.1 (#46)
+- [fea66e1](https://github.com/stashed/cli/commit/fea66e1) Update Kubernetes v1.18.3 dependencies (#45)
+- [334aff0](https://github.com/stashed/cli/commit/334aff0) Use AppsCode Community License (#44)
+- [5e07d8f](https://github.com/stashed/cli/commit/5e07d8f) Update Kubernetes v1.18.3 dependencies (#43)
+- [c6a8d81](https://github.com/stashed/cli/commit/c6a8d81) Update Kubernetes v1.18.3 dependencies (#42)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v2](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v2)
+
+- [ced22a9](https://github.com/stashed/elasticsearch/commit/ced22a9) Prepare for release 5.6.4-v2 (#246)
+- [2ff93eb](https://github.com/stashed/elasticsearch/commit/2ff93eb) [cherry-pick] Verify license info from stash operator (#237) (#238)
+- [9fffb2d](https://github.com/stashed/elasticsearch/commit/9fffb2d) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#229)
+- [54e853c](https://github.com/stashed/elasticsearch/commit/54e853c) [cherry-pick] Switch to AppsCode Trial license (#219) (#220)
+- [cf45e19](https://github.com/stashed/elasticsearch/commit/cf45e19) [cherry-pick] Use AppsCode Community License (#210) (#211)
+
+
+### [6.2.4-v2](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v2)
+
+- [a4a25fb](https://github.com/stashed/elasticsearch/commit/a4a25fb) Prepare for release 6.2.4-v2 (#247)
+- [faccd9c](https://github.com/stashed/elasticsearch/commit/faccd9c) [cherry-pick] Verify license info from stash operator (#237) (#239)
+- [1fcca35](https://github.com/stashed/elasticsearch/commit/1fcca35) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#230)
+- [5ff3d49](https://github.com/stashed/elasticsearch/commit/5ff3d49) [cherry-pick] Switch to AppsCode Trial license (#219) (#221)
+- [f3fae80](https://github.com/stashed/elasticsearch/commit/f3fae80) [cherry-pick] Use AppsCode Community License (#210) (#212)
+
+
+### [6.3.0-v2](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v2)
+
+- [0e19668](https://github.com/stashed/elasticsearch/commit/0e19668) Prepare for release 6.3.0-v2 (#248)
+- [9648ed3](https://github.com/stashed/elasticsearch/commit/9648ed3) [cherry-pick] Verify license info from stash operator (#237) (#240)
+- [4d23c41](https://github.com/stashed/elasticsearch/commit/4d23c41) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#231)
+- [58649ad](https://github.com/stashed/elasticsearch/commit/58649ad) [cherry-pick] Switch to AppsCode Trial license (#219) (#222)
+- [d950285](https://github.com/stashed/elasticsearch/commit/d950285) [cherry-pick] Use AppsCode Community License (#210) (#213)
+
+
+### [6.4.0-v2](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v2)
+
+- [1020631](https://github.com/stashed/elasticsearch/commit/1020631) Prepare for release 6.4.0-v2 (#249)
+- [7bfb7d7](https://github.com/stashed/elasticsearch/commit/7bfb7d7) [cherry-pick] Verify license info from stash operator (#237) (#241)
+- [3eb4fb9](https://github.com/stashed/elasticsearch/commit/3eb4fb9) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#232)
+- [f7c6228](https://github.com/stashed/elasticsearch/commit/f7c6228) [cherry-pick] Switch to AppsCode Trial license (#219) (#223)
+- [b80c2f4](https://github.com/stashed/elasticsearch/commit/b80c2f4) [cherry-pick] Use AppsCode Community License (#210) (#214)
+
+
+### [6.5.3-v2](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v2)
+
+- [3793d92](https://github.com/stashed/elasticsearch/commit/3793d92) Prepare for release 6.5.3-v2 (#250)
+- [0e38789](https://github.com/stashed/elasticsearch/commit/0e38789) [cherry-pick] Verify license info from stash operator (#237) (#242)
+- [3560a7e](https://github.com/stashed/elasticsearch/commit/3560a7e) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#233)
+- [b904573](https://github.com/stashed/elasticsearch/commit/b904573) [cherry-pick] Switch to AppsCode Trial license (#219) (#224)
+- [7b0b5f9](https://github.com/stashed/elasticsearch/commit/7b0b5f9) [cherry-pick] Use AppsCode Community License (#210) (#215)
+
+
+### [6.8.0-v2](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v2)
+
+- [3c46fa4](https://github.com/stashed/elasticsearch/commit/3c46fa4) Prepare for release 6.8.0-v2 (#251)
+- [489bf75](https://github.com/stashed/elasticsearch/commit/489bf75) [cherry-pick] Verify license info from stash operator (#237) (#243)
+- [5dee02e](https://github.com/stashed/elasticsearch/commit/5dee02e) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#234)
+- [067642a](https://github.com/stashed/elasticsearch/commit/067642a) [cherry-pick] Switch to AppsCode Trial license (#219) (#225)
+- [7f96aea](https://github.com/stashed/elasticsearch/commit/7f96aea) [cherry-pick] Use AppsCode Community License (#210) (#216)
+
+
+### [7.2.0-v2](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v2)
+
+- [32cffd2](https://github.com/stashed/elasticsearch/commit/32cffd2) Prepare for release 7.2.0-v2 (#252)
+- [d123f35](https://github.com/stashed/elasticsearch/commit/d123f35) [cherry-pick] Verify license info from stash operator (#237) (#244)
+- [25e8779](https://github.com/stashed/elasticsearch/commit/25e8779) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#235)
+- [ddcd7ef](https://github.com/stashed/elasticsearch/commit/ddcd7ef) [cherry-pick] Switch to AppsCode Trial license (#219) (#226)
+- [96add80](https://github.com/stashed/elasticsearch/commit/96add80) [cherry-pick] Use AppsCode Community License (#210) (#217)
+
+
+### [7.3.2-v2](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v2)
+
+- [3acdbad](https://github.com/stashed/elasticsearch/commit/3acdbad) Prepare for release 7.3.2-v2 (#253)
+- [346f7d8](https://github.com/stashed/elasticsearch/commit/346f7d8) [cherry-pick] Verify license info from stash operator (#237) (#245)
+- [5ad4ebb](https://github.com/stashed/elasticsearch/commit/5ad4ebb) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#228) (#236)
+- [fbe8fdc](https://github.com/stashed/elasticsearch/commit/fbe8fdc) [cherry-pick] Switch to AppsCode Trial license (#219) (#227)
+- [bfdd1fb](https://github.com/stashed/elasticsearch/commit/bfdd1fb) [cherry-pick] Use AppsCode Community License (#210) (#218)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.0](https://github.com/stashed/installer/releases/tag/v0.11.0)
+
+- [11a4b97](https://github.com/stashed/installer/commit/11a4b97) Prepare for release v0.11.0 (#101)
+- [96e1ea0](https://github.com/stashed/installer/commit/96e1ea0) Add permission to list nodes (#100)
+- [e18b2f9](https://github.com/stashed/installer/commit/e18b2f9) Add cluster role for license checker (#98)
+- [25ee54b](https://github.com/stashed/installer/commit/25ee54b) Update Kubernetes v1.18.3 dependencies (#99)
+- [194b734](https://github.com/stashed/installer/commit/194b734) Update Kubernetes v1.18.3 dependencies (#97)
+- [a9c363b](https://github.com/stashed/installer/commit/a9c363b) Use AppsCode Community License (#96)
+- [48e8a45](https://github.com/stashed/installer/commit/48e8a45) Update Kubernetes v1.18.3 dependencies (#95)
+- [85e89b2](https://github.com/stashed/installer/commit/85e89b2) Update Kubernetes v1.18.3 dependencies (#94)
+- [a7ebe2f](https://github.com/stashed/installer/commit/a7ebe2f) Update chart icons
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.1-v2](https://github.com/stashed/mongodb/releases/tag/3.4.1-v2)
+
+- [d6cd42a](https://github.com/stashed/mongodb/commit/d6cd42a) Prepare for release 3.4.1-v2 (#315)
+- [5d846c3](https://github.com/stashed/mongodb/commit/5d846c3) [cherry-pick] Verify license info from stash operator (#303) (#304)
+- [f0f5274](https://github.com/stashed/mongodb/commit/f0f5274) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#292)
+- [3e1f75b](https://github.com/stashed/mongodb/commit/3e1f75b) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#281)
+- [58f36c3](https://github.com/stashed/mongodb/commit/58f36c3) [cherry-pick] Switch to AppsCode Trial license (#268) (#269)
+- [d8bfed7](https://github.com/stashed/mongodb/commit/d8bfed7) [cherry-pick] Use AppsCode Community License (#256) (#257)
+
+
+### [3.4.2-v2](https://github.com/stashed/mongodb/releases/tag/3.4.2-v2)
+
+- [9f39b16](https://github.com/stashed/mongodb/commit/9f39b16) Prepare for release 3.4.2-v2 (#316)
+- [342b46f](https://github.com/stashed/mongodb/commit/342b46f) [cherry-pick] Verify license info from stash operator (#303) (#305)
+- [056167e](https://github.com/stashed/mongodb/commit/056167e) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#293)
+- [a4fbda4](https://github.com/stashed/mongodb/commit/a4fbda4) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#282)
+- [10dd2fe](https://github.com/stashed/mongodb/commit/10dd2fe) [cherry-pick] Switch to AppsCode Trial license (#268) (#270)
+- [89323b4](https://github.com/stashed/mongodb/commit/89323b4) [cherry-pick] Use AppsCode Community License (#256) (#258)
+
+
+### [3.6.1-v2](https://github.com/stashed/mongodb/releases/tag/3.6.1-v2)
+
+- [fe0e93b](https://github.com/stashed/mongodb/commit/fe0e93b) Prepare for release 3.6.1-v2 (#317)
+- [b53756a](https://github.com/stashed/mongodb/commit/b53756a) [cherry-pick] Verify license info from stash operator (#303) (#306)
+- [239ef49](https://github.com/stashed/mongodb/commit/239ef49) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#294)
+- [9684b9b](https://github.com/stashed/mongodb/commit/9684b9b) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#283)
+- [6697768](https://github.com/stashed/mongodb/commit/6697768) [cherry-pick] Switch to AppsCode Trial license (#268) (#271)
+- [b25b9e0](https://github.com/stashed/mongodb/commit/b25b9e0) [cherry-pick] Use AppsCode Community License (#256) (#259)
+
+
+### [3.6.8-v2](https://github.com/stashed/mongodb/releases/tag/3.6.8-v2)
+
+- [f358adb](https://github.com/stashed/mongodb/commit/f358adb) Prepare for release 3.6.8-v2 (#318)
+- [57d51f3](https://github.com/stashed/mongodb/commit/57d51f3) [cherry-pick] Verify license info from stash operator (#303) (#307)
+- [e25588b](https://github.com/stashed/mongodb/commit/e25588b) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#295)
+- [e727df2](https://github.com/stashed/mongodb/commit/e727df2) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#284)
+- [e2a3e54](https://github.com/stashed/mongodb/commit/e2a3e54) [cherry-pick] Switch to AppsCode Trial license (#268) (#272)
+- [3125f19](https://github.com/stashed/mongodb/commit/3125f19) [cherry-pick] Use AppsCode Community License (#256) (#260)
+
+
+### [4.0.3-v2](https://github.com/stashed/mongodb/releases/tag/4.0.3-v2)
+
+- [5734929](https://github.com/stashed/mongodb/commit/5734929) Prepare for release 4.0.3-v2 (#320)
+- [554125f](https://github.com/stashed/mongodb/commit/554125f) [cherry-pick] Verify license info from stash operator (#303) (#309)
+- [51fc4fc](https://github.com/stashed/mongodb/commit/51fc4fc) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#297)
+- [5a25af3](https://github.com/stashed/mongodb/commit/5a25af3) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#286)
+- [791057c](https://github.com/stashed/mongodb/commit/791057c) [cherry-pick] Switch to AppsCode Trial license (#268) (#274)
+- [cab86cc](https://github.com/stashed/mongodb/commit/cab86cc) [cherry-pick] Use AppsCode Community License (#256) (#262)
+
+
+### [4.0.5-v2](https://github.com/stashed/mongodb/releases/tag/4.0.5-v2)
+
+- [4939a48](https://github.com/stashed/mongodb/commit/4939a48) Prepare for release 4.0.5-v2 (#321)
+- [b5df908](https://github.com/stashed/mongodb/commit/b5df908) [cherry-pick] Verify license info from stash operator (#303) (#310)
+- [051f4cd](https://github.com/stashed/mongodb/commit/051f4cd) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#298)
+- [3ba1f6c](https://github.com/stashed/mongodb/commit/3ba1f6c) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#287)
+- [8f1e9ae](https://github.com/stashed/mongodb/commit/8f1e9ae) [cherry-pick] Switch to AppsCode Trial license (#268) (#275)
+- [6ff6079](https://github.com/stashed/mongodb/commit/6ff6079) [cherry-pick] Use AppsCode Community License (#256) (#263)
+
+
+### [4.0.11-v2](https://github.com/stashed/mongodb/releases/tag/4.0.11-v2)
+
+- [dd45e66](https://github.com/stashed/mongodb/commit/dd45e66) Prepare for release 4.0.11-v2 (#319)
+- [909ce13](https://github.com/stashed/mongodb/commit/909ce13) [cherry-pick] Verify license info from stash operator (#303) (#308)
+- [27c9145](https://github.com/stashed/mongodb/commit/27c9145) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#296)
+- [c0fd352](https://github.com/stashed/mongodb/commit/c0fd352) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#285)
+- [9594c13](https://github.com/stashed/mongodb/commit/9594c13) [cherry-pick] Switch to AppsCode Trial license (#268) (#273)
+- [4d211b9](https://github.com/stashed/mongodb/commit/4d211b9) [cherry-pick] Use AppsCode Community License (#256) (#261)
+
+
+### [4.1.1-v2](https://github.com/stashed/mongodb/releases/tag/4.1.1-v2)
+
+- [5740420](https://github.com/stashed/mongodb/commit/5740420) Prepare for release 4.1.1-v2 (#322)
+- [2b824a1](https://github.com/stashed/mongodb/commit/2b824a1) [cherry-pick] Verify license info from stash operator (#303) (#311)
+- [d19b059](https://github.com/stashed/mongodb/commit/d19b059) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#299)
+- [271906b](https://github.com/stashed/mongodb/commit/271906b) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#288)
+- [0de8dd3](https://github.com/stashed/mongodb/commit/0de8dd3) [cherry-pick] Switch to AppsCode Trial license (#268) (#276)
+- [159d83f](https://github.com/stashed/mongodb/commit/159d83f) [cherry-pick] Use AppsCode Community License (#256) (#264)
+
+
+### [4.1.4-v2](https://github.com/stashed/mongodb/releases/tag/4.1.4-v2)
+
+- [6507bd9](https://github.com/stashed/mongodb/commit/6507bd9) Prepare for release 4.1.4-v2 (#323)
+- [2faa4f1](https://github.com/stashed/mongodb/commit/2faa4f1) [cherry-pick] Verify license info from stash operator (#303) (#312)
+- [4201854](https://github.com/stashed/mongodb/commit/4201854) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#300)
+- [a106836](https://github.com/stashed/mongodb/commit/a106836) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#289)
+- [e1ad15f](https://github.com/stashed/mongodb/commit/e1ad15f) [cherry-pick] Switch to AppsCode Trial license (#268) (#277)
+- [721bef2](https://github.com/stashed/mongodb/commit/721bef2) [cherry-pick] Use AppsCode Community License (#256) (#265)
+
+
+### [4.1.7-v2](https://github.com/stashed/mongodb/releases/tag/4.1.7-v2)
+
+- [833905a](https://github.com/stashed/mongodb/commit/833905a) Prepare for release 4.1.7-v2 (#324)
+- [2e06c98](https://github.com/stashed/mongodb/commit/2e06c98) [cherry-pick] Verify license info from stash operator (#303) (#313)
+- [d7b6f14](https://github.com/stashed/mongodb/commit/d7b6f14) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#301)
+- [1f70c99](https://github.com/stashed/mongodb/commit/1f70c99) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#290)
+- [dadc11a](https://github.com/stashed/mongodb/commit/dadc11a) [cherry-pick] Switch to AppsCode Trial license (#268) (#278)
+- [9ebe64f](https://github.com/stashed/mongodb/commit/9ebe64f) [cherry-pick] Use AppsCode Community License (#256) (#266)
+
+
+### [4.2.3-v2](https://github.com/stashed/mongodb/releases/tag/4.2.3-v2)
+
+- [ae039dd](https://github.com/stashed/mongodb/commit/ae039dd) Prepare for release 4.2.3-v2 (#325)
+- [99fe171](https://github.com/stashed/mongodb/commit/99fe171) [cherry-pick] Verify license info from stash operator (#303) (#314)
+- [60ee4a0](https://github.com/stashed/mongodb/commit/60ee4a0) [cherry-pick] Switch to tls secret from pem in AppBinding (#255) (#302)
+- [c24a9bc](https://github.com/stashed/mongodb/commit/c24a9bc) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#280) (#291)
+- [add112a](https://github.com/stashed/mongodb/commit/add112a) [cherry-pick] Switch to AppsCode Trial license (#268) (#279)
+- [e9dded8](https://github.com/stashed/mongodb/commit/e9dded8) [cherry-pick] Use AppsCode Community License (#256) (#267)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v2](https://github.com/stashed/mysql/releases/tag/5.7.25-v2)
+
+- [c28b084](https://github.com/stashed/mysql/commit/c28b084) Prepare for release 5.7.25-v2 (#123)
+- [c2f5aab](https://github.com/stashed/mysql/commit/c2f5aab) [cherry-pick] Verify license info from stash operator (#119) (#120)
+- [4686afa](https://github.com/stashed/mysql/commit/4686afa) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#115) (#116)
+- [09c142d](https://github.com/stashed/mysql/commit/09c142d) [cherry-pick] Switch to AppsCode Trial license (#111) (#112)
+- [b0b47b4](https://github.com/stashed/mysql/commit/b0b47b4) [cherry-pick] Use AppsCode Community License (#107) (#108)
+
+
+### [8.0.3-v2](https://github.com/stashed/mysql/releases/tag/8.0.3-v2)
+
+- [0bd9422](https://github.com/stashed/mysql/commit/0bd9422) Prepare for release 8.0.3-v2 (#125)
+- [753c3b5](https://github.com/stashed/mysql/commit/753c3b5) [cherry-pick] Verify license info from stash operator (#119) (#122)
+- [e931e41](https://github.com/stashed/mysql/commit/e931e41) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#115) (#118)
+- [96c677d](https://github.com/stashed/mysql/commit/96c677d) [cherry-pick] Switch to AppsCode Trial license (#111) (#114)
+- [3f231cf](https://github.com/stashed/mysql/commit/3f231cf) [cherry-pick] Use AppsCode Community License (#107) (#110)
+
+
+### [8.0.14-v2](https://github.com/stashed/mysql/releases/tag/8.0.14-v2)
+
+- [5e20d12](https://github.com/stashed/mysql/commit/5e20d12) Prepare for release 8.0.14-v2 (#124)
+- [7c4801f](https://github.com/stashed/mysql/commit/7c4801f) [cherry-pick] Verify license info from stash operator (#119) (#121)
+- [76980c4](https://github.com/stashed/mysql/commit/76980c4) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#115) (#117)
+- [23a26cd](https://github.com/stashed/mysql/commit/23a26cd) [cherry-pick] Switch to AppsCode Trial license (#111) (#113)
+- [3954180](https://github.com/stashed/mysql/commit/3954180) [cherry-pick] Use AppsCode Community License (#107) (#109)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v2](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v2)
+
+- [d33e539](https://github.com/stashed/percona-xtradb/commit/d33e539) Prepare for release 5.7-v2 (#65)
+- [b53cfc8](https://github.com/stashed/percona-xtradb/commit/b53cfc8) [cherry-pick] Verify license info from stash operator (#63) (#64)
+- [859b6a4](https://github.com/stashed/percona-xtradb/commit/859b6a4) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#61) (#62)
+- [14f50b8](https://github.com/stashed/percona-xtradb/commit/14f50b8) Switch to AppsCode Trial license
+- [c287878](https://github.com/stashed/percona-xtradb/commit/c287878) Delete LICENSE
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19](https://github.com/stashed/postgres/releases/tag/9.6.19)
+
+- [6fd2741](https://github.com/stashed/postgres/commit/6fd2741) Prepare for release 9.6.19 (#198)
+- [06b6542](https://github.com/stashed/postgres/commit/06b6542) Add support for postgres:9.6.19
+- [e1cfed8](https://github.com/stashed/postgres/commit/e1cfed8) [cherry-pick] Verify license info from stash operator (#189) (#194)
+- [82fc42b](https://github.com/stashed/postgres/commit/82fc42b) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#183) (#188)
+- [e64c0c7](https://github.com/stashed/postgres/commit/e64c0c7) [cherry-pick] Switch to AppsCode Trial license (#177) (#182)
+- [1004dfb](https://github.com/stashed/postgres/commit/1004dfb) [cherry-pick] Use AppsCode Community License (#171) (#176)
+
+
+### [10.14.0](https://github.com/stashed/postgres/releases/tag/10.14.0)
+
+- [4642779](https://github.com/stashed/postgres/commit/4642779) Prepare for release 10.14.0 (#195)
+- [2e94c31](https://github.com/stashed/postgres/commit/2e94c31) Add support for postgres:10.14
+- [9d1856e](https://github.com/stashed/postgres/commit/9d1856e) [cherry-pick] Verify license info from stash operator (#189) (#191)
+- [86798e0](https://github.com/stashed/postgres/commit/86798e0) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#183) (#185)
+- [f58127c](https://github.com/stashed/postgres/commit/f58127c) [cherry-pick] Switch to AppsCode Trial license (#177) (#179)
+- [d1929f1](https://github.com/stashed/postgres/commit/d1929f1) [cherry-pick] Use AppsCode Community License (#171) (#173)
+
+
+### [11.9.0](https://github.com/stashed/postgres/releases/tag/11.9.0)
+
+- [5138fc7](https://github.com/stashed/postgres/commit/5138fc7) Prepare for release 11.9.0 (#196)
+- [81de1d6](https://github.com/stashed/postgres/commit/81de1d6) Add support for postgres:11.9
+- [747613b](https://github.com/stashed/postgres/commit/747613b) [cherry-pick] Verify license info from stash operator (#189) (#193)
+- [af40fa9](https://github.com/stashed/postgres/commit/af40fa9) [cherry-pick] Use github.com/prometheus/client_golang@v1.7.1 (#183) (#187)
+- [00f48a6](https://github.com/stashed/postgres/commit/00f48a6) [cherry-pick] Switch to AppsCode Trial license (#177) (#181)
+- [d673cea](https://github.com/stashed/postgres/commit/d673cea) [cherry-pick] Use AppsCode Community License (#171) (#175)
+
+
+### [12.4.0](https://github.com/stashed/postgres/releases/tag/12.4.0)
+
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.0](https://github.com/stashed/stash/releases/tag/v0.11.0)
+
+- [a919b347](https://github.com/stashed/stash/commit/a919b347) Prepare for release v0.11.0 (#1198)
+- [33cc3131](https://github.com/stashed/stash/commit/33cc3131) Update Kubernetes v1.18.3 dependencies (#1197)
+- [58b28e02](https://github.com/stashed/stash/commit/58b28e02) Install license handler to operator webhook server (#1194)
+- [642f935c](https://github.com/stashed/stash/commit/642f935c) Update Kubernetes v1.18.3 dependencies (#1196)
+- [09f7213e](https://github.com/stashed/stash/commit/09f7213e) Document database addons as enterprise feature (#1195)
+- [77b40b2b](https://github.com/stashed/stash/commit/77b40b2b) Update Prometheus client version (#1191)
+- [f452230c](https://github.com/stashed/stash/commit/f452230c) Update Kubernetes v1.18.3 dependencies (#1189)
+- [9f5e1c70](https://github.com/stashed/stash/commit/9f5e1c70) Use AppsCode Community License (#1188)
+- [6802b5aa](https://github.com/stashed/stash/commit/6802b5aa) Update Kubernetes v1.18.3 dependencies (#1186)
+- [b5a4a690](https://github.com/stashed/stash/commit/b5a4a690) Update Kubernetes v1.18.3 dependencies (#1185)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.09.16
Release-tracker: https://github.com/stashed/CHANGELOG/pull/8
Signed-off-by: 1gtm <1gtm@appscode.com>