### PR TITLE
Prepare for release v2020.09.29

### DIFF
--- a/docs/CHANGELOG-v2020.09.29.md
+++ b/docs/CHANGELOG-v2020.09.29.md
@@ -1,0 +1,109 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.09.29
+    name: Changelog-v2020.09.29
+    parent: welcome
+    weight: 20200929
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.09.29/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.09.29/
+---
+
+# Stash v2020.09.29 (2020-09-29)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.2](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.2)
+
+- [b6b0c6ac](https://github.com/appscode/stash-enterprise/commit/b6b0c6ac) Prepare for release v0.11.2 (#28)
+- [281b513c](https://github.com/appscode/stash-enterprise/commit/281b513c) Fix database auto-backup + Repository status update (#27)
+- [10da79b8](https://github.com/appscode/stash-enterprise/commit/10da79b8) Update repository config (#26)
+- [0aecb235](https://github.com/appscode/stash-enterprise/commit/0aecb235) Update repository config (#25)
+- [81726ec5](https://github.com/appscode/stash-enterprise/commit/81726ec5) Update features table
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.2](https://github.com/stashed/apimachinery/releases/tag/v0.11.2)
+
+- [fdc12ac2](https://github.com/stashed/apimachinery/commit/fdc12ac2) Update Kubernetes v1.18.9 dependencies (#56)
+- [6ed3a17b](https://github.com/stashed/apimachinery/commit/6ed3a17b) Use POST instead of PUT method to push metrics into pushgateway (#55)
+- [1cff3b6b](https://github.com/stashed/apimachinery/commit/1cff3b6b) Update Kubernetes v1.18.9 dependencies (#54)
+- [596541c6](https://github.com/stashed/apimachinery/commit/596541c6) Update repository config (#53)
+- [64f1e392](https://github.com/stashed/apimachinery/commit/64f1e392) Update repository config (#52)
+- [3b73ec67](https://github.com/stashed/apimachinery/commit/3b73ec67) Update Kubernetes v1.18.9 dependencies (#51)
+- [0c4ff5e6](https://github.com/stashed/apimachinery/commit/0c4ff5e6) Update Kubernetes v1.18.3 dependencies (#50)
+- [01d9fb4d](https://github.com/stashed/apimachinery/commit/01d9fb4d) Update Kubernetes v1.18.3 dependencies (#49)
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.09.29](https://github.com/stashed/catalog/releases/tag/v2020.09.29)
+
+- [c971630](https://github.com/stashed/catalog/commit/c971630) Prepare for release v2020.09.29 (#41)
+- [bacd576](https://github.com/stashed/catalog/commit/bacd576) Update repository config (#40)
+- [2d001cd](https://github.com/stashed/catalog/commit/2d001cd) Update repository config (#39)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.2](https://github.com/stashed/cli/releases/tag/v0.11.2)
+
+- [9566b46](https://github.com/stashed/cli/commit/9566b46) Prepare for release v0.11.2 (#56)
+- [8eab6d9](https://github.com/stashed/cli/commit/8eab6d9) Update Kubernetes v1.18.9 dependencies (#55)
+- [91ae713](https://github.com/stashed/cli/commit/91ae713) Update Kubernetes v1.18.9 dependencies (#54)
+- [ae36a24](https://github.com/stashed/cli/commit/ae36a24) Update repository config (#53)
+- [a2f4793](https://github.com/stashed/cli/commit/a2f4793) Update Kubernetes v1.18.9 dependencies (#52)
+- [6edbe6d](https://github.com/stashed/cli/commit/6edbe6d) Update Kubernetes v1.18.3 dependencies (#51)
+- [37eee1c](https://github.com/stashed/cli/commit/37eee1c) Update Kubernetes v1.18.3 dependencies (#50)
+- [7045e6b](https://github.com/stashed/cli/commit/7045e6b) Update Kubernetes v1.18.3 dependencies (#49)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.2](https://github.com/stashed/installer/releases/tag/v0.11.2)
+
+- [6b6c270](https://github.com/stashed/installer/commit/6b6c270) Prepare for release v0.11.2 (#110)
+- [15d8827](https://github.com/stashed/installer/commit/15d8827) Update Kubernetes v1.18.9 dependencies (#109)
+- [ade81f7](https://github.com/stashed/installer/commit/ade81f7) Update pushgateway version (#108)
+- [4b8dcbf](https://github.com/stashed/installer/commit/4b8dcbf) Update Kubernetes v1.18.9 dependencies (#107)
+- [72b9d7d](https://github.com/stashed/installer/commit/72b9d7d) Update repository config (#106)
+- [d4c3d9f](https://github.com/stashed/installer/commit/d4c3d9f) Update repository config (#105)
+- [a1b99bd](https://github.com/stashed/installer/commit/a1b99bd) Update Kubernetes v1.18.9 dependencies (#104)
+- [2d13138](https://github.com/stashed/installer/commit/2d13138) Update Kubernetes v1.18.3 dependencies (#103)
+- [7f17beb](https://github.com/stashed/installer/commit/7f17beb) Update Kubernetes v1.18.3 dependencies (#102)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.2](https://github.com/stashed/stash/releases/tag/v0.11.2)
+
+- [ba1cb598](https://github.com/stashed/stash/commit/ba1cb598) Prepare for release v0.11.2 (#1211)
+- [09b06beb](https://github.com/stashed/stash/commit/09b06beb) Update Kubernetes v1.18.9 dependencies (#1209)
+- [d0bae661](https://github.com/stashed/stash/commit/d0bae661) Fix repository status update (#1208)
+- [d7ee2d1e](https://github.com/stashed/stash/commit/d7ee2d1e) Update Kubernetes v1.18.9 dependencies (#1205)
+- [b97403dc](https://github.com/stashed/stash/commit/b97403dc) Update repository config (#1204)
+- [44173b82](https://github.com/stashed/stash/commit/44173b82) Update repository config (#1203)
+- [3e62cd2d](https://github.com/stashed/stash/commit/3e62cd2d) Update repository config (#1202)
+- [bfac4f0f](https://github.com/stashed/stash/commit/bfac4f0f) Update Kubernetes v1.18.9 dependencies (#1201)
+- [022c5eac](https://github.com/stashed/stash/commit/022c5eac) Update Kubernetes v1.18.3 dependencies (#1200)
+- [9793d44b](https://github.com/stashed/stash/commit/9793d44b) Update README.md
+- [2970d018](https://github.com/stashed/stash/commit/2970d018) Update Kubernetes v1.18.3 dependencies (#1199)
+- [86e90746](https://github.com/stashed/stash/commit/86e90746) Implicitly import go.bytebuilders.dev/license-verifier
+- [8acf60c2](https://github.com/stashed/stash/commit/8acf60c2) Update README.md
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.09.29
Release-tracker: https://github.com/stashed/CHANGELOG/pull/10
Signed-off-by: 1gtm <1gtm@appscode.com>