### PR TITLE
Prepare for release v2020.11.06

### DIFF
--- a/docs/CHANGELOG-v2020.11.06.md
+++ b/docs/CHANGELOG-v2020.11.06.md
@@ -1,0 +1,410 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.11.06
+    name: Changelog-v2020.11.06
+    parent: welcome
+    weight: 20201106
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.11.06/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.11.06/
+---
+
+# Stash v2020.11.06 (2020-11-07)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.6](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.6)
+
+- [844f92dc](https://github.com/appscode/stash-enterprise/commit/844f92dc) Prepare for release v0.11.6 (#52)
+- [7c121617](https://github.com/appscode/stash-enterprise/commit/7c121617) Use restic 0.11.0 (#51)
+- [98cc42b4](https://github.com/appscode/stash-enterprise/commit/98cc42b4) Update Kubernetes v1.18.9 dependencies (#38)
+- [a882fc9b](https://github.com/appscode/stash-enterprise/commit/a882fc9b) Fix E2E tests (#50)
+- [6950f54a](https://github.com/appscode/stash-enterprise/commit/6950f54a) Use modified UpdateStatus & Invoker utils (#49)
+- [079d90e2](https://github.com/appscode/stash-enterprise/commit/079d90e2) Use backup/restore invoker information as prometheus job name (#48)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.6](https://github.com/stashed/apimachinery/releases/tag/v0.11.6)
+
+- [5e04c853](https://github.com/stashed/apimachinery/commit/5e04c853) Use restic 0.11.0 (#70)
+- [132a511f](https://github.com/stashed/apimachinery/commit/132a511f) Update Kubernetes v1.18.9 dependencies (#69)
+- [b51d7c6a](https://github.com/stashed/apimachinery/commit/b51d7c6a) Use invoker variable name 'inv'
+- [c2190f6b](https://github.com/stashed/apimachinery/commit/c2190f6b) Various fixes (#67)
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.11.06](https://github.com/stashed/catalog/releases/tag/v2020.11.06)
+
+- [4f5b081](https://github.com/stashed/catalog/commit/4f5b081) Prepare for release v2020.11.06 (#45)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.6](https://github.com/stashed/cli/releases/tag/v0.11.6)
+
+- [ea1e330](https://github.com/stashed/cli/commit/ea1e330) Prepare for release v0.11.6 (#73)
+- [803662d](https://github.com/stashed/cli/commit/803662d) Update Kubernetes v1.18.9 dependencies (#72)
+- [af00ba6](https://github.com/stashed/cli/commit/af00ba6) Replace appscode/go with gomodules.xyz/x (#71)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v4](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v4)
+
+- [3c39fdd](https://github.com/stashed/elasticsearch/commit/3c39fdd) Prepare for release 5.6.4-v4 (#444)
+- [0e8f7fb](https://github.com/stashed/elasticsearch/commit/0e8f7fb) [cherry-pick] Use restic 0.11.0 (#435) (#436)
+- [096bbe4](https://github.com/stashed/elasticsearch/commit/096bbe4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#427)
+- [c6e6b02](https://github.com/stashed/elasticsearch/commit/c6e6b02) [cherry-pick] Update README.md (#416)
+- [a383692](https://github.com/stashed/elasticsearch/commit/a383692) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#408)
+- [830f3f1](https://github.com/stashed/elasticsearch/commit/830f3f1) [cherry-pick] Update readme (#399)
+- [5f101c6](https://github.com/stashed/elasticsearch/commit/5f101c6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#391)
+
+
+### [6.2.4-v4](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v4)
+
+- [e7887a2](https://github.com/stashed/elasticsearch/commit/e7887a2) Prepare for release 6.2.4-v4 (#445)
+- [575a05e](https://github.com/stashed/elasticsearch/commit/575a05e) [cherry-pick] Use restic 0.11.0 (#435) (#437)
+- [569f892](https://github.com/stashed/elasticsearch/commit/569f892) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#428)
+- [078a72e](https://github.com/stashed/elasticsearch/commit/078a72e) [cherry-pick] Update README.md (#417)
+- [8918137](https://github.com/stashed/elasticsearch/commit/8918137) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#409)
+- [6d5f1bd](https://github.com/stashed/elasticsearch/commit/6d5f1bd) [cherry-pick] Update readme (#400)
+- [e42222f](https://github.com/stashed/elasticsearch/commit/e42222f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#392)
+
+
+### [6.3.0-v4](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v4)
+
+- [624a0a1](https://github.com/stashed/elasticsearch/commit/624a0a1) Prepare for release 6.3.0-v4 (#446)
+- [b6dd67d](https://github.com/stashed/elasticsearch/commit/b6dd67d) [cherry-pick] Use restic 0.11.0 (#435) (#438)
+- [b4bb13a](https://github.com/stashed/elasticsearch/commit/b4bb13a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#429)
+- [f18573a](https://github.com/stashed/elasticsearch/commit/f18573a) [cherry-pick] Update README.md (#418)
+- [9f1ec99](https://github.com/stashed/elasticsearch/commit/9f1ec99) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#410)
+- [72e6eca](https://github.com/stashed/elasticsearch/commit/72e6eca) [cherry-pick] Update readme (#401)
+- [ef6e72e](https://github.com/stashed/elasticsearch/commit/ef6e72e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#393)
+
+
+### [6.4.0-v4](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v4)
+
+- [3477804](https://github.com/stashed/elasticsearch/commit/3477804) Prepare for release 6.4.0-v4 (#447)
+- [c58be67](https://github.com/stashed/elasticsearch/commit/c58be67) [cherry-pick] Use restic 0.11.0 (#435) (#439)
+- [27d0542](https://github.com/stashed/elasticsearch/commit/27d0542) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#430)
+- [b7beb6c](https://github.com/stashed/elasticsearch/commit/b7beb6c) [cherry-pick] Update README.md (#419)
+- [667b91b](https://github.com/stashed/elasticsearch/commit/667b91b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#411)
+- [4b15de5](https://github.com/stashed/elasticsearch/commit/4b15de5) [cherry-pick] Update readme (#402)
+- [ec4f862](https://github.com/stashed/elasticsearch/commit/ec4f862) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#394)
+
+
+### [6.5.3-v4](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v4)
+
+- [ecfeda3](https://github.com/stashed/elasticsearch/commit/ecfeda3) Prepare for release 6.5.3-v4 (#448)
+- [811d778](https://github.com/stashed/elasticsearch/commit/811d778) [cherry-pick] Use restic 0.11.0 (#435) (#440)
+- [a4e8fc8](https://github.com/stashed/elasticsearch/commit/a4e8fc8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#431)
+- [9bb8991](https://github.com/stashed/elasticsearch/commit/9bb8991) [cherry-pick] Update README.md (#420)
+- [ca23821](https://github.com/stashed/elasticsearch/commit/ca23821) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#412)
+- [81a6e81](https://github.com/stashed/elasticsearch/commit/81a6e81) [cherry-pick] Update readme (#403)
+- [7c544fb](https://github.com/stashed/elasticsearch/commit/7c544fb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#395)
+
+
+### [6.8.0-v4](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v4)
+
+- [3be68de](https://github.com/stashed/elasticsearch/commit/3be68de) Prepare for release 6.8.0-v4 (#449)
+- [056aec2](https://github.com/stashed/elasticsearch/commit/056aec2) [cherry-pick] Use restic 0.11.0 (#435) (#441)
+- [c08d53d](https://github.com/stashed/elasticsearch/commit/c08d53d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#432)
+- [e67c72e](https://github.com/stashed/elasticsearch/commit/e67c72e) [cherry-pick] Update README.md (#421)
+- [6b58712](https://github.com/stashed/elasticsearch/commit/6b58712) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#413)
+- [588169f](https://github.com/stashed/elasticsearch/commit/588169f) [cherry-pick] Update readme (#404)
+- [242ba7c](https://github.com/stashed/elasticsearch/commit/242ba7c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#396)
+
+
+### [7.2.0-v4](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v4)
+
+- [9004882](https://github.com/stashed/elasticsearch/commit/9004882) Prepare for release 7.2.0-v4 (#450)
+- [61ac4fe](https://github.com/stashed/elasticsearch/commit/61ac4fe) [cherry-pick] Use restic 0.11.0 (#435) (#442)
+- [8c47ff0](https://github.com/stashed/elasticsearch/commit/8c47ff0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#433)
+- [d9de6b0](https://github.com/stashed/elasticsearch/commit/d9de6b0) [cherry-pick] Update README.md (#422)
+- [82bdf3a](https://github.com/stashed/elasticsearch/commit/82bdf3a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#414)
+- [7b12b81](https://github.com/stashed/elasticsearch/commit/7b12b81) [cherry-pick] Update readme (#405)
+- [88cc572](https://github.com/stashed/elasticsearch/commit/88cc572) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#397)
+
+
+### [7.3.2-v4](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v4)
+
+- [ae4510a](https://github.com/stashed/elasticsearch/commit/ae4510a) Prepare for release 7.3.2-v4 (#451)
+- [c5fa263](https://github.com/stashed/elasticsearch/commit/c5fa263) [cherry-pick] Use restic 0.11.0 (#435) (#443)
+- [ac4a169](https://github.com/stashed/elasticsearch/commit/ac4a169) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#426) (#434)
+- [7918c06](https://github.com/stashed/elasticsearch/commit/7918c06) [cherry-pick] Update README.md (#423)
+- [dc2459d](https://github.com/stashed/elasticsearch/commit/dc2459d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#407) (#415)
+- [91bccfb](https://github.com/stashed/elasticsearch/commit/91bccfb) [cherry-pick] Update readme (#406)
+- [0543df9](https://github.com/stashed/elasticsearch/commit/0543df9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#390) (#398)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.6](https://github.com/stashed/installer/releases/tag/v0.11.6)
+
+- [d6b5977](https://github.com/stashed/installer/commit/d6b5977) Prepare for release v0.11.6 (#124)
+- [35a3dcf](https://github.com/stashed/installer/commit/35a3dcf) Update Kubernetes v1.18.9 dependencies (#123)
+- [cc04710](https://github.com/stashed/installer/commit/cc04710) Update Kubernetes v1.18.9 dependencies (#122)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v4](https://github.com/stashed/mongodb/releases/tag/3.4.17-v4)
+
+- [3f6b306a](https://github.com/stashed/mongodb/commit/3f6b306a) Prepare for release 3.4.17-v4 (#579)
+- [68d6e5de](https://github.com/stashed/mongodb/commit/68d6e5de) [cherry-pick] Use restic 0.11.0 (#567) (#568)
+- [8d7f4a2c](https://github.com/stashed/mongodb/commit/8d7f4a2c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#556)
+- [4b80b637](https://github.com/stashed/mongodb/commit/4b80b637) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#544)
+- [e0a76f8d](https://github.com/stashed/mongodb/commit/e0a76f8d) [cherry-pick] Update README.md (#532)
+- [e78fbf27](https://github.com/stashed/mongodb/commit/e78fbf27) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#520)
+- [2896604c](https://github.com/stashed/mongodb/commit/2896604c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#508)
+
+
+### [3.4.22-v4](https://github.com/stashed/mongodb/releases/tag/3.4.22-v4)
+
+- [0007f664](https://github.com/stashed/mongodb/commit/0007f664) Prepare for release 3.4.22-v4 (#580)
+- [f6d2bbe5](https://github.com/stashed/mongodb/commit/f6d2bbe5) [cherry-pick] Use restic 0.11.0 (#567) (#569)
+- [dceeccab](https://github.com/stashed/mongodb/commit/dceeccab) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#557)
+- [b449e06b](https://github.com/stashed/mongodb/commit/b449e06b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#545)
+- [43651d6d](https://github.com/stashed/mongodb/commit/43651d6d) [cherry-pick] Update README.md (#533)
+- [7955c033](https://github.com/stashed/mongodb/commit/7955c033) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#521)
+- [4de72368](https://github.com/stashed/mongodb/commit/4de72368) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#509)
+
+
+### [3.6.8-v4](https://github.com/stashed/mongodb/releases/tag/3.6.8-v4)
+
+- [e460c71c](https://github.com/stashed/mongodb/commit/e460c71c) Prepare for release 3.6.8-v4 (#582)
+- [2de66fe3](https://github.com/stashed/mongodb/commit/2de66fe3) [cherry-pick] Use restic 0.11.0 (#567) (#571)
+- [baca40a9](https://github.com/stashed/mongodb/commit/baca40a9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#559)
+- [ca71febb](https://github.com/stashed/mongodb/commit/ca71febb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#547)
+- [e6b625d4](https://github.com/stashed/mongodb/commit/e6b625d4) [cherry-pick] Update README.md (#535)
+- [34b93cc6](https://github.com/stashed/mongodb/commit/34b93cc6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#523)
+- [a253c0b1](https://github.com/stashed/mongodb/commit/a253c0b1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#511)
+
+
+### [3.6.13-v4](https://github.com/stashed/mongodb/releases/tag/3.6.13-v4)
+
+- [2016d666](https://github.com/stashed/mongodb/commit/2016d666) Prepare for release 3.6.13-v4 (#581)
+- [f43e0233](https://github.com/stashed/mongodb/commit/f43e0233) [cherry-pick] Use restic 0.11.0 (#567) (#570)
+- [f019b7f6](https://github.com/stashed/mongodb/commit/f019b7f6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#558)
+- [0a2fe70c](https://github.com/stashed/mongodb/commit/0a2fe70c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#546)
+- [9ca6738b](https://github.com/stashed/mongodb/commit/9ca6738b) [cherry-pick] Update README.md (#534)
+- [82545252](https://github.com/stashed/mongodb/commit/82545252) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#522)
+- [27fcbdb5](https://github.com/stashed/mongodb/commit/27fcbdb5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#510)
+
+
+### [4.0.3-v4](https://github.com/stashed/mongodb/releases/tag/4.0.3-v4)
+
+- [47debac9](https://github.com/stashed/mongodb/commit/47debac9) Prepare for release 4.0.3-v4 (#584)
+- [107d4a79](https://github.com/stashed/mongodb/commit/107d4a79) [cherry-pick] Use restic 0.11.0 (#567) (#573)
+- [9c08be11](https://github.com/stashed/mongodb/commit/9c08be11) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#561)
+- [172917bc](https://github.com/stashed/mongodb/commit/172917bc) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#549)
+- [270d533f](https://github.com/stashed/mongodb/commit/270d533f) [cherry-pick] Update README.md (#537)
+- [bd5fb620](https://github.com/stashed/mongodb/commit/bd5fb620) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#525)
+- [df2a3bf5](https://github.com/stashed/mongodb/commit/df2a3bf5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#513)
+
+
+### [4.0.5-v4](https://github.com/stashed/mongodb/releases/tag/4.0.5-v4)
+
+- [328baadc](https://github.com/stashed/mongodb/commit/328baadc) Prepare for release 4.0.5-v4 (#585)
+- [d10db825](https://github.com/stashed/mongodb/commit/d10db825) [cherry-pick] Use restic 0.11.0 (#567) (#574)
+- [2a25fe1c](https://github.com/stashed/mongodb/commit/2a25fe1c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#562)
+- [f42c4554](https://github.com/stashed/mongodb/commit/f42c4554) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#550)
+- [df2e29b0](https://github.com/stashed/mongodb/commit/df2e29b0) [cherry-pick] Update README.md (#538)
+- [e810d537](https://github.com/stashed/mongodb/commit/e810d537) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#526)
+- [40f8e2d1](https://github.com/stashed/mongodb/commit/40f8e2d1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#514)
+
+
+### [4.0.11-v4](https://github.com/stashed/mongodb/releases/tag/4.0.11-v4)
+
+- [36b75678](https://github.com/stashed/mongodb/commit/36b75678) Prepare for release 4.0.11-v4 (#583)
+- [58bcaea8](https://github.com/stashed/mongodb/commit/58bcaea8) [cherry-pick] Use restic 0.11.0 (#567) (#572)
+- [8d780f2b](https://github.com/stashed/mongodb/commit/8d780f2b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#560)
+- [4f109db3](https://github.com/stashed/mongodb/commit/4f109db3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#548)
+- [8b532dd7](https://github.com/stashed/mongodb/commit/8b532dd7) [cherry-pick] Update README.md (#536)
+- [ac872685](https://github.com/stashed/mongodb/commit/ac872685) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#524)
+- [056fa168](https://github.com/stashed/mongodb/commit/056fa168) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#512)
+
+
+### [4.1.4-v4](https://github.com/stashed/mongodb/releases/tag/4.1.4-v4)
+
+- [dc3929e6](https://github.com/stashed/mongodb/commit/dc3929e6) Prepare for release 4.1.4-v4 (#587)
+- [4eb1b197](https://github.com/stashed/mongodb/commit/4eb1b197) [cherry-pick] Use restic 0.11.0 (#567) (#576)
+- [991eca5f](https://github.com/stashed/mongodb/commit/991eca5f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#564)
+- [c1bcd233](https://github.com/stashed/mongodb/commit/c1bcd233) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#552)
+- [fa15af15](https://github.com/stashed/mongodb/commit/fa15af15) [cherry-pick] Update README.md (#540)
+- [c80096b2](https://github.com/stashed/mongodb/commit/c80096b2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#528)
+- [e672fa66](https://github.com/stashed/mongodb/commit/e672fa66) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#516)
+
+
+### [4.1.7-v4](https://github.com/stashed/mongodb/releases/tag/4.1.7-v4)
+
+- [21ab7971](https://github.com/stashed/mongodb/commit/21ab7971) Prepare for release 4.1.7-v4 (#588)
+- [b4b9eb87](https://github.com/stashed/mongodb/commit/b4b9eb87) [cherry-pick] Use restic 0.11.0 (#567) (#577)
+- [ab8bb239](https://github.com/stashed/mongodb/commit/ab8bb239) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#565)
+- [1aa4347e](https://github.com/stashed/mongodb/commit/1aa4347e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#553)
+- [941b402d](https://github.com/stashed/mongodb/commit/941b402d) [cherry-pick] Update README.md (#541)
+- [4ada82d7](https://github.com/stashed/mongodb/commit/4ada82d7) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#529)
+- [1469fb25](https://github.com/stashed/mongodb/commit/1469fb25) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#517)
+
+
+### [4.1.13-v4](https://github.com/stashed/mongodb/releases/tag/4.1.13-v4)
+
+- [472485fb](https://github.com/stashed/mongodb/commit/472485fb) Prepare for release 4.1.13-v4 (#586)
+- [cd948e74](https://github.com/stashed/mongodb/commit/cd948e74) [cherry-pick] Use restic 0.11.0 (#567) (#575)
+- [8ee583d0](https://github.com/stashed/mongodb/commit/8ee583d0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#563)
+- [fd492e62](https://github.com/stashed/mongodb/commit/fd492e62) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#551)
+- [1bf69a8c](https://github.com/stashed/mongodb/commit/1bf69a8c) [cherry-pick] Update README.md (#539)
+- [02c39c0c](https://github.com/stashed/mongodb/commit/02c39c0c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#527)
+- [3a803f84](https://github.com/stashed/mongodb/commit/3a803f84) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#515)
+
+
+### [4.2.3-v4](https://github.com/stashed/mongodb/releases/tag/4.2.3-v4)
+
+- [89afb349](https://github.com/stashed/mongodb/commit/89afb349) Prepare for release 4.2.3-v4 (#589)
+- [8d0edc1c](https://github.com/stashed/mongodb/commit/8d0edc1c) [cherry-pick] Use restic 0.11.0 (#567) (#578)
+- [4affd4d6](https://github.com/stashed/mongodb/commit/4affd4d6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#566)
+- [bb26680f](https://github.com/stashed/mongodb/commit/bb26680f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#543) (#554)
+- [d1330686](https://github.com/stashed/mongodb/commit/d1330686) [cherry-pick] Update README.md (#542)
+- [05eadfb2](https://github.com/stashed/mongodb/commit/05eadfb2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#519) (#530)
+- [5ebe5624](https://github.com/stashed/mongodb/commit/5ebe5624) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#507) (#518)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v4](https://github.com/stashed/mysql/releases/tag/5.7.25-v4)
+
+- [3a6158e](https://github.com/stashed/mysql/commit/3a6158e) Prepare for release 5.7.25-v4 (#218)
+- [8a7b612](https://github.com/stashed/mysql/commit/8a7b612) [cherry-pick] Use restic 0.11.0 (#214) (#215)
+- [7abed46](https://github.com/stashed/mysql/commit/7abed46) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#210) (#211)
+- [8fa530d](https://github.com/stashed/mysql/commit/8fa530d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#206) (#207)
+- [83f2101](https://github.com/stashed/mysql/commit/83f2101) [cherry-pick] Update README.md (#203)
+- [1ea81ab](https://github.com/stashed/mysql/commit/1ea81ab) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#199) (#200)
+- [bc9131e](https://github.com/stashed/mysql/commit/bc9131e) [cherry-pick] Update readme (#196)
+- [c94eb1e](https://github.com/stashed/mysql/commit/c94eb1e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#192) (#193)
+- [a1d9a87](https://github.com/stashed/mysql/commit/a1d9a87) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#188) (#189)
+
+
+### [8.0.3-v4](https://github.com/stashed/mysql/releases/tag/8.0.3-v4)
+
+- [10c111d](https://github.com/stashed/mysql/commit/10c111d) Prepare for release 8.0.3-v4 (#220)
+- [9204bff](https://github.com/stashed/mysql/commit/9204bff) [cherry-pick] Use restic 0.11.0 (#214) (#217)
+- [833fb2e](https://github.com/stashed/mysql/commit/833fb2e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#210) (#213)
+- [c0e8ec0](https://github.com/stashed/mysql/commit/c0e8ec0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#206) (#209)
+- [31eb6c5](https://github.com/stashed/mysql/commit/31eb6c5) [cherry-pick] Update README.md (#205)
+- [0679bff](https://github.com/stashed/mysql/commit/0679bff) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#199) (#202)
+- [7699793](https://github.com/stashed/mysql/commit/7699793) [cherry-pick] Update readme (#198)
+- [e2a2ad3](https://github.com/stashed/mysql/commit/e2a2ad3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#192) (#195)
+- [eee397e](https://github.com/stashed/mysql/commit/eee397e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#188) (#191)
+
+
+### [8.0.14-v4](https://github.com/stashed/mysql/releases/tag/8.0.14-v4)
+
+- [1dd0da8](https://github.com/stashed/mysql/commit/1dd0da8) Prepare for release 8.0.14-v4 (#219)
+- [4722d69](https://github.com/stashed/mysql/commit/4722d69) [cherry-pick] Use restic 0.11.0 (#214) (#216)
+- [35e0e97](https://github.com/stashed/mysql/commit/35e0e97) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#210) (#212)
+- [0700e1b](https://github.com/stashed/mysql/commit/0700e1b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#206) (#208)
+- [f68dcb7](https://github.com/stashed/mysql/commit/f68dcb7) [cherry-pick] Update README.md (#204)
+- [abb8870](https://github.com/stashed/mysql/commit/abb8870) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#199) (#201)
+- [aea15a1](https://github.com/stashed/mysql/commit/aea15a1) [cherry-pick] Update readme (#197)
+- [862d1cb](https://github.com/stashed/mysql/commit/862d1cb) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#192) (#194)
+- [230a723](https://github.com/stashed/mysql/commit/230a723) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#188) (#190)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v4](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v4)
+
+- [2243395](https://github.com/stashed/percona-xtradb/commit/2243395) Prepare for release 5.7-v4 (#110)
+- [4355836](https://github.com/stashed/percona-xtradb/commit/4355836) [cherry-pick] Use restic 0.11.0 (#108) (#109)
+- [fb391dc](https://github.com/stashed/percona-xtradb/commit/fb391dc) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#106) (#107)
+- [caff85c](https://github.com/stashed/percona-xtradb/commit/caff85c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#104) (#105)
+- [6b23346](https://github.com/stashed/percona-xtradb/commit/6b23346) [cherry-pick] Update README.md (#103)
+- [eead980](https://github.com/stashed/percona-xtradb/commit/eead980) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#101) (#102)
+- [9981cb1](https://github.com/stashed/percona-xtradb/commit/9981cb1) [cherry-pick] Update readme (#100)
+- [e434d72](https://github.com/stashed/percona-xtradb/commit/e434d72) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#98) (#99)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v2](https://github.com/stashed/postgres/releases/tag/9.6.19-v2)
+
+- [efeac24](https://github.com/stashed/postgres/commit/efeac24) Prepare for release 9.6.19-v2 (#417)
+- [be55874](https://github.com/stashed/postgres/commit/be55874) [cherry-pick] Use restic 0.11.0 (#404) (#413)
+- [8844fb2](https://github.com/stashed/postgres/commit/8844fb2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#394) (#403)
+- [856fea8](https://github.com/stashed/postgres/commit/856fea8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#384) (#393)
+- [51324d8](https://github.com/stashed/postgres/commit/51324d8) [cherry-pick] Update README.md (#383)
+- [da74dd2](https://github.com/stashed/postgres/commit/da74dd2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#365) (#374)
+- [472db2b](https://github.com/stashed/postgres/commit/472db2b) [cherry-pick] Update readme (#364)
+- [b847956](https://github.com/stashed/postgres/commit/b847956) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#346) (#355)
+
+
+### [10.14.0-v2](https://github.com/stashed/postgres/releases/tag/10.14.0-v2)
+
+- [56979a2](https://github.com/stashed/postgres/commit/56979a2) Prepare for release 10.14.0-v2 (#414)
+- [6311db6](https://github.com/stashed/postgres/commit/6311db6) [cherry-pick] Use restic 0.11.0 (#404) (#405)
+- [a214531](https://github.com/stashed/postgres/commit/a214531) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#394) (#395)
+- [014f32d](https://github.com/stashed/postgres/commit/014f32d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#384) (#385)
+- [d2af0a7](https://github.com/stashed/postgres/commit/d2af0a7) [cherry-pick] Update README.md (#375)
+- [47c1554](https://github.com/stashed/postgres/commit/47c1554) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#365) (#366)
+- [f929b3f](https://github.com/stashed/postgres/commit/f929b3f) [cherry-pick] Update readme (#356)
+- [c40b28e](https://github.com/stashed/postgres/commit/c40b28e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#346) (#347)
+
+
+### [11.9.0-v2](https://github.com/stashed/postgres/releases/tag/11.9.0-v2)
+
+- [cbde939](https://github.com/stashed/postgres/commit/cbde939) Prepare for release 11.9.0-v2 (#415)
+- [784e869](https://github.com/stashed/postgres/commit/784e869) [cherry-pick] Use restic 0.11.0 (#404) (#410)
+- [e27dc3f](https://github.com/stashed/postgres/commit/e27dc3f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#394) (#400)
+- [13f56f9](https://github.com/stashed/postgres/commit/13f56f9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#384) (#390)
+- [6bf8688](https://github.com/stashed/postgres/commit/6bf8688) [cherry-pick] Update README.md (#380)
+- [7242780](https://github.com/stashed/postgres/commit/7242780) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#365) (#371)
+- [f50f4aa](https://github.com/stashed/postgres/commit/f50f4aa) [cherry-pick] Update readme (#361)
+- [1e42c94](https://github.com/stashed/postgres/commit/1e42c94) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#346) (#352)
+
+
+### [12.4.0-v2](https://github.com/stashed/postgres/releases/tag/12.4.0-v2)
+
+- [6d8aa2f](https://github.com/stashed/postgres/commit/6d8aa2f) Prepare for release 12.4.0-v2 (#416)
+- [d8ca600](https://github.com/stashed/postgres/commit/d8ca600) [cherry-pick] Use restic 0.11.0 (#404) (#411)
+- [9814a3e](https://github.com/stashed/postgres/commit/9814a3e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#394) (#401)
+- [9de7a4c](https://github.com/stashed/postgres/commit/9de7a4c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#384) (#391)
+- [9901d95](https://github.com/stashed/postgres/commit/9901d95) [cherry-pick] Update README.md (#381)
+- [df32228](https://github.com/stashed/postgres/commit/df32228) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#365) (#372)
+- [b859a9f](https://github.com/stashed/postgres/commit/b859a9f) [cherry-pick] Update readme (#362)
+- [f9186d9](https://github.com/stashed/postgres/commit/f9186d9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#346) (#353)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.6](https://github.com/stashed/stash/releases/tag/v0.11.6)
+
+- [8cbac525](https://github.com/stashed/stash/commit/8cbac525) Prepare for release v0.11.6 (#1252)
+- [57db9b74](https://github.com/stashed/stash/commit/57db9b74) Use restic 0.11.0 (#1251)
+- [10d02b13](https://github.com/stashed/stash/commit/10d02b13) Update dependencies
+- [437a1968](https://github.com/stashed/stash/commit/437a1968) Update Kubernetes v1.18.9 dependencies (#1250)
+- [29cef180](https://github.com/stashed/stash/commit/29cef180) Fix E2E tests (#1249)
+- [e88ab544](https://github.com/stashed/stash/commit/e88ab544) Use backup/restore invoker information as prometheus job name (#1248)
+- [d0a4751b](https://github.com/stashed/stash/commit/d0a4751b) Use modified UpdateStatus & Invoker utils (#1247)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.11.06
Release-tracker: https://github.com/stashed/CHANGELOG/pull/23
Signed-off-by: 1gtm <1gtm@appscode.com>