### PR TITLE
Prepare for release v2021.03.11

### DIFF
--- a/docs/CHANGELOG-v2021.03.11.md
+++ b/docs/CHANGELOG-v2021.03.11.md
@@ -1,0 +1,38 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.03.11
+    name: Changelog-v2021.03.11
+    parent: welcome
+    weight: 20210311
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.03.11/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.03.11/
+---
+
+# Stash v2021.03.11 (2021-03-12)
+
+
+## [stashed/catalog](https://github.com/stashed/catalog)
+
+### [v2021.03.11](https://github.com/stashed/catalog/releases/tag/v2021.03.11)
+
+- [3544e1b](https://github.com/stashed/catalog/commit/3544e1b) Update semvers library (#63)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.11.11](https://github.com/stashed/installer/releases/tag/v0.11.11)
+
+- [6cb1c71](https://github.com/stashed/installer/commit/6cb1c71) Prepare for release v0.11.11 (#159)
+- [3a8941a](https://github.com/stashed/installer/commit/3a8941a) Auto download api repo to update crds (#158)
+
+
+
+

--- a/docs/examples/guides/latest/auto-backup/database/sample-postgres-1.yaml
+++ b/docs/examples/guides/latest/auto-backup/database/sample-postgres-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-postgres-1
   namespace: demo
 spec:
-  version: "11.2"
+  version: "13.2"
   storageType: Durable
   storage:
     storageClassName: "standard"

--- a/docs/examples/guides/latest/auto-backup/database/sample-postgres-2.yaml
+++ b/docs/examples/guides/latest/auto-backup/database/sample-postgres-2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-postgres-2
   namespace: demo
 spec:
-  version: "10.6-v2"
+  version: "13.2"
   storageType: Durable
   storage:
     storageClassName: "standard"


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.03.11
Release-tracker: https://github.com/stashed/CHANGELOG/pull/31
Signed-off-by: 1gtm <1gtm@appscode.com>