### PR TITLE
Prepare for release v2021.01.21

### DIFF
--- a/docs/CHANGELOG-v2021.01.21.md
+++ b/docs/CHANGELOG-v2021.01.21.md
@@ -1,0 +1,241 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.01.21
+    name: Changelog-v2021.01.21
+    parent: welcome
+    weight: 20210121
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.01.21/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.01.21/
+---
+
+# Stash v2021.01.21 (2021-01-22)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.11.9](https://github.com/appscode/stash-enterprise/releases/tag/v0.11.9)
+
+- [88d87727](https://github.com/appscode/stash-enterprise/commit/88d87727) Prepare for release v0.11.9 (#68)
+- [bb802f88](https://github.com/appscode/stash-enterprise/commit/bb802f88) Update repository config (#66)
+- [52c63a81](https://github.com/appscode/stash-enterprise/commit/52c63a81) Update portforwarding api (#64)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.11.9](https://github.com/stashed/apimachinery/releases/tag/v0.11.9)
+
+- [bb631c73](https://github.com/stashed/apimachinery/commit/bb631c73) Update repository config (#80)
+- [d8cd6413](https://github.com/stashed/apimachinery/commit/d8cd6413) Update repository config (#79)
+- [0388c111](https://github.com/stashed/apimachinery/commit/0388c111) Update Kubernetes v1.18.9 dependencies (#78)
+- [10606b14](https://github.com/stashed/apimachinery/commit/10606b14) Update Kubernetes v1.18.9 dependencies (#77)
+- [04f9e8bf](https://github.com/stashed/apimachinery/commit/04f9e8bf) Update Kubernetes v1.18.9 dependencies (#76)
+
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2021.01.21](https://github.com/stashed/catalog/releases/tag/v2021.01.21)
+
+- [9b678ea](https://github.com/stashed/catalog/commit/9b678ea) Prepare for release v2021.01.21 (#52)
+- [6a227fe](https://github.com/stashed/catalog/commit/6a227fe) Update repository config (#51)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.11.9](https://github.com/stashed/cli/releases/tag/v0.11.9)
+
+- [0551150](https://github.com/stashed/cli/commit/0551150) Prepare for release v0.11.9 (#103)
+- [d6217c0](https://github.com/stashed/cli/commit/d6217c0) Update repository config (#102)
+- [3998037](https://github.com/stashed/cli/commit/3998037) Update repository config (#101)
+- [1ed5ff3](https://github.com/stashed/cli/commit/1ed5ff3) Update Kubernetes v1.18.9 dependencies (#100)
+- [beccb98](https://github.com/stashed/cli/commit/beccb98) Update Kubernetes v1.18.9 dependencies (#99)
+- [626d3ba](https://github.com/stashed/cli/commit/626d3ba) Update Kubernetes v1.18.9 dependencies (#98)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v6](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v6)
+
+- [08922c3](https://github.com/stashed/elasticsearch/commit/08922c3) Prepare for release 5.6.4-v6 (#579)
+- [069a5ab](https://github.com/stashed/elasticsearch/commit/069a5ab) [cherry-pick] Update repository config (#570) (#571)
+- [0d4ced1](https://github.com/stashed/elasticsearch/commit/0d4ced1) [cherry-pick] Update repository config (#561) (#562)
+- [ac1bcc6](https://github.com/stashed/elasticsearch/commit/ac1bcc6) [cherry-pick] Use node:14-alpine as base image (#552) (#553)
+- [0dab1a8](https://github.com/stashed/elasticsearch/commit/0dab1a8) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#544)
+- [34d300d](https://github.com/stashed/elasticsearch/commit/34d300d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#535)
+- [0343edd](https://github.com/stashed/elasticsearch/commit/0343edd) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#526)
+- [11fa1fd](https://github.com/stashed/elasticsearch/commit/11fa1fd) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#517)
+- [b7777f3](https://github.com/stashed/elasticsearch/commit/b7777f3) [cherry-pick] Speed up schema generation process (#507) (#508)
+
+
+### [6.2.4-v6](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v6)
+
+- [bf5a0fa](https://github.com/stashed/elasticsearch/commit/bf5a0fa) Prepare for release 6.2.4-v6 (#580)
+- [9e6d280](https://github.com/stashed/elasticsearch/commit/9e6d280) [cherry-pick] Update repository config (#570) (#572)
+- [df5cce2](https://github.com/stashed/elasticsearch/commit/df5cce2) [cherry-pick] Update repository config (#561) (#563)
+- [b3d40ce](https://github.com/stashed/elasticsearch/commit/b3d40ce) [cherry-pick] Use node:14-alpine as base image (#552) (#554)
+- [70b5f27](https://github.com/stashed/elasticsearch/commit/70b5f27) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#545)
+- [ec498f7](https://github.com/stashed/elasticsearch/commit/ec498f7) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#536)
+- [e819869](https://github.com/stashed/elasticsearch/commit/e819869) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#527)
+- [dfa8a1e](https://github.com/stashed/elasticsearch/commit/dfa8a1e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#518)
+- [7e3f45c](https://github.com/stashed/elasticsearch/commit/7e3f45c) [cherry-pick] Speed up schema generation process (#507) (#509)
+
+
+### [6.3.0-v6](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v6)
+
+- [e3e1afa](https://github.com/stashed/elasticsearch/commit/e3e1afa) Prepare for release 6.3.0-v6 (#581)
+- [8c75683](https://github.com/stashed/elasticsearch/commit/8c75683) [cherry-pick] Update repository config (#570) (#573)
+- [31557a4](https://github.com/stashed/elasticsearch/commit/31557a4) [cherry-pick] Update repository config (#561) (#564)
+- [059f6ec](https://github.com/stashed/elasticsearch/commit/059f6ec) [cherry-pick] Use node:14-alpine as base image (#552) (#555)
+- [87c4718](https://github.com/stashed/elasticsearch/commit/87c4718) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#546)
+- [5cb8af6](https://github.com/stashed/elasticsearch/commit/5cb8af6) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#537)
+- [6857924](https://github.com/stashed/elasticsearch/commit/6857924) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#528)
+- [4f4114f](https://github.com/stashed/elasticsearch/commit/4f4114f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#519)
+- [0f18d62](https://github.com/stashed/elasticsearch/commit/0f18d62) [cherry-pick] Speed up schema generation process (#507) (#510)
+
+
+### [6.4.0-v6](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v6)
+
+- [06e4dc6](https://github.com/stashed/elasticsearch/commit/06e4dc6) Prepare for release 6.4.0-v6 (#582)
+- [7eb1e44](https://github.com/stashed/elasticsearch/commit/7eb1e44) [cherry-pick] Update repository config (#570) (#574)
+- [30d0a80](https://github.com/stashed/elasticsearch/commit/30d0a80) [cherry-pick] Update repository config (#561) (#565)
+- [954e23a](https://github.com/stashed/elasticsearch/commit/954e23a) [cherry-pick] Use node:14-alpine as base image (#552) (#556)
+- [140abce](https://github.com/stashed/elasticsearch/commit/140abce) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#547)
+- [dfcd94b](https://github.com/stashed/elasticsearch/commit/dfcd94b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#538)
+- [2eea2d2](https://github.com/stashed/elasticsearch/commit/2eea2d2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#529)
+- [d73b741](https://github.com/stashed/elasticsearch/commit/d73b741) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#520)
+- [df6fd5c](https://github.com/stashed/elasticsearch/commit/df6fd5c) [cherry-pick] Speed up schema generation process (#507) (#511)
+
+
+### [6.5.3-v6](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v6)
+
+- [0a497b5](https://github.com/stashed/elasticsearch/commit/0a497b5) Prepare for release 6.5.3-v6 (#583)
+- [5bc7e7c](https://github.com/stashed/elasticsearch/commit/5bc7e7c) [cherry-pick] Update repository config (#570) (#575)
+- [76e4df1](https://github.com/stashed/elasticsearch/commit/76e4df1) [cherry-pick] Update repository config (#561) (#566)
+- [8fe2314](https://github.com/stashed/elasticsearch/commit/8fe2314) [cherry-pick] Use node:14-alpine as base image (#552) (#557)
+- [20c0eda](https://github.com/stashed/elasticsearch/commit/20c0eda) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#548)
+- [a567dc8](https://github.com/stashed/elasticsearch/commit/a567dc8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#539)
+- [7d00d9c](https://github.com/stashed/elasticsearch/commit/7d00d9c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#530)
+- [28df759](https://github.com/stashed/elasticsearch/commit/28df759) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#521)
+- [287c59c](https://github.com/stashed/elasticsearch/commit/287c59c) [cherry-pick] Speed up schema generation process (#507) (#512)
+
+
+### [6.8.0-v6](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v6)
+
+- [0c64799](https://github.com/stashed/elasticsearch/commit/0c64799) Prepare for release 6.8.0-v6 (#584)
+- [da93602](https://github.com/stashed/elasticsearch/commit/da93602) [cherry-pick] Update repository config (#570) (#576)
+- [197dd2f](https://github.com/stashed/elasticsearch/commit/197dd2f) [cherry-pick] Update repository config (#561) (#567)
+- [abd7a78](https://github.com/stashed/elasticsearch/commit/abd7a78) [cherry-pick] Use node:14-alpine as base image (#552) (#558)
+- [c942e6d](https://github.com/stashed/elasticsearch/commit/c942e6d) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#549)
+- [847e41d](https://github.com/stashed/elasticsearch/commit/847e41d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#540)
+- [146df5e](https://github.com/stashed/elasticsearch/commit/146df5e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#531)
+- [74ebe8f](https://github.com/stashed/elasticsearch/commit/74ebe8f) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#522)
+- [382939e](https://github.com/stashed/elasticsearch/commit/382939e) [cherry-pick] Speed up schema generation process (#507) (#513)
+
+
+### [7.2.0-v6](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v6)
+
+- [0e6c708](https://github.com/stashed/elasticsearch/commit/0e6c708) Prepare for release 7.2.0-v6 (#585)
+- [0da54b1](https://github.com/stashed/elasticsearch/commit/0da54b1) [cherry-pick] Update repository config (#570) (#577)
+- [0818310](https://github.com/stashed/elasticsearch/commit/0818310) [cherry-pick] Update repository config (#561) (#568)
+- [cd2f4e8](https://github.com/stashed/elasticsearch/commit/cd2f4e8) [cherry-pick] Use node:14-alpine as base image (#552) (#559)
+- [803f2bc](https://github.com/stashed/elasticsearch/commit/803f2bc) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#550)
+- [1ed55e0](https://github.com/stashed/elasticsearch/commit/1ed55e0) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#541)
+- [6e65169](https://github.com/stashed/elasticsearch/commit/6e65169) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#532)
+- [6ba13ae](https://github.com/stashed/elasticsearch/commit/6ba13ae) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#523)
+- [c37730e](https://github.com/stashed/elasticsearch/commit/c37730e) [cherry-pick] Speed up schema generation process (#507) (#514)
+
+
+### [7.3.2-v6](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v6)
+
+- [2767117](https://github.com/stashed/elasticsearch/commit/2767117) Prepare for release 7.3.2-v6 (#586)
+- [ce0a302](https://github.com/stashed/elasticsearch/commit/ce0a302) [cherry-pick] Update repository config (#570) (#578)
+- [01aefe2](https://github.com/stashed/elasticsearch/commit/01aefe2) [cherry-pick] Update repository config (#561) (#569)
+- [3b50d61](https://github.com/stashed/elasticsearch/commit/3b50d61) [cherry-pick] Use node:14-alpine as base image (#552) (#560)
+- [b7525e1](https://github.com/stashed/elasticsearch/commit/b7525e1) [cherry-pick] Use BasicAuth Keys for reading credentials from secret (#543) (#551)
+- [68591ee](https://github.com/stashed/elasticsearch/commit/68591ee) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#542)
+- [a14eb3e](https://github.com/stashed/elasticsearch/commit/a14eb3e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#525) (#533)
+- [ef63f91](https://github.com/stashed/elasticsearch/commit/ef63f91) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#516) (#524)
+- [4eb60cb](https://github.com/stashed/elasticsearch/commit/4eb60cb) [cherry-pick] Speed up schema generation process (#507) (#515)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.9](https://github.com/stashed/installer/releases/tag/v0.11.9)
+
+- [297af47](https://github.com/stashed/installer/commit/297af47) Prepare for release v0.11.9 (#135)
+- [9182697](https://github.com/stashed/installer/commit/9182697) Use kmodules.xyz/schema-checker to validate values schema (#134)
+- [7b2f051](https://github.com/stashed/installer/commit/7b2f051) Update repository config (#133)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v6](https://github.com/stashed/mysql/releases/tag/5.7.25-v6)
+
+- [a323265](https://github.com/stashed/mysql/commit/a323265) Prepare for release 5.7.25-v6 (#286)
+- [28fc525](https://github.com/stashed/mysql/commit/28fc525) [cherry-pick] /cherry-pick (#271) (#282)
+- [8eff987](https://github.com/stashed/mysql/commit/8eff987) [cherry-pick] Update repository config (#277) (#278)
+- [8c431a1](https://github.com/stashed/mysql/commit/8c431a1) [cherry-pick] Update repository config (#272) (#273)
+- [90540fe](https://github.com/stashed/mysql/commit/90540fe) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#266) (#267)
+- [75adb40](https://github.com/stashed/mysql/commit/75adb40) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#262) (#263)
+- [8a6631c](https://github.com/stashed/mysql/commit/8a6631c) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#258) (#259)
+- [c89196d](https://github.com/stashed/mysql/commit/c89196d) [cherry-pick] Generate README.md using templates (#254) (#255)
+- [38d1a2e](https://github.com/stashed/mysql/commit/38d1a2e) [cherry-pick] Speed up schema generation process (#250) (#251)
+
+
+### [8.0.3-v6](https://github.com/stashed/mysql/releases/tag/8.0.3-v6)
+
+- [239ab4b](https://github.com/stashed/mysql/commit/239ab4b) Prepare for release 8.0.3-v6 (#289)
+- [fb952a6](https://github.com/stashed/mysql/commit/fb952a6) /cherry-pick (#271) (#285)
+- [394a229](https://github.com/stashed/mysql/commit/394a229) [cherry-pick] Update repository config (#277) (#281)
+- [e8e2cf5](https://github.com/stashed/mysql/commit/e8e2cf5) [cherry-pick] Update repository config (#272) (#276)
+- [31a0894](https://github.com/stashed/mysql/commit/31a0894) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#266) (#270)
+- [2b7e67b](https://github.com/stashed/mysql/commit/2b7e67b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#262) (#265)
+- [ca0a700](https://github.com/stashed/mysql/commit/ca0a700) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#258) (#261)
+- [e7135de](https://github.com/stashed/mysql/commit/e7135de) [cherry-pick] Generate README.md using templates (#254) (#257)
+- [6cf15c3](https://github.com/stashed/mysql/commit/6cf15c3) [cherry-pick] Speed up schema generation process (#250) (#253)
+
+
+### [8.0.14-v6](https://github.com/stashed/mysql/releases/tag/8.0.14-v6)
+
+- [80103d0](https://github.com/stashed/mysql/commit/80103d0) Prepare for release 8.0.14-v6 (#287)
+- [1ba0074](https://github.com/stashed/mysql/commit/1ba0074) [cherry-pick] /cherry-pick (#271) (#283)
+- [d63cbc1](https://github.com/stashed/mysql/commit/d63cbc1) [cherry-pick] Update repository config (#277) (#279)
+- [9fb2be6](https://github.com/stashed/mysql/commit/9fb2be6) [cherry-pick] Update repository config (#272) (#274)
+- [9170a97](https://github.com/stashed/mysql/commit/9170a97) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#266) (#268)
+- [44f99e9](https://github.com/stashed/mysql/commit/44f99e9) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#262) (#264)
+- [52ffb49](https://github.com/stashed/mysql/commit/52ffb49) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#258) (#260)
+- [5979f66](https://github.com/stashed/mysql/commit/5979f66) [cherry-pick] Generate README.md using templates (#254) (#256)
+- [e96a04e](https://github.com/stashed/mysql/commit/e96a04e) [cherry-pick] Speed up schema generation process (#250) (#252)
+
+
+### [8.0.21](https://github.com/stashed/mysql/releases/tag/8.0.21)
+
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.11.9](https://github.com/stashed/stash/releases/tag/v0.11.9)
+
+- [fbc144b7](https://github.com/stashed/stash/commit/fbc144b7) Prepare for release v0.11.9 (#1300)
+- [7a2ee50c](https://github.com/stashed/stash/commit/7a2ee50c) Update repository config (#1299)
+- [597cd6b2](https://github.com/stashed/stash/commit/597cd6b2) Update repository config (#1298)
+- [182d5ebf](https://github.com/stashed/stash/commit/182d5ebf) Update Kubernetes v1.18.9 dependencies (#1295)
+- [a225db0c](https://github.com/stashed/stash/commit/a225db0c) Update portforwarding api (#1294)
+- [398ffd1e](https://github.com/stashed/stash/commit/398ffd1e) Update Kubernetes v1.18.9 dependencies (#1293)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.01.21
Release-tracker: https://github.com/stashed/CHANGELOG/pull/27
Signed-off-by: 1gtm <1gtm@appscode.com>