### PR TITLE
Prepare for release v2020.10.30

### DIFF
--- a/docs/CHANGELOG-v2020.10.30.md
+++ b/docs/CHANGELOG-v2020.10.30.md
@@ -1,0 +1,70 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.10.30
+    name: Changelog-v2020.10.30
+    parent: welcome
+    weight: 20201030
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.10.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.10.30/
+---
+
+# Stash v2020.10.30 (2020-10-30)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.5](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.5)
+
+- [3f46fc61](https://github.com/appscode/stash-enterprise/commit/3f46fc61) Prepare for release v0.11.5 (#47)
+- [b7dd790e](https://github.com/appscode/stash-enterprise/commit/b7dd790e) Fix RestoreSession targetPhase calculation (#46)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.5](https://github.com/stashed/apimachinery/releases/tag/v0.11.5)
+
+- [45f4ed32](https://github.com/stashed/apimachinery/commit/45f4ed32) Update readme
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.10.30](https://github.com/stashed/catalog/releases/tag/v2020.10.30)
+
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.5](https://github.com/stashed/cli/releases/tag/v0.11.5)
+
+- [0144016](https://github.com/stashed/cli/commit/0144016) Prepare for release v0.11.5 (#70)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.5](https://github.com/stashed/installer/releases/tag/v0.11.5)
+
+- [4cbcc62](https://github.com/stashed/installer/commit/4cbcc62) Prepare for release v0.11.5 (#121)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.5](https://github.com/stashed/stash/releases/tag/v0.11.5)
+
+- [8d19f197](https://github.com/stashed/stash/commit/8d19f197) Prepare for release v0.11.5 (#1241)
+- [4fe4b3c9](https://github.com/stashed/stash/commit/4fe4b3c9) Fix RestoreSession target phase calculation (#1240)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.10.30
Release-tracker: https://github.com/stashed/CHANGELOG/pull/22
Signed-off-by: 1gtm <1gtm@appscode.com>