### PR TITLE
Prepare for release v2020.12.17

### DIFF
--- a/docs/CHANGELOG-v2020.12.17.md
+++ b/docs/CHANGELOG-v2020.12.17.md
@@ -1,0 +1,440 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2020.12.17
+    name: Changelog-v2020.12.17
+    parent: welcome
+    weight: 20201217
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2020.12.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2020.12.17/
+---
+
+# Stash v2020.12.17 (2020-12-17)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.8](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.8)
+
+- [eccabd16](https://github.com/appscode/stash-enterprise/commit/eccabd16) Prepare for release v0.11.8 (#63)
+- [1e03db14](https://github.com/appscode/stash-enterprise/commit/1e03db14) Update Kubernetes v1.18.9 dependencies (#61)
+- [b3031f75](https://github.com/appscode/stash-enterprise/commit/b3031f75) Run backup job as user 65535 (#62)
+- [f3207a94](https://github.com/appscode/stash-enterprise/commit/f3207a94) Fix secretTransforation for AppBinding (#60)
+- [c7e3248f](https://github.com/appscode/stash-enterprise/commit/c7e3248f) Update CI workflow
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.8](https://github.com/stashed/apimachinery/releases/tag/v0.11.8)
+
+- [cec1888a](https://github.com/stashed/apimachinery/commit/cec1888a) Update Kubernetes v1.18.9 dependencies (#74)
+- [c7aed993](https://github.com/stashed/apimachinery/commit/c7aed993) Update Kubernetes v1.18.9 dependencies (#73)
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2020.12.17](https://github.com/stashed/catalog/releases/tag/v2020.12.17)
+
+- [e8c931c](https://github.com/stashed/catalog/commit/e8c931c) Prepare for release v2020.12.17 (#50)
+- [d169e34](https://github.com/stashed/catalog/commit/d169e34) Add MariaDB catalog + Cleanup (#48)
+- [5dd2aa2](https://github.com/stashed/catalog/commit/5dd2aa2) Update repository config (#49)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.8](https://github.com/stashed/cli/releases/tag/v0.11.8)
+
+- [33bebfb](https://github.com/stashed/cli/commit/33bebfb) Prepare for release v0.11.8 (#97)
+- [d343c7e](https://github.com/stashed/cli/commit/d343c7e) Update Kubernetes v1.18.9 dependencies (#96)
+- [5a5069c](https://github.com/stashed/cli/commit/5a5069c) Update Kubernetes v1.18.9 dependencies (#95)
+- [0b4b68b](https://github.com/stashed/cli/commit/0b4b68b) Update Kubernetes v1.18.9 dependencies (#94)
+- [99cd366](https://github.com/stashed/cli/commit/99cd366) Update Kubernetes v1.18.9 dependencies (#93)
+- [84f4f2f](https://github.com/stashed/cli/commit/84f4f2f) Update Kubernetes v1.18.9 dependencies (#92)
+- [018b14a](https://github.com/stashed/cli/commit/018b14a) Update Kubernetes v1.18.9 dependencies (#91)
+- [18ed3c6](https://github.com/stashed/cli/commit/18ed3c6) Update Kubernetes v1.18.9 dependencies (#90)
+- [ad95cbe](https://github.com/stashed/cli/commit/ad95cbe) Update Kubernetes v1.18.9 dependencies (#89)
+- [42ffef5](https://github.com/stashed/cli/commit/42ffef5) Update Kubernetes v1.18.9 dependencies (#88)
+- [cb657bb](https://github.com/stashed/cli/commit/cb657bb) Update Kubernetes v1.18.9 dependencies (#87)
+- [8853995](https://github.com/stashed/cli/commit/8853995) Update Kubernetes v1.18.9 dependencies (#86)
+- [3af9028](https://github.com/stashed/cli/commit/3af9028) Update Kubernetes v1.18.9 dependencies (#85)
+- [074c37b](https://github.com/stashed/cli/commit/074c37b) Update Kubernetes v1.18.9 dependencies (#84)
+- [d08b872](https://github.com/stashed/cli/commit/d08b872) Update Kubernetes v1.18.9 dependencies (#83)
+- [d9b1b93](https://github.com/stashed/cli/commit/d9b1b93) Update Kubernetes v1.18.9 dependencies (#82)
+- [4e96e8e](https://github.com/stashed/cli/commit/4e96e8e) Update Kubernetes v1.18.9 dependencies (#81)
+- [d38c1ba](https://github.com/stashed/cli/commit/d38c1ba) Update Kubernetes v1.18.9 dependencies (#80)
+- [37c7d87](https://github.com/stashed/cli/commit/37c7d87) Update Kubernetes v1.18.9 dependencies (#79)
+- [67ec7d1](https://github.com/stashed/cli/commit/67ec7d1) Update Kubernetes v1.18.9 dependencies (#78)
+- [328763e](https://github.com/stashed/cli/commit/328763e) Update Kubernetes v1.18.9 dependencies (#77)
+- [c8cfdab](https://github.com/stashed/cli/commit/c8cfdab) Update Kubernetes v1.18.9 dependencies (#76)
+- [7354628](https://github.com/stashed/cli/commit/7354628) Update Kubernetes v1.18.9 dependencies (#75)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v5](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v5)
+
+- [7234135](https://github.com/stashed/elasticsearch/commit/7234135) Prepare for release 5.6.4-v5 (#498)
+- [d9a692f](https://github.com/stashed/elasticsearch/commit/d9a692f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#490)
+- [3c96ea3](https://github.com/stashed/elasticsearch/commit/3c96ea3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#481)
+- [0a2e843](https://github.com/stashed/elasticsearch/commit/0a2e843) [cherry-pick] Update repository config (#471) (#472)
+- [4165f8e](https://github.com/stashed/elasticsearch/commit/4165f8e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#463)
+- [acdac11](https://github.com/stashed/elasticsearch/commit/acdac11) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#454)
+
+
+### [6.2.4-v5](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v5)
+
+- [7b78f9e](https://github.com/stashed/elasticsearch/commit/7b78f9e) Prepare for release 6.2.4-v5 (#499)
+- [413434d](https://github.com/stashed/elasticsearch/commit/413434d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#491)
+- [7bdf655](https://github.com/stashed/elasticsearch/commit/7bdf655) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#482)
+- [74f4c2c](https://github.com/stashed/elasticsearch/commit/74f4c2c) [cherry-pick] Update repository config (#471) (#473)
+- [4248af4](https://github.com/stashed/elasticsearch/commit/4248af4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#464)
+- [197b7c5](https://github.com/stashed/elasticsearch/commit/197b7c5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#455)
+
+
+### [6.3.0-v5](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v5)
+
+- [1c2dd6f](https://github.com/stashed/elasticsearch/commit/1c2dd6f) Prepare for release 6.3.0-v5 (#500)
+- [37e2fe8](https://github.com/stashed/elasticsearch/commit/37e2fe8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#492)
+- [c27a297](https://github.com/stashed/elasticsearch/commit/c27a297) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#483)
+- [2df4955](https://github.com/stashed/elasticsearch/commit/2df4955) [cherry-pick] Update repository config (#471) (#474)
+- [fe7cef6](https://github.com/stashed/elasticsearch/commit/fe7cef6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#465)
+- [d94cc74](https://github.com/stashed/elasticsearch/commit/d94cc74) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#456)
+
+
+### [6.4.0-v5](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v5)
+
+- [28db07e](https://github.com/stashed/elasticsearch/commit/28db07e) Prepare for release 6.4.0-v5 (#501)
+- [98936e6](https://github.com/stashed/elasticsearch/commit/98936e6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#493)
+- [11f03fa](https://github.com/stashed/elasticsearch/commit/11f03fa) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#484)
+- [dc339aa](https://github.com/stashed/elasticsearch/commit/dc339aa) [cherry-pick] Update repository config (#471) (#475)
+- [9b131a4](https://github.com/stashed/elasticsearch/commit/9b131a4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#466)
+- [16bb8b3](https://github.com/stashed/elasticsearch/commit/16bb8b3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#457)
+
+
+### [6.5.3-v5](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v5)
+
+- [acf444e](https://github.com/stashed/elasticsearch/commit/acf444e) Prepare for release 6.5.3-v5 (#502)
+- [d1c4849](https://github.com/stashed/elasticsearch/commit/d1c4849) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#494)
+- [668c97a](https://github.com/stashed/elasticsearch/commit/668c97a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#485)
+- [e25a596](https://github.com/stashed/elasticsearch/commit/e25a596) [cherry-pick] Update repository config (#471) (#476)
+- [0567419](https://github.com/stashed/elasticsearch/commit/0567419) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#467)
+- [0b99e60](https://github.com/stashed/elasticsearch/commit/0b99e60) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#458)
+
+
+### [6.8.0-v5](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v5)
+
+- [8959fd4](https://github.com/stashed/elasticsearch/commit/8959fd4) Prepare for release 6.8.0-v5 (#503)
+- [6772e20](https://github.com/stashed/elasticsearch/commit/6772e20) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#495)
+- [68127a5](https://github.com/stashed/elasticsearch/commit/68127a5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#486)
+- [cda62d0](https://github.com/stashed/elasticsearch/commit/cda62d0) [cherry-pick] Update repository config (#471) (#477)
+- [3357ece](https://github.com/stashed/elasticsearch/commit/3357ece) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#468)
+- [fcfbb43](https://github.com/stashed/elasticsearch/commit/fcfbb43) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#459)
+
+
+### [7.2.0-v5](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v5)
+
+- [2d738a4](https://github.com/stashed/elasticsearch/commit/2d738a4) Prepare for release 7.2.0-v5 (#504)
+- [b943b7e](https://github.com/stashed/elasticsearch/commit/b943b7e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#496)
+- [cfb5023](https://github.com/stashed/elasticsearch/commit/cfb5023) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#487)
+- [551eb3b](https://github.com/stashed/elasticsearch/commit/551eb3b) [cherry-pick] Update repository config (#471) (#478)
+- [df007da](https://github.com/stashed/elasticsearch/commit/df007da) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#469)
+- [c218201](https://github.com/stashed/elasticsearch/commit/c218201) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#460)
+
+
+### [7.3.2-v5](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v5)
+
+- [04e1f4f](https://github.com/stashed/elasticsearch/commit/04e1f4f) Prepare for release 7.3.2-v5 (#505)
+- [ea147c5](https://github.com/stashed/elasticsearch/commit/ea147c5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#489) (#497)
+- [893cfea](https://github.com/stashed/elasticsearch/commit/893cfea) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#480) (#488)
+- [f3ed4bf](https://github.com/stashed/elasticsearch/commit/f3ed4bf) [cherry-pick] Update repository config (#471) (#479)
+- [cb65c92](https://github.com/stashed/elasticsearch/commit/cb65c92) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#470)
+- [a3d520e](https://github.com/stashed/elasticsearch/commit/a3d520e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#453) (#461)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.8](https://github.com/stashed/installer/releases/tag/v0.11.8)
+
+- [c2c8362](https://github.com/stashed/installer/commit/c2c8362) Prepare for release v0.11.8 (#132)
+- [ae8900a](https://github.com/stashed/installer/commit/ae8900a) Speed up schema generation process (#131)
+- [262e0b5](https://github.com/stashed/installer/commit/262e0b5) Update repository config (#130)
+- [05f9e82](https://github.com/stashed/installer/commit/05f9e82) Delete DCO
+- [abaf344](https://github.com/stashed/installer/commit/abaf344) Update Kubernetes v1.18.9 dependencies (#129)
+- [2d928b1](https://github.com/stashed/installer/commit/2d928b1) Use apiregistration.k8s.io/v1 (#128)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8](https://github.com/stashed/mariadb/releases/tag/10.5.8)
+
+- [c11b255](https://github.com/stashed/mariadb/commit/c11b255) Prepare for release 10.5.8 (#38)
+- [2cc62f5](https://github.com/stashed/mariadb/commit/2cc62f5) [cherry-pick] Update chart-contents target (#37)
+- [1d99e4d](https://github.com/stashed/mariadb/commit/1d99e4d) Add support for MariaDB 10.5.8 (#14)
+- [484a8be](https://github.com/stashed/mariadb/commit/484a8be) Update Kubernetes v1.18.9 dependencies (#36)
+- [8e51d89](https://github.com/stashed/mariadb/commit/8e51d89) Update Kubernetes v1.18.9 dependencies (#35)
+- [f28b38c](https://github.com/stashed/mariadb/commit/f28b38c) Update Kubernetes v1.18.9 dependencies (#34)
+- [6bb158b](https://github.com/stashed/mariadb/commit/6bb158b) Update Kubernetes v1.18.9 dependencies (#33)
+- [96a2f9c](https://github.com/stashed/mariadb/commit/96a2f9c) Update Kubernetes v1.18.9 dependencies (#32)
+- [9c039e1](https://github.com/stashed/mariadb/commit/9c039e1) Update Kubernetes v1.18.9 dependencies (#31)
+- [cc724ca](https://github.com/stashed/mariadb/commit/cc724ca) Update Kubernetes v1.18.9 dependencies (#30)
+- [efae597](https://github.com/stashed/mariadb/commit/efae597) Update Kubernetes v1.18.9 dependencies (#29)
+- [90fd790](https://github.com/stashed/mariadb/commit/90fd790) Update Kubernetes v1.18.9 dependencies (#28)
+- [ac68465](https://github.com/stashed/mariadb/commit/ac68465) Update Kubernetes v1.18.9 dependencies (#27)
+- [ba7af92](https://github.com/stashed/mariadb/commit/ba7af92) Update Kubernetes v1.18.9 dependencies (#26)
+- [3b6c2c7](https://github.com/stashed/mariadb/commit/3b6c2c7) Update Kubernetes v1.18.9 dependencies (#25)
+- [9c9c161](https://github.com/stashed/mariadb/commit/9c9c161) Update Kubernetes v1.18.9 dependencies (#24)
+- [bf87299](https://github.com/stashed/mariadb/commit/bf87299) Update Kubernetes v1.18.9 dependencies (#23)
+- [947a95f](https://github.com/stashed/mariadb/commit/947a95f) Update Kubernetes v1.18.9 dependencies (#22)
+- [7588fc3](https://github.com/stashed/mariadb/commit/7588fc3) Update Kubernetes v1.18.9 dependencies (#21)
+- [669416e](https://github.com/stashed/mariadb/commit/669416e) Update Kubernetes v1.18.9 dependencies (#20)
+- [c0d2ac5](https://github.com/stashed/mariadb/commit/c0d2ac5) Update Kubernetes v1.18.9 dependencies (#19)
+- [798dd36](https://github.com/stashed/mariadb/commit/798dd36) Update Kubernetes v1.18.9 dependencies (#18)
+- [1648324](https://github.com/stashed/mariadb/commit/1648324) Update Kubernetes v1.18.9 dependencies (#17)
+- [6593603](https://github.com/stashed/mariadb/commit/6593603) Update Kubernetes v1.18.9 dependencies (#16)
+- [aa36f3c](https://github.com/stashed/mariadb/commit/aa36f3c) Update Kubernetes v1.18.9 dependencies (#15)
+- [15d9947](https://github.com/stashed/mariadb/commit/15d9947) Update Kubernetes v1.18.9 dependencies (#13)
+- [479ca8d](https://github.com/stashed/mariadb/commit/479ca8d) Update Kubernetes v1.18.9 dependencies (#12)
+- [ce73357](https://github.com/stashed/mariadb/commit/ce73357) Update Kubernetes v1.18.9 dependencies (#10)
+- [43c3ec2](https://github.com/stashed/mariadb/commit/43c3ec2) Update repository config (#11)
+- [00cd391](https://github.com/stashed/mariadb/commit/00cd391) Update Kubernetes v1.18.9 dependencies (#9)
+- [aea5290](https://github.com/stashed/mariadb/commit/aea5290) Update Kubernetes v1.18.9 dependencies (#8)
+- [bfff9f8](https://github.com/stashed/mariadb/commit/bfff9f8) Update Kubernetes v1.18.9 dependencies (#7)
+- [d8181c8](https://github.com/stashed/mariadb/commit/d8181c8) Update Kubernetes v1.18.9 dependencies (#6)
+- [fa64213](https://github.com/stashed/mariadb/commit/fa64213) Update Kubernetes v1.18.9 dependencies (#5)
+- [d1bd8a2](https://github.com/stashed/mariadb/commit/d1bd8a2) Update Kubernetes v1.18.9 dependencies (#4)
+- [1b64d94](https://github.com/stashed/mariadb/commit/1b64d94) Update repository config (#3)
+- [bac09d7](https://github.com/stashed/mariadb/commit/bac09d7) Update repository config (#2)
+- [8769371](https://github.com/stashed/mariadb/commit/8769371) Update Kubernetes v1.18.9 dependencies (#1)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v5](https://github.com/stashed/mongodb/releases/tag/3.4.17-v5)
+
+- [8446da57](https://github.com/stashed/mongodb/commit/8446da57) Prepare for release 3.4.17-v5 (#651)
+- [e53bd66b](https://github.com/stashed/mongodb/commit/e53bd66b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#640)
+- [164a0550](https://github.com/stashed/mongodb/commit/164a0550) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#628)
+- [ffd89381](https://github.com/stashed/mongodb/commit/ffd89381) [cherry-pick] Update repository config (#615) (#616)
+- [038d3800](https://github.com/stashed/mongodb/commit/038d3800) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#604)
+- [6b8d1b1c](https://github.com/stashed/mongodb/commit/6b8d1b1c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#592)
+
+
+### [3.4.22-v5](https://github.com/stashed/mongodb/releases/tag/3.4.22-v5)
+
+- [e33853a9](https://github.com/stashed/mongodb/commit/e33853a9) Prepare for release 3.4.22-v5 (#652)
+- [9acaefc6](https://github.com/stashed/mongodb/commit/9acaefc6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#641)
+- [814695e2](https://github.com/stashed/mongodb/commit/814695e2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#629)
+- [49b00083](https://github.com/stashed/mongodb/commit/49b00083) [cherry-pick] Update repository config (#615) (#617)
+- [27ba40d3](https://github.com/stashed/mongodb/commit/27ba40d3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#605)
+- [297d6932](https://github.com/stashed/mongodb/commit/297d6932) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#593)
+
+
+### [3.6.8-v5](https://github.com/stashed/mongodb/releases/tag/3.6.8-v5)
+
+- [31c09024](https://github.com/stashed/mongodb/commit/31c09024) Prepare for release 3.6.8-v5 (#654)
+- [e8bbdad4](https://github.com/stashed/mongodb/commit/e8bbdad4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#643)
+- [0623cd6b](https://github.com/stashed/mongodb/commit/0623cd6b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#631)
+- [e04c6e4d](https://github.com/stashed/mongodb/commit/e04c6e4d) [cherry-pick] Update repository config (#615) (#619)
+- [cbb64bcd](https://github.com/stashed/mongodb/commit/cbb64bcd) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#607)
+- [4485a5d4](https://github.com/stashed/mongodb/commit/4485a5d4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#595)
+
+
+### [3.6.13-v5](https://github.com/stashed/mongodb/releases/tag/3.6.13-v5)
+
+- [b6204090](https://github.com/stashed/mongodb/commit/b6204090) Prepare for release 3.6.13-v5 (#653)
+- [4be9caa1](https://github.com/stashed/mongodb/commit/4be9caa1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#642)
+- [d22abaa0](https://github.com/stashed/mongodb/commit/d22abaa0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#630)
+- [54bd4ef2](https://github.com/stashed/mongodb/commit/54bd4ef2) [cherry-pick] Update repository config (#615) (#618)
+- [73a1b87a](https://github.com/stashed/mongodb/commit/73a1b87a) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#606)
+- [929b7d9f](https://github.com/stashed/mongodb/commit/929b7d9f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#594)
+
+
+### [4.0.3-v5](https://github.com/stashed/mongodb/releases/tag/4.0.3-v5)
+
+- [7a9825fa](https://github.com/stashed/mongodb/commit/7a9825fa) Prepare for release 4.0.3-v5 (#656)
+- [8e266e3f](https://github.com/stashed/mongodb/commit/8e266e3f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#645)
+- [33b24502](https://github.com/stashed/mongodb/commit/33b24502) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#633)
+- [a3f42c8c](https://github.com/stashed/mongodb/commit/a3f42c8c) [cherry-pick] Update repository config (#615) (#621)
+- [9a28fdd3](https://github.com/stashed/mongodb/commit/9a28fdd3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#609)
+- [450dbfe1](https://github.com/stashed/mongodb/commit/450dbfe1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#597)
+
+
+### [4.0.5-v5](https://github.com/stashed/mongodb/releases/tag/4.0.5-v5)
+
+- [2b4d6c0b](https://github.com/stashed/mongodb/commit/2b4d6c0b) Prepare for release 4.0.5-v5 (#657)
+- [1532c3c3](https://github.com/stashed/mongodb/commit/1532c3c3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#646)
+- [aa601ec9](https://github.com/stashed/mongodb/commit/aa601ec9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#634)
+- [9b423801](https://github.com/stashed/mongodb/commit/9b423801) [cherry-pick] Update repository config (#615) (#622)
+- [81ae1857](https://github.com/stashed/mongodb/commit/81ae1857) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#610)
+- [d4ecdf06](https://github.com/stashed/mongodb/commit/d4ecdf06) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#598)
+
+
+### [4.0.11-v5](https://github.com/stashed/mongodb/releases/tag/4.0.11-v5)
+
+- [3d58d128](https://github.com/stashed/mongodb/commit/3d58d128) Prepare for release 4.0.11-v5 (#655)
+- [3efd27ec](https://github.com/stashed/mongodb/commit/3efd27ec) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#644)
+- [0700bb03](https://github.com/stashed/mongodb/commit/0700bb03) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#632)
+- [214b8f02](https://github.com/stashed/mongodb/commit/214b8f02) [cherry-pick] Update repository config (#615) (#620)
+- [adea0e7e](https://github.com/stashed/mongodb/commit/adea0e7e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#608)
+- [52d070a0](https://github.com/stashed/mongodb/commit/52d070a0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#596)
+
+
+### [4.1.4-v5](https://github.com/stashed/mongodb/releases/tag/4.1.4-v5)
+
+- [d3efc3b9](https://github.com/stashed/mongodb/commit/d3efc3b9) Prepare for release 4.1.4-v5 (#659)
+- [e5ad51d9](https://github.com/stashed/mongodb/commit/e5ad51d9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#648)
+- [1a71cc31](https://github.com/stashed/mongodb/commit/1a71cc31) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#636)
+- [f8f9f1f8](https://github.com/stashed/mongodb/commit/f8f9f1f8) [cherry-pick] Update repository config (#615) (#624)
+- [f548d611](https://github.com/stashed/mongodb/commit/f548d611) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#612)
+- [ffd16236](https://github.com/stashed/mongodb/commit/ffd16236) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#600)
+
+
+### [4.1.7-v5](https://github.com/stashed/mongodb/releases/tag/4.1.7-v5)
+
+- [09645ca2](https://github.com/stashed/mongodb/commit/09645ca2) Prepare for release 4.1.7-v5 (#660)
+- [4c1eb210](https://github.com/stashed/mongodb/commit/4c1eb210) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#649)
+- [a4848e57](https://github.com/stashed/mongodb/commit/a4848e57) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#637)
+- [63ea5b9e](https://github.com/stashed/mongodb/commit/63ea5b9e) [cherry-pick] Update repository config (#615) (#625)
+- [826348c4](https://github.com/stashed/mongodb/commit/826348c4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#613)
+- [64abe141](https://github.com/stashed/mongodb/commit/64abe141) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#601)
+
+
+### [4.1.13-v5](https://github.com/stashed/mongodb/releases/tag/4.1.13-v5)
+
+- [f9985076](https://github.com/stashed/mongodb/commit/f9985076) Prepare for release 4.1.13-v5 (#658)
+- [271f7b13](https://github.com/stashed/mongodb/commit/271f7b13) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#647)
+- [0598642c](https://github.com/stashed/mongodb/commit/0598642c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#635)
+- [d0e3ffd7](https://github.com/stashed/mongodb/commit/d0e3ffd7) [cherry-pick] Update repository config (#615) (#623)
+- [21981a19](https://github.com/stashed/mongodb/commit/21981a19) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#611)
+- [4213d19d](https://github.com/stashed/mongodb/commit/4213d19d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#599)
+
+
+### [4.2.3-v5](https://github.com/stashed/mongodb/releases/tag/4.2.3-v5)
+
+- [dc344fb3](https://github.com/stashed/mongodb/commit/dc344fb3) Prepare for release 4.2.3-v5 (#661)
+- [451544f4](https://github.com/stashed/mongodb/commit/451544f4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#639) (#650)
+- [499bdd68](https://github.com/stashed/mongodb/commit/499bdd68) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#627) (#638)
+- [f60aff42](https://github.com/stashed/mongodb/commit/f60aff42) [cherry-pick] Update repository config (#615) (#626)
+- [54755039](https://github.com/stashed/mongodb/commit/54755039) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#603) (#614)
+- [ad73a841](https://github.com/stashed/mongodb/commit/ad73a841) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#591) (#602)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v5](https://github.com/stashed/mysql/releases/tag/5.7.25-v5)
+
+- [5561dce](https://github.com/stashed/mysql/commit/5561dce) Prepare for release 5.7.25-v5 (#246)
+- [7b380f0](https://github.com/stashed/mysql/commit/7b380f0) Use port from the AppBinding (#234) (#243)
+- [3ea5fc8](https://github.com/stashed/mysql/commit/3ea5fc8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#239) (#240)
+- [7dcd320](https://github.com/stashed/mysql/commit/7dcd320) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#235) (#236)
+- [ea65a68](https://github.com/stashed/mysql/commit/ea65a68) [cherry-pick] Update repository config (#230) (#231)
+- [ba47f47](https://github.com/stashed/mysql/commit/ba47f47) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#226) (#227)
+- [775ff72](https://github.com/stashed/mysql/commit/775ff72) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#222) (#223)
+
+
+### [8.0.3-v5](https://github.com/stashed/mysql/releases/tag/8.0.3-v5)
+
+- [800f3da](https://github.com/stashed/mysql/commit/800f3da) Prepare for release 8.0.3-v5 (#248)
+- [74da539](https://github.com/stashed/mysql/commit/74da539) Use port from the AppBinding (#234) (#245)
+- [30852a5](https://github.com/stashed/mysql/commit/30852a5) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#239) (#242)
+- [de0721c](https://github.com/stashed/mysql/commit/de0721c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#235) (#238)
+- [6dd1480](https://github.com/stashed/mysql/commit/6dd1480) [cherry-pick] Update repository config (#230) (#233)
+- [bdf4d17](https://github.com/stashed/mysql/commit/bdf4d17) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#226) (#229)
+- [b404222](https://github.com/stashed/mysql/commit/b404222) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#222) (#225)
+
+
+### [8.0.14-v5](https://github.com/stashed/mysql/releases/tag/8.0.14-v5)
+
+- [1393938](https://github.com/stashed/mysql/commit/1393938) Prepare for release 8.0.14-v5 (#247)
+- [672cea7](https://github.com/stashed/mysql/commit/672cea7) Use port from the AppBinding (#234) (#244)
+- [1a04a62](https://github.com/stashed/mysql/commit/1a04a62) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#239) (#241)
+- [dd88423](https://github.com/stashed/mysql/commit/dd88423) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#235) (#237)
+- [890f0f1](https://github.com/stashed/mysql/commit/890f0f1) [cherry-pick] Update repository config (#230) (#232)
+- [0868321](https://github.com/stashed/mysql/commit/0868321) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#226) (#228)
+- [616dec4](https://github.com/stashed/mysql/commit/616dec4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#222) (#224)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7.0-v1](https://github.com/stashed/percona-xtradb/releases/tag/5.7.0-v1)
+
+- [3e48d47](https://github.com/stashed/percona-xtradb/commit/3e48d47) Prepare for release 5.7.0-v1 (#126)
+- [42458b3](https://github.com/stashed/percona-xtradb/commit/42458b3) Use port from AppBinding (#120) (#125)
+- [70d872d](https://github.com/stashed/percona-xtradb/commit/70d872d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#123) (#124)
+- [2927d77](https://github.com/stashed/percona-xtradb/commit/2927d77) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#121) (#122)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v4](https://github.com/stashed/postgres/releases/tag/9.6.19-v4)
+
+- [ef4d4e8](https://github.com/stashed/postgres/commit/ef4d4e8) Prepare for release 9.6.19-v4 (#499)
+- [6702c39](https://github.com/stashed/postgres/commit/6702c39) Use port from AppBinding (#461) (#494)
+- [36c0904](https://github.com/stashed/postgres/commit/36c0904) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#474) (#484)
+- [6903ab9](https://github.com/stashed/postgres/commit/6903ab9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#472)
+
+
+### [10.14.0-v4](https://github.com/stashed/postgres/releases/tag/10.14.0-v4)
+
+- [110a97f](https://github.com/stashed/postgres/commit/110a97f) Prepare for release 10.14.0-v4 (#495)
+- [0b3138c](https://github.com/stashed/postgres/commit/0b3138c) Use port from AppBinding (#461) (#485)
+- [1676e80](https://github.com/stashed/postgres/commit/1676e80) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#474) (#475)
+- [98e3e77](https://github.com/stashed/postgres/commit/98e3e77) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#463)
+
+
+### [11.9.0-v4](https://github.com/stashed/postgres/releases/tag/11.9.0-v4)
+
+- [719b8d1](https://github.com/stashed/postgres/commit/719b8d1) Prepare for release 11.9.0-v4 (#496)
+- [723403f](https://github.com/stashed/postgres/commit/723403f) Use port from AppBinding (#461) (#490)
+- [8b973a4](https://github.com/stashed/postgres/commit/8b973a4) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#474) (#480)
+- [726a5fa](https://github.com/stashed/postgres/commit/726a5fa) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#468)
+
+
+### [12.4.0-v4](https://github.com/stashed/postgres/releases/tag/12.4.0-v4)
+
+- [652db84](https://github.com/stashed/postgres/commit/652db84) Prepare for release 12.4.0-v4 (#497)
+- [12cf759](https://github.com/stashed/postgres/commit/12cf759) Use port from AppBinding (#461) (#491)
+- [c4f5823](https://github.com/stashed/postgres/commit/c4f5823) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#474) (#481)
+- [413d475](https://github.com/stashed/postgres/commit/413d475) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#469)
+
+
+### [13.1.0-v1](https://github.com/stashed/postgres/releases/tag/13.1.0-v1)
+
+- [e384f2f](https://github.com/stashed/postgres/commit/e384f2f) Prepare for release 13.1.0-v1 (#498)
+- [5725c15](https://github.com/stashed/postgres/commit/5725c15) Use port from AppBinding (#461) (#492)
+- [531f932](https://github.com/stashed/postgres/commit/531f932) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#474) (#482)
+- [e974cca](https://github.com/stashed/postgres/commit/e974cca) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#462) (#470)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.8](https://github.com/stashed/stash/releases/tag/v0.11.8)
+
+- [d06c4f1d](https://github.com/stashed/stash/commit/d06c4f1d) Prepare for release v0.11.8 (#1287)
+- [14dfff22](https://github.com/stashed/stash/commit/14dfff22) Run backup job as user 65535 (#1284)
+- [2379c0f8](https://github.com/stashed/stash/commit/2379c0f8) Fix secretTransformation for AppBinding (#1274)
+- [88c71b23](https://github.com/stashed/stash/commit/88c71b23) Update repository config (#1285)
+- [0667b421](https://github.com/stashed/stash/commit/0667b421) Update Kubernetes v1.18.9 dependencies (#1283)
+- [c01a1c95](https://github.com/stashed/stash/commit/c01a1c95) Update Kubernetes v1.18.9 dependencies (#1277)
+- [e953c0af](https://github.com/stashed/stash/commit/e953c0af) Use build, config, Kubernetes jobs for e2e workflow
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.12.17
Release-tracker: https://github.com/stashed/CHANGELOG/pull/25
Signed-off-by: 1gtm <1gtm@appscode.com>