### PR TITLE
Prepare for release v2020.10.21

### DIFF
--- a/docs/CHANGELOG-v2020.10.21.md
+++ b/docs/CHANGELOG-v2020.10.21.md
@@ -1,0 +1,618 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.10.21
+    name: Changelog-v2020.10.21
+    parent: welcome
+    weight: 20201021
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.10.21/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.10.21/
+---
+
+# Stash v2020.10.21 (2020-10-22)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.3](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.3)
+
+- [371a7035](https://github.com/appscode/stash-enterprise/commit/371a7035) Prepare for release v0.11.3 (#41)
+- [2e72fb71](https://github.com/appscode/stash-enterprise/commit/2e72fb71) Pass offshoot labels to CronJob pods (#40)
+- [c1c186bf](https://github.com/appscode/stash-enterprise/commit/c1c186bf) Use BackoffLimit=0 for backup/restore job (#30)
+- [1d39bbf9](https://github.com/appscode/stash-enterprise/commit/1d39bbf9) Fix ClusterRoleBinding name conflict (#39)
+- [07c17b9c](https://github.com/appscode/stash-enterprise/commit/07c17b9c) Use restic 0.10.0 (#35)
+- [e6757e0f](https://github.com/appscode/stash-enterprise/commit/e6757e0f) Update Kubernetes v1.18.9 dependencies (#34)
+- [22b9bc3a](https://github.com/appscode/stash-enterprise/commit/22b9bc3a) Update repository config (#36)
+- [701ba9f1](https://github.com/appscode/stash-enterprise/commit/701ba9f1) Publish docker images to ghcr.io (#33)
+- [e975d3e4](https://github.com/appscode/stash-enterprise/commit/e975d3e4) Update repository config (#32)
+- [26bfbe64](https://github.com/appscode/stash-enterprise/commit/26bfbe64) Update Kubernetes v1.18.9 dependencies (#29)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.3](https://github.com/stashed/apimachinery/releases/tag/v0.11.3)
+
+- [e8a63084](https://github.com/stashed/apimachinery/commit/e8a63084) Update dependencies (#63)
+- [403ba163](https://github.com/stashed/apimachinery/commit/403ba163) Update Kubernetes v1.18.9 dependencies (#61)
+- [8f316890](https://github.com/stashed/apimachinery/commit/8f316890) Use restic 0.10.0 (#60)
+- [28c0ca71](https://github.com/stashed/apimachinery/commit/28c0ca71) Update Kubernetes v1.18.9 dependencies (#59)
+- [9df9f83e](https://github.com/stashed/apimachinery/commit/9df9f83e) Update Kubernetes v1.18.9 dependencies (#58)
+- [fed98cfa](https://github.com/stashed/apimachinery/commit/fed98cfa) Update Kubernetes v1.18.9 dependencies (#57)
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.10.21](https://github.com/stashed/catalog/releases/tag/v2020.10.21)
+
+- [0e40f71](https://github.com/stashed/catalog/commit/0e40f71) Prepare for release v2020.10.21 (#44)
+- [1cf5e3e](https://github.com/stashed/catalog/commit/1cf5e3e) Update repository config (#43)
+- [ccae76e](https://github.com/stashed/catalog/commit/ccae76e) Update repository config (#42)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.3](https://github.com/stashed/cli/releases/tag/v0.11.3)
+
+- [1b821c8](https://github.com/stashed/cli/commit/1b821c8) Prepare for release v0.11.3 (#66)
+- [2aa47f7](https://github.com/stashed/cli/commit/2aa47f7) Update Kubernetes v1.18.9 dependencies (#65)
+- [82b3843](https://github.com/stashed/cli/commit/82b3843) Update Kubernetes v1.18.9 dependencies (#64)
+- [51bd7b7](https://github.com/stashed/cli/commit/51bd7b7) Update Kubernetes v1.18.9 dependencies (#63)
+- [fc82c5d](https://github.com/stashed/cli/commit/fc82c5d) Don't update krew manifest for pre-releases
+- [673758d](https://github.com/stashed/cli/commit/673758d) Change plugin name to stash from kubectl-stash
+- [119fefc](https://github.com/stashed/cli/commit/119fefc) Fix krew plugin.yaml
+- [5467516](https://github.com/stashed/cli/commit/5467516) Fix plugin name
+- [d3c25e5](https://github.com/stashed/cli/commit/d3c25e5) Publish krew manifest via CI (#62)
+- [c4552d9](https://github.com/stashed/cli/commit/c4552d9) Publish to krew index (#61)
+- [c1389c4](https://github.com/stashed/cli/commit/c1389c4) Update Kubernetes v1.18.9 dependencies (#60)
+- [e902dfc](https://github.com/stashed/cli/commit/e902dfc) Add completion command (#59)
+- [0037eb7](https://github.com/stashed/cli/commit/0037eb7) Update Kubernetes v1.18.9 dependencies (#58)
+- [f94e368](https://github.com/stashed/cli/commit/f94e368) Update Kubernetes v1.18.9 dependencies (#57)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v3](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v3)
+
+- [85da764](https://github.com/stashed/elasticsearch/commit/85da764) Prepare for release 5.6.4-v3 (#381)
+- [8033c85](https://github.com/stashed/elasticsearch/commit/8033c85) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#373)
+- [5033b27](https://github.com/stashed/elasticsearch/commit/5033b27) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#364)
+- [1cf0819](https://github.com/stashed/elasticsearch/commit/1cf0819) [cherry-pick] Use restic 0.10.0 (#336) (#355)
+- [9011d54](https://github.com/stashed/elasticsearch/commit/9011d54) [cherry-pick] Update repository config (#346) (#347)
+- [9ef801a](https://github.com/stashed/elasticsearch/commit/9ef801a) [cherry-pick] Update repository config (#337) (#338)
+- [8e65c75](https://github.com/stashed/elasticsearch/commit/8e65c75) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#328)
+- [0ba0f67](https://github.com/stashed/elasticsearch/commit/0ba0f67) [cherry-pick] Publish docker images to ghcr.io (#318) (#319)
+- [ebd8b01](https://github.com/stashed/elasticsearch/commit/ebd8b01) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#310)
+- [a3ea8c5](https://github.com/stashed/elasticsearch/commit/a3ea8c5) [cherry-pick] Update repository config (#300) (#301)
+- [ba742d4](https://github.com/stashed/elasticsearch/commit/ba742d4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#292)
+- [85d6a43](https://github.com/stashed/elasticsearch/commit/85d6a43) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#283)
+- [16a665b](https://github.com/stashed/elasticsearch/commit/16a665b) [cherry-pick] Update repository config (#273) (#274)
+- [63cd812](https://github.com/stashed/elasticsearch/commit/63cd812) [cherry-pick] Update repository config (#264) (#265)
+
+
+### [6.2.4-v3](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v3)
+
+- [25d0528](https://github.com/stashed/elasticsearch/commit/25d0528) Prepare for release 6.2.4-v3 (#382)
+- [d81f012](https://github.com/stashed/elasticsearch/commit/d81f012) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#374)
+- [109eb77](https://github.com/stashed/elasticsearch/commit/109eb77) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#365)
+- [05ba1a8](https://github.com/stashed/elasticsearch/commit/05ba1a8) [cherry-pick] Use restic 0.10.0 (#336) (#356)
+- [827473f](https://github.com/stashed/elasticsearch/commit/827473f) [cherry-pick] Update repository config (#346) (#348)
+- [6f0cde4](https://github.com/stashed/elasticsearch/commit/6f0cde4) [cherry-pick] Update repository config (#337) (#339)
+- [4793f49](https://github.com/stashed/elasticsearch/commit/4793f49) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#329)
+- [dd6b467](https://github.com/stashed/elasticsearch/commit/dd6b467) [cherry-pick] Publish docker images to ghcr.io (#318) (#320)
+- [21be63d](https://github.com/stashed/elasticsearch/commit/21be63d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#311)
+- [71db88d](https://github.com/stashed/elasticsearch/commit/71db88d) [cherry-pick] Update repository config (#300) (#302)
+- [270ffce](https://github.com/stashed/elasticsearch/commit/270ffce) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#293)
+- [3242dd7](https://github.com/stashed/elasticsearch/commit/3242dd7) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#284)
+- [1c629ba](https://github.com/stashed/elasticsearch/commit/1c629ba) [cherry-pick] Update repository config (#273) (#275)
+- [cea5a3d](https://github.com/stashed/elasticsearch/commit/cea5a3d) [cherry-pick] Update repository config (#264) (#266)
+
+
+### [6.3.0-v3](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v3)
+
+- [e811b13](https://github.com/stashed/elasticsearch/commit/e811b13) Prepare for release 6.3.0-v3 (#383)
+- [05dfd0c](https://github.com/stashed/elasticsearch/commit/05dfd0c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#375)
+- [4926a53](https://github.com/stashed/elasticsearch/commit/4926a53) Update Kubernetes v1.18.9 dependencies (#363) (#366)
+- [567890b](https://github.com/stashed/elasticsearch/commit/567890b) [cherry-pick] Use restic 0.10.0 (#336) (#357)
+- [759d6f1](https://github.com/stashed/elasticsearch/commit/759d6f1) [cherry-pick] Update repository config (#346) (#349)
+- [7585820](https://github.com/stashed/elasticsearch/commit/7585820) [cherry-pick] Update repository config (#337) (#340)
+- [aa7664a](https://github.com/stashed/elasticsearch/commit/aa7664a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#330)
+- [f076e39](https://github.com/stashed/elasticsearch/commit/f076e39) [cherry-pick] Publish docker images to ghcr.io (#318) (#321)
+- [40bbf42](https://github.com/stashed/elasticsearch/commit/40bbf42) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#312)
+- [73e96e2](https://github.com/stashed/elasticsearch/commit/73e96e2) [cherry-pick] Update repository config (#300) (#303)
+- [9026cba](https://github.com/stashed/elasticsearch/commit/9026cba) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#294)
+- [10a886d](https://github.com/stashed/elasticsearch/commit/10a886d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#285)
+- [c15b3f4](https://github.com/stashed/elasticsearch/commit/c15b3f4) [cherry-pick] Update repository config (#273) (#276)
+- [3ddc2ed](https://github.com/stashed/elasticsearch/commit/3ddc2ed) [cherry-pick] Update repository config (#264) (#267)
+
+
+### [6.4.0-v3](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v3)
+
+- [4ae7651](https://github.com/stashed/elasticsearch/commit/4ae7651) Prepare for release 6.4.0-v3 (#384)
+- [ceb1e31](https://github.com/stashed/elasticsearch/commit/ceb1e31) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#376)
+- [fd798f7](https://github.com/stashed/elasticsearch/commit/fd798f7) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#367)
+- [5f53d79](https://github.com/stashed/elasticsearch/commit/5f53d79) [cherry-pick] Use restic 0.10.0 (#336) (#358)
+- [06e35d1](https://github.com/stashed/elasticsearch/commit/06e35d1) [cherry-pick] Update repository config (#346) (#350)
+- [1867c78](https://github.com/stashed/elasticsearch/commit/1867c78) [cherry-pick] Update repository config (#337) (#341)
+- [5e24b84](https://github.com/stashed/elasticsearch/commit/5e24b84) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#331)
+- [4db1d24](https://github.com/stashed/elasticsearch/commit/4db1d24) [cherry-pick] Publish docker images to ghcr.io (#318) (#322)
+- [6e0b947](https://github.com/stashed/elasticsearch/commit/6e0b947) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#313)
+- [93daeb7](https://github.com/stashed/elasticsearch/commit/93daeb7) [cherry-pick] Update repository config (#300) (#304)
+- [6e5ab75](https://github.com/stashed/elasticsearch/commit/6e5ab75) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#295)
+- [606f4b1](https://github.com/stashed/elasticsearch/commit/606f4b1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#286)
+- [acee769](https://github.com/stashed/elasticsearch/commit/acee769) [cherry-pick] Update repository config (#273) (#277)
+- [637761f](https://github.com/stashed/elasticsearch/commit/637761f) [cherry-pick] Update repository config (#264) (#268)
+
+
+### [6.5.3-v3](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v3)
+
+- [2cb12c4](https://github.com/stashed/elasticsearch/commit/2cb12c4) Prepare for release 6.5.3-v3 (#385)
+- [b32658b](https://github.com/stashed/elasticsearch/commit/b32658b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#377)
+- [bd148dc](https://github.com/stashed/elasticsearch/commit/bd148dc) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#368)
+- [4377647](https://github.com/stashed/elasticsearch/commit/4377647) [cherry-pick] Use restic 0.10.0 (#336) (#359)
+- [3d78224](https://github.com/stashed/elasticsearch/commit/3d78224) [cherry-pick] Update repository config (#346) (#351)
+- [4722acb](https://github.com/stashed/elasticsearch/commit/4722acb) [cherry-pick] Update repository config (#337) (#342)
+- [f8a4dec](https://github.com/stashed/elasticsearch/commit/f8a4dec) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#332)
+- [b5d9a78](https://github.com/stashed/elasticsearch/commit/b5d9a78) [cherry-pick] Publish docker images to ghcr.io (#318) (#323)
+- [b5e6e6b](https://github.com/stashed/elasticsearch/commit/b5e6e6b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#314)
+- [a8cb4a7](https://github.com/stashed/elasticsearch/commit/a8cb4a7) [cherry-pick] Update repository config (#300) (#305)
+- [2d2506e](https://github.com/stashed/elasticsearch/commit/2d2506e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#296)
+- [6516f35](https://github.com/stashed/elasticsearch/commit/6516f35) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#287)
+- [e20572d](https://github.com/stashed/elasticsearch/commit/e20572d) [cherry-pick] Update repository config (#273) (#278)
+- [19ad8d4](https://github.com/stashed/elasticsearch/commit/19ad8d4) [cherry-pick] Update repository config (#264) (#269)
+
+
+### [6.8.0-v3](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v3)
+
+- [121adfc](https://github.com/stashed/elasticsearch/commit/121adfc) Prepare for release 6.8.0-v3 (#386)
+- [ac6b38c](https://github.com/stashed/elasticsearch/commit/ac6b38c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#378)
+- [e862e81](https://github.com/stashed/elasticsearch/commit/e862e81) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#369)
+- [6a6168a](https://github.com/stashed/elasticsearch/commit/6a6168a) [cherry-pick] Use restic 0.10.0 (#336) (#360)
+- [25dc520](https://github.com/stashed/elasticsearch/commit/25dc520) [cherry-pick] Update repository config (#346) (#352)
+- [df21854](https://github.com/stashed/elasticsearch/commit/df21854) [cherry-pick] Update repository config (#337) (#343)
+- [2245053](https://github.com/stashed/elasticsearch/commit/2245053) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#333)
+- [0edc5c0](https://github.com/stashed/elasticsearch/commit/0edc5c0) [cherry-pick] Publish docker images to ghcr.io (#318) (#324)
+- [e79e6e2](https://github.com/stashed/elasticsearch/commit/e79e6e2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#315)
+- [0d09a3f](https://github.com/stashed/elasticsearch/commit/0d09a3f) [cherry-pick] Update repository config (#300) (#306)
+- [e1610ff](https://github.com/stashed/elasticsearch/commit/e1610ff) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#297)
+- [6df475d](https://github.com/stashed/elasticsearch/commit/6df475d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#288)
+- [ac5361a](https://github.com/stashed/elasticsearch/commit/ac5361a) [cherry-pick] Update repository config (#273) (#279)
+- [ef7e1a4](https://github.com/stashed/elasticsearch/commit/ef7e1a4) [cherry-pick] Update repository config (#264) (#270)
+
+
+### [7.2.0-v3](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v3)
+
+- [827b433](https://github.com/stashed/elasticsearch/commit/827b433) Prepare for release 7.2.0-v3 (#387)
+- [e9af2ff](https://github.com/stashed/elasticsearch/commit/e9af2ff) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#379)
+- [32e7298](https://github.com/stashed/elasticsearch/commit/32e7298) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#370)
+- [ac680c9](https://github.com/stashed/elasticsearch/commit/ac680c9) [cherry-pick] Use restic 0.10.0 (#336) (#361)
+- [1f7630e](https://github.com/stashed/elasticsearch/commit/1f7630e) [cherry-pick] Update repository config (#346) (#353)
+- [882b6a3](https://github.com/stashed/elasticsearch/commit/882b6a3) [cherry-pick] Update repository config (#337) (#344)
+- [cc0183f](https://github.com/stashed/elasticsearch/commit/cc0183f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#334)
+- [d91b62c](https://github.com/stashed/elasticsearch/commit/d91b62c) [cherry-pick] Publish docker images to ghcr.io (#318) (#325)
+- [147f502](https://github.com/stashed/elasticsearch/commit/147f502) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#316)
+- [a69fe96](https://github.com/stashed/elasticsearch/commit/a69fe96) [cherry-pick] Update repository config (#300) (#307)
+- [5071afd](https://github.com/stashed/elasticsearch/commit/5071afd) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#298)
+- [d22dbda](https://github.com/stashed/elasticsearch/commit/d22dbda) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#289)
+- [16d53cc](https://github.com/stashed/elasticsearch/commit/16d53cc) [cherry-pick] Update repository config (#273) (#280)
+- [49b59ff](https://github.com/stashed/elasticsearch/commit/49b59ff) [cherry-pick] Update repository config (#264) (#271)
+
+
+### [7.3.2-v3](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v3)
+
+- [6186f5a](https://github.com/stashed/elasticsearch/commit/6186f5a) Prepare for release 7.3.2-v3 (#388)
+- [f77d957](https://github.com/stashed/elasticsearch/commit/f77d957) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#372) (#380)
+- [8be3043](https://github.com/stashed/elasticsearch/commit/8be3043) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#371)
+- [b5a442b](https://github.com/stashed/elasticsearch/commit/b5a442b) [cherry-pick] Use restic 0.10.0 (#336) (#362)
+- [06b10eb](https://github.com/stashed/elasticsearch/commit/06b10eb) [cherry-pick] Update repository config (#346) (#354)
+- [583623a](https://github.com/stashed/elasticsearch/commit/583623a) [cherry-pick] Update repository config (#337) (#345)
+- [ba82277](https://github.com/stashed/elasticsearch/commit/ba82277) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#327) (#335)
+- [b74b188](https://github.com/stashed/elasticsearch/commit/b74b188) [cherry-pick] Publish docker images to ghcr.io (#318) (#326)
+- [6005177](https://github.com/stashed/elasticsearch/commit/6005177) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#309) (#317)
+- [fae3083](https://github.com/stashed/elasticsearch/commit/fae3083) [cherry-pick] Update repository config (#300) (#308)
+- [9f418d2](https://github.com/stashed/elasticsearch/commit/9f418d2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#291) (#299)
+- [c14c36d](https://github.com/stashed/elasticsearch/commit/c14c36d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#282) (#290)
+- [f088a35](https://github.com/stashed/elasticsearch/commit/f088a35) [cherry-pick] Update repository config (#273) (#281)
+- [f12f5b6](https://github.com/stashed/elasticsearch/commit/f12f5b6) [cherry-pick] Update repository config (#264) (#272)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.3](https://github.com/stashed/installer/releases/tag/v0.11.3)
+
+- [5bc51f3](https://github.com/stashed/installer/commit/5bc51f3) Prepare for release v0.11.3 (#116)
+- [c22bc9a](https://github.com/stashed/installer/commit/c22bc9a) Create ServiceMonitor in the same namespace as the operator (#115)
+- [003bc08](https://github.com/stashed/installer/commit/003bc08) Update Kubernetes v1.18.9 dependencies (#114)
+- [33956a8](https://github.com/stashed/installer/commit/33956a8) Update repository config (#113)
+- [501c63e](https://github.com/stashed/installer/commit/501c63e) Update Kubernetes v1.18.9 dependencies (#112)
+- [ee560a1](https://github.com/stashed/installer/commit/ee560a1) Update repository config (#111)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v3](https://github.com/stashed/mongodb/releases/tag/3.4.17-v3)
+
+- [bfdd9972](https://github.com/stashed/mongodb/commit/bfdd9972) Prepare for release 3.4.17-v3 (#495)
+- [bda45485](https://github.com/stashed/mongodb/commit/bda45485) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#484)
+- [cb43638f](https://github.com/stashed/mongodb/commit/cb43638f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#472)
+- [c3adc69f](https://github.com/stashed/mongodb/commit/c3adc69f) [cherry-pick] Use restic 0.10.0 (#435) (#460)
+- [d768e676](https://github.com/stashed/mongodb/commit/d768e676) [cherry-pick] Update repository config (#448) (#449)
+- [9453ae69](https://github.com/stashed/mongodb/commit/9453ae69) [cherry-pick] Update repository config (#436) (#437)
+- [ed7222d7](https://github.com/stashed/mongodb/commit/ed7222d7) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#424)
+- [cf6ffd6e](https://github.com/stashed/mongodb/commit/cf6ffd6e) [cherry-pick] Publish docker images to ghcr.io (#411) (#412)
+- [8e996ed8](https://github.com/stashed/mongodb/commit/8e996ed8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#400)
+- [0d9a59d8](https://github.com/stashed/mongodb/commit/0d9a59d8) [cherry-pick] Update repository config (#387) (#388)
+- [277a9390](https://github.com/stashed/mongodb/commit/277a9390) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#376)
+- [f06e0951](https://github.com/stashed/mongodb/commit/f06e0951) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#364)
+- [b00216d6](https://github.com/stashed/mongodb/commit/b00216d6) [cherry-pick] Update repository config (#351) (#352)
+- [ab7f8f0c](https://github.com/stashed/mongodb/commit/ab7f8f0c) [cherry-pick] Update repository config (#339) (#340)
+
+
+### [3.4.22-v3](https://github.com/stashed/mongodb/releases/tag/3.4.22-v3)
+
+- [9255e7b5](https://github.com/stashed/mongodb/commit/9255e7b5) Prepare for release 3.4.22-v3 (#496)
+- [89c73b0b](https://github.com/stashed/mongodb/commit/89c73b0b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#485)
+- [ee9a261e](https://github.com/stashed/mongodb/commit/ee9a261e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#473)
+- [6117deca](https://github.com/stashed/mongodb/commit/6117deca) [cherry-pick] Use restic 0.10.0 (#435) (#461)
+- [bee02903](https://github.com/stashed/mongodb/commit/bee02903) [cherry-pick] Update repository config (#448) (#450)
+- [c7711aec](https://github.com/stashed/mongodb/commit/c7711aec) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#425)
+- [f7a2a2cb](https://github.com/stashed/mongodb/commit/f7a2a2cb) [cherry-pick] Update repository config (#436) (#438)
+- [d4e1aef8](https://github.com/stashed/mongodb/commit/d4e1aef8) [cherry-pick] Publish docker images to ghcr.io (#411) (#413)
+- [2aceb1cb](https://github.com/stashed/mongodb/commit/2aceb1cb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#401)
+- [3b5521bd](https://github.com/stashed/mongodb/commit/3b5521bd) [cherry-pick] Update repository config (#387) (#389)
+- [29da42f2](https://github.com/stashed/mongodb/commit/29da42f2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#377)
+- [739876b8](https://github.com/stashed/mongodb/commit/739876b8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#365)
+- [e7ee7aca](https://github.com/stashed/mongodb/commit/e7ee7aca) [cherry-pick] Update repository config (#351) (#353)
+- [2c4f42bd](https://github.com/stashed/mongodb/commit/2c4f42bd) [cherry-pick] Update repository config (#339) (#341)
+
+
+### [3.6.8-v3](https://github.com/stashed/mongodb/releases/tag/3.6.8-v3)
+
+- [92d7be92](https://github.com/stashed/mongodb/commit/92d7be92) Prepare for release 3.6.8-v3 (#498)
+- [51f20d93](https://github.com/stashed/mongodb/commit/51f20d93) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#487)
+- [06a92af9](https://github.com/stashed/mongodb/commit/06a92af9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#475)
+- [dbabdcdd](https://github.com/stashed/mongodb/commit/dbabdcdd) [cherry-pick] Use restic 0.10.0 (#435) (#463)
+- [4cd8e248](https://github.com/stashed/mongodb/commit/4cd8e248) [cherry-pick] Update repository config (#448) (#452)
+- [e59cad4a](https://github.com/stashed/mongodb/commit/e59cad4a) [cherry-pick] Update repository config (#436) (#440)
+- [e793b48d](https://github.com/stashed/mongodb/commit/e793b48d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#427)
+- [726f238c](https://github.com/stashed/mongodb/commit/726f238c) [cherry-pick] Publish docker images to ghcr.io (#411) (#415)
+- [15a96fd5](https://github.com/stashed/mongodb/commit/15a96fd5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#403)
+- [742141e4](https://github.com/stashed/mongodb/commit/742141e4) [cherry-pick] Update repository config (#387) (#391)
+- [dc32bd9f](https://github.com/stashed/mongodb/commit/dc32bd9f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#379)
+- [d419ad0f](https://github.com/stashed/mongodb/commit/d419ad0f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#367)
+- [0293db64](https://github.com/stashed/mongodb/commit/0293db64) [cherry-pick] Update repository config (#351) (#355)
+- [9bb9955a](https://github.com/stashed/mongodb/commit/9bb9955a) [cherry-pick] Update repository config (#339) (#343)
+
+
+### [3.6.13-v3](https://github.com/stashed/mongodb/releases/tag/3.6.13-v3)
+
+- [68276550](https://github.com/stashed/mongodb/commit/68276550) Prepare for release 3.6.13-v3 (#497)
+- [f336cc12](https://github.com/stashed/mongodb/commit/f336cc12) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#486)
+- [21c24e47](https://github.com/stashed/mongodb/commit/21c24e47) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#474)
+- [e7b8dfa3](https://github.com/stashed/mongodb/commit/e7b8dfa3) [cherry-pick] Use restic 0.10.0 (#435) (#462)
+- [98f15137](https://github.com/stashed/mongodb/commit/98f15137) [cherry-pick] Update repository config (#448) (#451)
+- [e2a1df01](https://github.com/stashed/mongodb/commit/e2a1df01) [cherry-pick] Update repository config (#436) (#439)
+- [6107c923](https://github.com/stashed/mongodb/commit/6107c923) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#426)
+- [02466320](https://github.com/stashed/mongodb/commit/02466320) [cherry-pick] Publish docker images to ghcr.io (#411) (#414)
+- [6f243714](https://github.com/stashed/mongodb/commit/6f243714) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#402)
+- [da2c0f8a](https://github.com/stashed/mongodb/commit/da2c0f8a) [cherry-pick] Update repository config (#387) (#390)
+- [914652f8](https://github.com/stashed/mongodb/commit/914652f8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#378)
+- [d28b54dc](https://github.com/stashed/mongodb/commit/d28b54dc) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#366)
+- [21f8b4e4](https://github.com/stashed/mongodb/commit/21f8b4e4) [cherry-pick] Update repository config (#351) (#354)
+- [c3d7cc46](https://github.com/stashed/mongodb/commit/c3d7cc46) [cherry-pick] Update repository config (#339) (#342)
+
+
+### [4.0.3-v3](https://github.com/stashed/mongodb/releases/tag/4.0.3-v3)
+
+- [37ee960a](https://github.com/stashed/mongodb/commit/37ee960a) Prepare for release 4.0.3-v3 (#500)
+- [dad34b57](https://github.com/stashed/mongodb/commit/dad34b57) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#489)
+- [65073380](https://github.com/stashed/mongodb/commit/65073380) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#477)
+- [9a3020cd](https://github.com/stashed/mongodb/commit/9a3020cd) [cherry-pick] Use restic 0.10.0 (#435) (#465)
+- [00c89fbe](https://github.com/stashed/mongodb/commit/00c89fbe) [cherry-pick] Update repository config (#448) (#454)
+- [f49d19fb](https://github.com/stashed/mongodb/commit/f49d19fb) [cherry-pick] Update repository config (#436) (#442)
+- [0b0da5eb](https://github.com/stashed/mongodb/commit/0b0da5eb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#429)
+- [ea1769a1](https://github.com/stashed/mongodb/commit/ea1769a1) [cherry-pick] Publish docker images to ghcr.io (#411) (#417)
+- [65c185b6](https://github.com/stashed/mongodb/commit/65c185b6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#405)
+- [091ff716](https://github.com/stashed/mongodb/commit/091ff716) [cherry-pick] Update repository config (#387) (#393)
+- [d9c42eba](https://github.com/stashed/mongodb/commit/d9c42eba) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#381)
+- [0940ece2](https://github.com/stashed/mongodb/commit/0940ece2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#369)
+- [b64ee104](https://github.com/stashed/mongodb/commit/b64ee104) [cherry-pick] Update repository config (#351) (#357)
+- [db6b3d2b](https://github.com/stashed/mongodb/commit/db6b3d2b) [cherry-pick] Update repository config (#339) (#345)
+
+
+### [4.0.5-v3](https://github.com/stashed/mongodb/releases/tag/4.0.5-v3)
+
+- [90d2a873](https://github.com/stashed/mongodb/commit/90d2a873) Prepare for release 4.0.5-v3 (#501)
+- [88752110](https://github.com/stashed/mongodb/commit/88752110) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#490)
+- [79b382fb](https://github.com/stashed/mongodb/commit/79b382fb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#478)
+- [337faf82](https://github.com/stashed/mongodb/commit/337faf82) [cherry-pick] Use restic 0.10.0 (#435) (#466)
+- [6d9af4e6](https://github.com/stashed/mongodb/commit/6d9af4e6) [cherry-pick] Update repository config (#448) (#455)
+- [74efde48](https://github.com/stashed/mongodb/commit/74efde48) [cherry-pick] Update repository config (#436) (#443)
+- [c97e5478](https://github.com/stashed/mongodb/commit/c97e5478) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#430)
+- [beeb45d5](https://github.com/stashed/mongodb/commit/beeb45d5) [cherry-pick] Publish docker images to ghcr.io (#411) (#418)
+- [da3d70b2](https://github.com/stashed/mongodb/commit/da3d70b2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#406)
+- [d410f276](https://github.com/stashed/mongodb/commit/d410f276) [cherry-pick] Update repository config (#387) (#394)
+- [35f0003b](https://github.com/stashed/mongodb/commit/35f0003b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#382)
+- [2acd384e](https://github.com/stashed/mongodb/commit/2acd384e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#370)
+- [aeec3423](https://github.com/stashed/mongodb/commit/aeec3423) [cherry-pick] Update repository config (#351) (#358)
+- [825f4c0e](https://github.com/stashed/mongodb/commit/825f4c0e) [cherry-pick] Update repository config (#339) (#346)
+
+
+### [4.0.11-v3](https://github.com/stashed/mongodb/releases/tag/4.0.11-v3)
+
+- [54a9e1ce](https://github.com/stashed/mongodb/commit/54a9e1ce) Prepare for release 4.0.11-v3 (#499)
+- [bfee3d7f](https://github.com/stashed/mongodb/commit/bfee3d7f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#488)
+- [72e304a2](https://github.com/stashed/mongodb/commit/72e304a2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#476)
+- [bd3b7d54](https://github.com/stashed/mongodb/commit/bd3b7d54) [cherry-pick] Use restic 0.10.0 (#435) (#464)
+- [958a2347](https://github.com/stashed/mongodb/commit/958a2347) [cherry-pick] Update repository config (#448) (#453)
+- [7d7a9059](https://github.com/stashed/mongodb/commit/7d7a9059) [cherry-pick] Update repository config (#436) (#441)
+- [a175a0c3](https://github.com/stashed/mongodb/commit/a175a0c3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#428)
+- [0c2f9839](https://github.com/stashed/mongodb/commit/0c2f9839) [cherry-pick] Publish docker images to ghcr.io (#411) (#416)
+- [4bb8bc3c](https://github.com/stashed/mongodb/commit/4bb8bc3c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#404)
+- [7ec86ea4](https://github.com/stashed/mongodb/commit/7ec86ea4) [cherry-pick] Update repository config (#387) (#392)
+- [f53bcb00](https://github.com/stashed/mongodb/commit/f53bcb00) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#380)
+- [4329109b](https://github.com/stashed/mongodb/commit/4329109b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#368)
+- [c70b759e](https://github.com/stashed/mongodb/commit/c70b759e) [cherry-pick] Update repository config (#351) (#356)
+- [903ddcc7](https://github.com/stashed/mongodb/commit/903ddcc7) [cherry-pick] Update repository config (#339) (#344)
+
+
+### [4.1.4-v3](https://github.com/stashed/mongodb/releases/tag/4.1.4-v3)
+
+- [f613ba52](https://github.com/stashed/mongodb/commit/f613ba52) Prepare for release 4.1.4-v3 (#503)
+- [f6ebfa88](https://github.com/stashed/mongodb/commit/f6ebfa88) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#492)
+- [10d6f4db](https://github.com/stashed/mongodb/commit/10d6f4db) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#480)
+- [4f317902](https://github.com/stashed/mongodb/commit/4f317902) [cherry-pick] Use restic 0.10.0 (#435) (#468)
+- [700b1a17](https://github.com/stashed/mongodb/commit/700b1a17) [cherry-pick] Update repository config (#448) (#457)
+- [99681cd5](https://github.com/stashed/mongodb/commit/99681cd5) [cherry-pick] Update repository config (#436) (#445)
+- [5b571e5d](https://github.com/stashed/mongodb/commit/5b571e5d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#432)
+- [056f45d2](https://github.com/stashed/mongodb/commit/056f45d2) [cherry-pick] Publish docker images to ghcr.io (#411) (#420)
+- [6a983254](https://github.com/stashed/mongodb/commit/6a983254) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#408)
+- [0dbf712c](https://github.com/stashed/mongodb/commit/0dbf712c) [cherry-pick] Update repository config (#387) (#396)
+- [8adbb6fe](https://github.com/stashed/mongodb/commit/8adbb6fe) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#384)
+- [0d7db778](https://github.com/stashed/mongodb/commit/0d7db778) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#372)
+- [e0da102b](https://github.com/stashed/mongodb/commit/e0da102b) [cherry-pick] Update repository config (#351) (#360)
+- [37a2bbc2](https://github.com/stashed/mongodb/commit/37a2bbc2) [cherry-pick] Update repository config (#339) (#348)
+
+
+### [4.1.7-v3](https://github.com/stashed/mongodb/releases/tag/4.1.7-v3)
+
+- [5dc82c7f](https://github.com/stashed/mongodb/commit/5dc82c7f) Prepare for release 4.1.7-v3 (#504)
+- [e2263058](https://github.com/stashed/mongodb/commit/e2263058) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#493)
+- [5620f9d1](https://github.com/stashed/mongodb/commit/5620f9d1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#481)
+- [5d00564b](https://github.com/stashed/mongodb/commit/5d00564b) [cherry-pick] Use restic 0.10.0 (#435) (#469)
+- [7765d8ad](https://github.com/stashed/mongodb/commit/7765d8ad) [cherry-pick] Update repository config (#448) (#458)
+- [07b43086](https://github.com/stashed/mongodb/commit/07b43086) [cherry-pick] Update repository config (#436) (#446)
+- [18e0c740](https://github.com/stashed/mongodb/commit/18e0c740) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#433)
+- [ec344370](https://github.com/stashed/mongodb/commit/ec344370) [cherry-pick] Publish docker images to ghcr.io (#411) (#421)
+- [a5080eee](https://github.com/stashed/mongodb/commit/a5080eee) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#409)
+- [ffc08e7d](https://github.com/stashed/mongodb/commit/ffc08e7d) [cherry-pick] Update repository config (#387) (#397)
+- [05e7d62d](https://github.com/stashed/mongodb/commit/05e7d62d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#385)
+- [17c7be7f](https://github.com/stashed/mongodb/commit/17c7be7f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#373)
+- [1f3a9e97](https://github.com/stashed/mongodb/commit/1f3a9e97) [cherry-pick] Update repository config (#351) (#361)
+- [c1606922](https://github.com/stashed/mongodb/commit/c1606922) [cherry-pick] Update repository config (#339) (#349)
+
+
+### [4.1.13-v3](https://github.com/stashed/mongodb/releases/tag/4.1.13-v3)
+
+- [0894946b](https://github.com/stashed/mongodb/commit/0894946b) Prepare for release 4.1.13-v3 (#502)
+- [c314b3ff](https://github.com/stashed/mongodb/commit/c314b3ff) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#491)
+- [63228a0e](https://github.com/stashed/mongodb/commit/63228a0e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#479)
+- [69573d31](https://github.com/stashed/mongodb/commit/69573d31) [cherry-pick] Use restic 0.10.0 (#435) (#467)
+- [d4a1fa82](https://github.com/stashed/mongodb/commit/d4a1fa82) [cherry-pick] Update repository config (#448) (#456)
+- [af592612](https://github.com/stashed/mongodb/commit/af592612) [cherry-pick] Update repository config (#436) (#444)
+- [4ab1a722](https://github.com/stashed/mongodb/commit/4ab1a722) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#431)
+- [0c9f73d1](https://github.com/stashed/mongodb/commit/0c9f73d1) [cherry-pick] Publish docker images to ghcr.io (#411) (#419)
+- [4b27ac15](https://github.com/stashed/mongodb/commit/4b27ac15) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#407)
+- [029af23f](https://github.com/stashed/mongodb/commit/029af23f) [cherry-pick] Update repository config (#387) (#395)
+- [f177f223](https://github.com/stashed/mongodb/commit/f177f223) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#383)
+- [5158cad9](https://github.com/stashed/mongodb/commit/5158cad9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#371)
+- [3b549e4d](https://github.com/stashed/mongodb/commit/3b549e4d) [cherry-pick] Update repository config (#351) (#359)
+- [d4c9d08b](https://github.com/stashed/mongodb/commit/d4c9d08b) [cherry-pick] Update repository config (#339) (#347)
+
+
+### [4.2.3-v3](https://github.com/stashed/mongodb/releases/tag/4.2.3-v3)
+
+- [7d17e60d](https://github.com/stashed/mongodb/commit/7d17e60d) Prepare for release 4.2.3-v3 (#505)
+- [2447962e](https://github.com/stashed/mongodb/commit/2447962e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#483) (#494)
+- [096c0d3c](https://github.com/stashed/mongodb/commit/096c0d3c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#471) (#482)
+- [0e167aa8](https://github.com/stashed/mongodb/commit/0e167aa8) [cherry-pick] Use restic 0.10.0 (#435) (#470)
+- [7e234b8f](https://github.com/stashed/mongodb/commit/7e234b8f) [cherry-pick] Update repository config (#448) (#459)
+- [e9be7ed0](https://github.com/stashed/mongodb/commit/e9be7ed0) [cherry-pick] Update repository config (#436) (#447)
+- [84a983b8](https://github.com/stashed/mongodb/commit/84a983b8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#423) (#434)
+- [31f3c2ca](https://github.com/stashed/mongodb/commit/31f3c2ca) [cherry-pick] Publish docker images to ghcr.io (#411) (#422)
+- [ffb3f579](https://github.com/stashed/mongodb/commit/ffb3f579) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#399) (#410)
+- [018f5609](https://github.com/stashed/mongodb/commit/018f5609) [cherry-pick] Update repository config (#387) (#398)
+- [2b32ca70](https://github.com/stashed/mongodb/commit/2b32ca70) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#375) (#386)
+- [f4a3ffd1](https://github.com/stashed/mongodb/commit/f4a3ffd1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#363) (#374)
+- [5bf63e9e](https://github.com/stashed/mongodb/commit/5bf63e9e) [cherry-pick] Update repository config (#351) (#362)
+- [04de4a95](https://github.com/stashed/mongodb/commit/04de4a95) [cherry-pick] Update repository config (#339) (#350)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v3](https://github.com/stashed/mysql/releases/tag/5.7.25-v3)
+
+- [8fffb58](https://github.com/stashed/mysql/commit/8fffb58) Prepare for release 5.7.25-v3 (#183)
+- [0e93a3e](https://github.com/stashed/mysql/commit/0e93a3e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#179) (#180)
+- [01e10af](https://github.com/stashed/mysql/commit/01e10af) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#175) (#176)
+- [f781cd8](https://github.com/stashed/mysql/commit/f781cd8) [cherry-pick] Use restic 0.10.0 (#163) (#172)
+- [0a0711d](https://github.com/stashed/mysql/commit/0a0711d) [cherry-pick] Update repository config (#168) (#169)
+- [97afbc9](https://github.com/stashed/mysql/commit/97afbc9) [cherry-pick] Update repository config (#164) (#165)
+- [dc985b5](https://github.com/stashed/mysql/commit/dc985b5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#159) (#160)
+- [d1cddb5](https://github.com/stashed/mysql/commit/d1cddb5) [cherry-pick] Publish docker images to ghcr.io (#155) (#156)
+- [ac6abcb](https://github.com/stashed/mysql/commit/ac6abcb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#151) (#152)
+- [303e216](https://github.com/stashed/mysql/commit/303e216) [cherry-pick] Update repository config (#147) (#148)
+- [a24b811](https://github.com/stashed/mysql/commit/a24b811) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#143) (#144)
+- [3601274](https://github.com/stashed/mysql/commit/3601274) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#139) (#140)
+- [f3a52c3](https://github.com/stashed/mysql/commit/f3a52c3) [cherry-pick] Update repository config (#135) (#136)
+- [3432c46](https://github.com/stashed/mysql/commit/3432c46) [cherry-pick] Update repository config (#131) (#132)
+
+
+### [8.0.3-v3](https://github.com/stashed/mysql/releases/tag/8.0.3-v3)
+
+- [07d878c](https://github.com/stashed/mysql/commit/07d878c) Prepare for release 8.0.3-v3 (#185)
+- [dfc1eb2](https://github.com/stashed/mysql/commit/dfc1eb2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#179) (#182)
+- [6aa4e78](https://github.com/stashed/mysql/commit/6aa4e78) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#175) (#178)
+- [b6c8270](https://github.com/stashed/mysql/commit/b6c8270) [cherry-pick] Use restic 0.10.0 (#163) (#174)
+- [02e5cac](https://github.com/stashed/mysql/commit/02e5cac) [cherry-pick] Update repository config (#168) (#171)
+- [a31cca9](https://github.com/stashed/mysql/commit/a31cca9) [cherry-pick] Update repository config (#164) (#167)
+- [035be38](https://github.com/stashed/mysql/commit/035be38) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#159) (#162)
+- [5befb61](https://github.com/stashed/mysql/commit/5befb61) [cherry-pick] Publish docker images to ghcr.io (#155) (#158)
+- [faaceb5](https://github.com/stashed/mysql/commit/faaceb5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#151) (#154)
+- [e749438](https://github.com/stashed/mysql/commit/e749438) [cherry-pick] Update repository config (#147) (#150)
+- [abaf351](https://github.com/stashed/mysql/commit/abaf351) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#143) (#146)
+- [e6e71d1](https://github.com/stashed/mysql/commit/e6e71d1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#139) (#142)
+- [06a5e8c](https://github.com/stashed/mysql/commit/06a5e8c) [cherry-pick] Update repository config (#135) (#138)
+- [9764674](https://github.com/stashed/mysql/commit/9764674) [cherry-pick] Update repository config (#131) (#134)
+
+
+### [8.0.14-v3](https://github.com/stashed/mysql/releases/tag/8.0.14-v3)
+
+- [c6bebde](https://github.com/stashed/mysql/commit/c6bebde) Prepare for release 8.0.14-v3 (#184)
+- [5310d2b](https://github.com/stashed/mysql/commit/5310d2b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#179) (#181)
+- [995d648](https://github.com/stashed/mysql/commit/995d648) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#175) (#177)
+- [815641c](https://github.com/stashed/mysql/commit/815641c) [cherry-pick] Use restic 0.10.0 (#163) (#173)
+- [1935314](https://github.com/stashed/mysql/commit/1935314) [cherry-pick] Update repository config (#168) (#170)
+- [9f92086](https://github.com/stashed/mysql/commit/9f92086) [cherry-pick] Update repository config (#164) (#166)
+- [1c1676e](https://github.com/stashed/mysql/commit/1c1676e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#159) (#161)
+- [4ea5a3a](https://github.com/stashed/mysql/commit/4ea5a3a) [cherry-pick] Publish docker images to ghcr.io (#155) (#157)
+- [75c3e72](https://github.com/stashed/mysql/commit/75c3e72) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#151) (#153)
+- [4c59612](https://github.com/stashed/mysql/commit/4c59612) [cherry-pick] Update repository config (#147) (#149)
+- [a452552](https://github.com/stashed/mysql/commit/a452552) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#143) (#145)
+- [0ec08a0](https://github.com/stashed/mysql/commit/0ec08a0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#139) (#141)
+- [33bb32c](https://github.com/stashed/mysql/commit/33bb32c) [cherry-pick] Update repository config (#135) (#137)
+- [406ff18](https://github.com/stashed/mysql/commit/406ff18) [cherry-pick] Update repository config (#131) (#133)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v3](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v3)
+
+- [6ec4bc6](https://github.com/stashed/percona-xtradb/commit/6ec4bc6) Prepare for release 5.7-v3 (#95)
+- [9220f29](https://github.com/stashed/percona-xtradb/commit/9220f29) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#93) (#94)
+- [c4bda0f](https://github.com/stashed/percona-xtradb/commit/c4bda0f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#91) (#92)
+- [1c5d488](https://github.com/stashed/percona-xtradb/commit/1c5d488) [cherry-pick] Use restic 0.10.0 (#85) (#90)
+- [90ba980](https://github.com/stashed/percona-xtradb/commit/90ba980) [cherry-pick] Update repository config (#88) (#89)
+- [dc078b6](https://github.com/stashed/percona-xtradb/commit/dc078b6) [cherry-pick] Update repository config (#86) (#87)
+- [c549a51](https://github.com/stashed/percona-xtradb/commit/c549a51) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#83) (#84)
+- [f885a87](https://github.com/stashed/percona-xtradb/commit/f885a87) [cherry-pick] Publish docker images to ghcr.io (#81) (#82)
+- [055383c](https://github.com/stashed/percona-xtradb/commit/055383c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#79) (#80)
+- [360e25e](https://github.com/stashed/percona-xtradb/commit/360e25e) [cherry-pick] Update repository config (#77) (#78)
+- [7462c45](https://github.com/stashed/percona-xtradb/commit/7462c45) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#75) (#76)
+- [3a85cc3](https://github.com/stashed/percona-xtradb/commit/3a85cc3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#73) (#74)
+- [079d748](https://github.com/stashed/percona-xtradb/commit/079d748) [cherry-pick] Update repository config (#71) (#72)
+- [7e96bac](https://github.com/stashed/percona-xtradb/commit/7e96bac) [cherry-pick] Update repository config (#69) (#70)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v1](https://github.com/stashed/postgres/releases/tag/9.6.19-v1)
+
+- [3ecdb2c](https://github.com/stashed/postgres/commit/3ecdb2c) Prepare for release 9.6.19-v1 (#343)
+- [0207e35](https://github.com/stashed/postgres/commit/0207e35) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#330) (#339)
+- [93a38c4](https://github.com/stashed/postgres/commit/93a38c4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#320) (#329)
+- [983a662](https://github.com/stashed/postgres/commit/983a662) [cherry-pick] Use restic 0.10.0 (#290) (#319)
+- [77e72e0](https://github.com/stashed/postgres/commit/77e72e0) [cherry-pick] Update repository config (#301) (#310)
+- [52e2c2b](https://github.com/stashed/postgres/commit/52e2c2b) [cherry-pick] Update repository config (#291) (#300)
+- [57fb376](https://github.com/stashed/postgres/commit/57fb376) [cherry-pick] Publish docker images to ghcr.io (#280) (#289)
+- [edb421c](https://github.com/stashed/postgres/commit/edb421c) [cherry-pick] Use username/password as keys in Postgres secret (#270) (#279)
+- [16746e3](https://github.com/stashed/postgres/commit/16746e3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#260) (#269)
+- [2516277](https://github.com/stashed/postgres/commit/2516277) [cherry-pick] Update repository config (#250) (#259)
+- [715c9ce](https://github.com/stashed/postgres/commit/715c9ce) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#240) (#249)
+- [11c7486](https://github.com/stashed/postgres/commit/11c7486) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#230) (#239)
+- [3f6f398](https://github.com/stashed/postgres/commit/3f6f398) [cherry-pick] Update repository config (#220) (#229)
+- [8248525](https://github.com/stashed/postgres/commit/8248525) [cherry-pick] Update repository config (#210) (#219)
+
+
+### [10.14.0-v1](https://github.com/stashed/postgres/releases/tag/10.14.0-v1)
+
+- [bc318b1](https://github.com/stashed/postgres/commit/bc318b1) Prepare for release 10.14.0-v1 (#340)
+- [ed3ba4d](https://github.com/stashed/postgres/commit/ed3ba4d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#330) (#331)
+- [475f8df](https://github.com/stashed/postgres/commit/475f8df) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#320) (#321)
+- [dc58fd7](https://github.com/stashed/postgres/commit/dc58fd7) [cherry-pick] Use restic 0.10.0 (#290) (#311)
+- [e15907e](https://github.com/stashed/postgres/commit/e15907e) [cherry-pick] Update repository config (#301) (#302)
+- [6d00f88](https://github.com/stashed/postgres/commit/6d00f88) [cherry-pick] Update repository config (#291) (#292)
+- [d1d0d7f](https://github.com/stashed/postgres/commit/d1d0d7f) [cherry-pick] Publish docker images to ghcr.io (#280) (#281)
+- [50d9b08](https://github.com/stashed/postgres/commit/50d9b08) [cherry-pick] Use username/password as keys in Postgres secret (#270) (#271)
+- [f583dac](https://github.com/stashed/postgres/commit/f583dac) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#260) (#261)
+- [e98ef32](https://github.com/stashed/postgres/commit/e98ef32) [cherry-pick] Update repository config (#250) (#251)
+- [7fc8ed4](https://github.com/stashed/postgres/commit/7fc8ed4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#240) (#241)
+- [a915d80](https://github.com/stashed/postgres/commit/a915d80) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#230) (#231)
+- [e057b5b](https://github.com/stashed/postgres/commit/e057b5b) [cherry-pick] Update repository config (#220) (#221)
+- [9c4f01e](https://github.com/stashed/postgres/commit/9c4f01e) [cherry-pick] Update repository config (#210) (#211)
+
+
+### [11.9.0-v1](https://github.com/stashed/postgres/releases/tag/11.9.0-v1)
+
+- [f6ceacc](https://github.com/stashed/postgres/commit/f6ceacc) Prepare for release 11.9.0-v1 (#341)
+- [07763d6](https://github.com/stashed/postgres/commit/07763d6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#330) (#336)
+- [8727e7f](https://github.com/stashed/postgres/commit/8727e7f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#320) (#326)
+- [70ec71b](https://github.com/stashed/postgres/commit/70ec71b) [cherry-pick] Use restic 0.10.0 (#290) (#316)
+- [f0353c4](https://github.com/stashed/postgres/commit/f0353c4) [cherry-pick] Update repository config (#301) (#307)
+- [ed3a066](https://github.com/stashed/postgres/commit/ed3a066) [cherry-pick] Update repository config (#291) (#297)
+- [84d9e99](https://github.com/stashed/postgres/commit/84d9e99) [cherry-pick] Publish docker images to ghcr.io (#280) (#286)
+- [8179b10](https://github.com/stashed/postgres/commit/8179b10) [cherry-pick] Use username/password as keys in Postgres secret (#270) (#276)
+- [afe907a](https://github.com/stashed/postgres/commit/afe907a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#260) (#266)
+- [e983f84](https://github.com/stashed/postgres/commit/e983f84) [cherry-pick] Update repository config (#250) (#256)
+- [8c56fc1](https://github.com/stashed/postgres/commit/8c56fc1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#240) (#246)
+- [af1b43a](https://github.com/stashed/postgres/commit/af1b43a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#230) (#236)
+- [c46c99c](https://github.com/stashed/postgres/commit/c46c99c) [cherry-pick] Update repository config (#220) (#226)
+- [d5bfd9a](https://github.com/stashed/postgres/commit/d5bfd9a) [cherry-pick] Update repository config (#210) (#216)
+
+
+### [12.4.0-v1](https://github.com/stashed/postgres/releases/tag/12.4.0-v1)
+
+- [03355e3](https://github.com/stashed/postgres/commit/03355e3) Prepare for release 12.4.0-v1 (#342)
+- [f686d3d](https://github.com/stashed/postgres/commit/f686d3d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#330) (#337)
+- [223e0df](https://github.com/stashed/postgres/commit/223e0df) Update Kubernetes v1.18.9 dependencies (#320) (#327)
+- [c429d54](https://github.com/stashed/postgres/commit/c429d54) [cherry-pick] Use restic 0.10.0 (#290) (#317)
+- [317e415](https://github.com/stashed/postgres/commit/317e415) [cherry-pick] Update repository config (#301) (#308)
+- [2050c60](https://github.com/stashed/postgres/commit/2050c60) [cherry-pick] Update repository config (#291) (#298)
+- [8e7195e](https://github.com/stashed/postgres/commit/8e7195e) [cherry-pick] Publish docker images to ghcr.io (#280) (#287)
+- [d4f998c](https://github.com/stashed/postgres/commit/d4f998c) [cherry-pick] Use username/password as keys in Postgres secret (#270) (#277)
+- [a6c0345](https://github.com/stashed/postgres/commit/a6c0345) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#260) (#267)
+- [14024cc](https://github.com/stashed/postgres/commit/14024cc) [cherry-pick] Update repository config (#250) (#257)
+- [0363817](https://github.com/stashed/postgres/commit/0363817) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#240) (#247)
+- [7c742dc](https://github.com/stashed/postgres/commit/7c742dc) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#230) (#237)
+- [2cd3054](https://github.com/stashed/postgres/commit/2cd3054) [cherry-pick] Update repository config (#220) (#227)
+- [bbc34f5](https://github.com/stashed/postgres/commit/bbc34f5) [cherry-pick] Update repository config (#210) (#217)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.3](https://github.com/stashed/stash/releases/tag/v0.11.3)
+
+- [ab872821](https://github.com/stashed/stash/commit/ab872821) Prepare for release v0.11.3 (#1233)
+- [d64e9c1e](https://github.com/stashed/stash/commit/d64e9c1e) Pass offshoot labels to CronJob pods (#1232)
+- [40a233c2](https://github.com/stashed/stash/commit/40a233c2) Use BackoffLimit=0 for backup/restore job (#1216)
+- [a206a9ce](https://github.com/stashed/stash/commit/a206a9ce) Fix ClusterRoleBinding name conflict (#1231)
+- [a5ec7562](https://github.com/stashed/stash/commit/a5ec7562) Update Kubernetes v1.18.9 dependencies (#1230)
+- [8cf2e397](https://github.com/stashed/stash/commit/8cf2e397) Update Kubernetes v1.18.9 dependencies (#1228)
+- [a4c19094](https://github.com/stashed/stash/commit/a4c19094) Use restic 0.10.0 (#1223)
+- [fad497a6](https://github.com/stashed/stash/commit/fad497a6) Update repository config (#1226)
+- [80933bde](https://github.com/stashed/stash/commit/80933bde) Update repository config (#1225)
+- [7974b478](https://github.com/stashed/stash/commit/7974b478) Update repository config (#1224)
+- [c7497ebc](https://github.com/stashed/stash/commit/c7497ebc) Update Kubernetes v1.18.9 dependencies (#1222)
+- [0280f08d](https://github.com/stashed/stash/commit/0280f08d) Publish docker images to ghcr.io (#1221)
+- [bf1df8d5](https://github.com/stashed/stash/commit/bf1df8d5) Update Kubernetes v1.18.9 dependencies (#1220)
+- [d2e86335](https://github.com/stashed/stash/commit/d2e86335) Update repository config (#1219)
+- [d8ccdd2b](https://github.com/stashed/stash/commit/d8ccdd2b) Update Kubernetes v1.18.9 dependencies (#1218)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/16
Signed-off-by: 1gtm <1gtm@appscode.com>