### PR TITLE
Prepare for release v2021.03.17

### DIFF
--- a/docs/CHANGELOG-v2021.03.17.md
+++ b/docs/CHANGELOG-v2021.03.17.md
@@ -1,0 +1,162 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.03.17
+    name: Changelog-v2021.03.17
+    parent: welcome
+    weight: 20210317
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.03.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.03.17/
+---
+
+# Stash v2021.03.17 (2021-03-17)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.12.0](https://github.com/appscode/stash-enterprise/releases/tag/v0.12.0)
+
+- [301bd05f](https://github.com/appscode/stash-enterprise/commit/301bd05f) Prepare for release v0.12.0 (#86)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.12.0](https://github.com/stashed/apimachinery/releases/tag/v0.12.0)
+
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.12.0](https://github.com/stashed/cli/releases/tag/v0.12.0)
+
+- [f1ca9e2](https://github.com/stashed/cli/commit/f1ca9e2) Prepare for release v0.12.0 (#114)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.12.0](https://github.com/stashed/installer/releases/tag/v0.12.0)
+
+- [adbca35](https://github.com/stashed/installer/commit/adbca35) Prepare for release v0.12.0 (#166)
+- [47cc4cf](https://github.com/stashed/installer/commit/47cc4cf) Use perconaxtradb-*-5.7
+- [801f30c](https://github.com/stashed/installer/commit/801f30c) Update dependencies
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [10.14-v5](https://github.com/stashed/postgres/releases/tag/10.14-v5)
+
+- [57eecdc3](https://github.com/stashed/postgres/commit/57eecdc3) Prepare for release 10.14.0-v5 (#716)
+- [9a56adea](https://github.com/stashed/postgres/commit/9a56adea) Fix Makefile (#705) (#706)
+- [925bd8e6](https://github.com/stashed/postgres/commit/925bd8e6) TLS support for postgres (#694) (#695)
+- [6509c44f](https://github.com/stashed/postgres/commit/6509c44f) [cherry-pick] Update repository config (#683) (#684)
+- [31626977](https://github.com/stashed/postgres/commit/31626977) Add auto-backup doc + Restructure docs (#618) (#673)
+- [2602a2e5](https://github.com/stashed/postgres/commit/2602a2e5) [cherry-pick] Don't overwrite superuser password of restored database (#660) (#663)
+- [3a5c3f93](https://github.com/stashed/postgres/commit/3a5c3f93) Update repository config (#649) (#650)
+- [4638354a](https://github.com/stashed/postgres/commit/4638354a) Use restic 0.12.0 (#637) (#638)
+- [b81480ec](https://github.com/stashed/postgres/commit/b81480ec) Update Kubernetes v1.18.9 dependencies (#626) (#627)
+- [7f7c4eb8](https://github.com/stashed/postgres/commit/7f7c4eb8) [cherry-pick] Check codespan schema (#617) (#619)
+- [cab4cb38](https://github.com/stashed/postgres/commit/cab4cb38) [cherry-pick] Update repository config (#600) (#601)
+- [fd9fa30f](https://github.com/stashed/postgres/commit/fd9fa30f) [cherry-pick] Update repository config (#589) (#590)
+- [29f17df8](https://github.com/stashed/postgres/commit/29f17df8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#578) (#579)
+- [cb6be80f](https://github.com/stashed/postgres/commit/cb6be80f) [cherry-pick] Update repository config (#566) (#567)
+- [3033a772](https://github.com/stashed/postgres/commit/3033a772) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#556)
+- [bf03d98d](https://github.com/stashed/postgres/commit/bf03d98d) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#544) (#545)
+- [b2fdc143](https://github.com/stashed/postgres/commit/b2fdc143) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#535)
+- [c898ee57](https://github.com/stashed/postgres/commit/c898ee57) [cherry-pick] Update README.md template (#523) (#524)
+- [fadedccd](https://github.com/stashed/postgres/commit/fadedccd) [cherry-pick] Generate README.md using templates (#512) (#513)
+- [46e2b6dd](https://github.com/stashed/postgres/commit/46e2b6dd) [cherry-pick] Speed up schema generation process (#501) (#502)
+
+
+### [11.9-v5](https://github.com/stashed/postgres/releases/tag/11.9-v5)
+
+- [45ecd27f](https://github.com/stashed/postgres/commit/45ecd27f) Prepare for release 11.9-v5 (#725)
+- [e7c1360f](https://github.com/stashed/postgres/commit/e7c1360f) Move docs into stashed/docs repo + Cleanup (#723)
+- [2a7a4f96](https://github.com/stashed/postgres/commit/2a7a4f96) Prepare for release 11.9.0-v5 (#717)
+- [e673d3c0](https://github.com/stashed/postgres/commit/e673d3c0) Fix Makefile (#705) (#711)
+- [c8e9b998](https://github.com/stashed/postgres/commit/c8e9b998) TLS support for postgres (#694) (#700)
+- [ebc0a1f9](https://github.com/stashed/postgres/commit/ebc0a1f9) [cherry-pick] Update repository config (#683) (#689)
+- [baa94cf6](https://github.com/stashed/postgres/commit/baa94cf6) Add auto-backup doc + Restructure docs (#618) (#678)
+- [06d62688](https://github.com/stashed/postgres/commit/06d62688) [cherry-pick] Don't overwrite superuser password of restored database (#660) (#668)
+- [7fa729aa](https://github.com/stashed/postgres/commit/7fa729aa) Update repository config (#649) (#655)
+- [637daf85](https://github.com/stashed/postgres/commit/637daf85) Use restic 0.12.0 (#637) (#643)
+- [2ec2a638](https://github.com/stashed/postgres/commit/2ec2a638) Update Kubernetes v1.18.9 dependencies (#626) (#632)
+- [db0433ed](https://github.com/stashed/postgres/commit/db0433ed) [cherry-pick] Check codespan schema (#617) (#624)
+- [bb3d5515](https://github.com/stashed/postgres/commit/bb3d5515) [cherry-pick] Update repository config (#600) (#606)
+- [c5b40a97](https://github.com/stashed/postgres/commit/c5b40a97) [cherry-pick] Update repository config (#589) (#595)
+- [8ad35d50](https://github.com/stashed/postgres/commit/8ad35d50) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#578) (#584)
+- [b5230e5f](https://github.com/stashed/postgres/commit/b5230e5f) [cherry-pick] Update repository config (#566) (#572)
+- [593a9b7e](https://github.com/stashed/postgres/commit/593a9b7e) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#561)
+- [ce7aa9d1](https://github.com/stashed/postgres/commit/ce7aa9d1) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#544) (#550)
+- [ce8bdb41](https://github.com/stashed/postgres/commit/ce8bdb41) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#540)
+- [da4c7f5b](https://github.com/stashed/postgres/commit/da4c7f5b) [cherry-pick] Update README.md template (#523) (#529)
+- [d928f7ac](https://github.com/stashed/postgres/commit/d928f7ac) [cherry-pick] Generate README.md using templates (#512) (#518)
+- [8bdef7b5](https://github.com/stashed/postgres/commit/8bdef7b5) [cherry-pick] Speed up schema generation process (#501) (#507)
+
+
+### [12.4-v5](https://github.com/stashed/postgres/releases/tag/12.4-v5)
+
+- [b1140414](https://github.com/stashed/postgres/commit/b1140414) Prepare for release 12.4.0-v5 (#718)
+- [403dfb51](https://github.com/stashed/postgres/commit/403dfb51) Fix Makefile (#705) (#712)
+- [0e98e14e](https://github.com/stashed/postgres/commit/0e98e14e) TLS support for postgres (#694) (#701)
+- [dfc98b6e](https://github.com/stashed/postgres/commit/dfc98b6e) [cherry-pick] Update repository config (#683) (#690)
+- [3a8c1036](https://github.com/stashed/postgres/commit/3a8c1036) Add auto-backup doc + Restructure docs (#618) (#679)
+- [a14c26d8](https://github.com/stashed/postgres/commit/a14c26d8) [cherry-pick] Don't overwrite superuser password of restored database (#660) (#669)
+- [fc9f2302](https://github.com/stashed/postgres/commit/fc9f2302) Update repository config (#649) (#656)
+- [ee83ac04](https://github.com/stashed/postgres/commit/ee83ac04) Use restic 0.12.0 (#637) (#644)
+- [9b27b063](https://github.com/stashed/postgres/commit/9b27b063) Update Kubernetes v1.18.9 dependencies (#626) (#633)
+- [32d5df70](https://github.com/stashed/postgres/commit/32d5df70) [cherry-pick] Check codespan schema (#617) (#625)
+- [54bba3b1](https://github.com/stashed/postgres/commit/54bba3b1) [cherry-pick] Update repository config (#600) (#607)
+- [2ac504d2](https://github.com/stashed/postgres/commit/2ac504d2) [cherry-pick] Update repository config (#589) (#596)
+- [0b4f7bea](https://github.com/stashed/postgres/commit/0b4f7bea) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#578) (#585)
+- [e3e822f3](https://github.com/stashed/postgres/commit/e3e822f3) [cherry-pick] Update repository config (#566) (#573)
+- [956653e3](https://github.com/stashed/postgres/commit/956653e3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#562)
+- [ef5cc730](https://github.com/stashed/postgres/commit/ef5cc730) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#544) (#551)
+- [02a8fc1b](https://github.com/stashed/postgres/commit/02a8fc1b) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#541)
+- [8c4e765f](https://github.com/stashed/postgres/commit/8c4e765f) [cherry-pick] Update README.md template (#523) (#530)
+- [66da0577](https://github.com/stashed/postgres/commit/66da0577) [cherry-pick] Generate README.md using templates (#512) (#519)
+- [a5be3888](https://github.com/stashed/postgres/commit/a5be3888) [cherry-pick] Speed up schema generation process (#501) (#508)
+
+
+### [13.1-v2](https://github.com/stashed/postgres/releases/tag/13.1-v2)
+
+- [6c59e1eb](https://github.com/stashed/postgres/commit/6c59e1eb) Prepare for release 13.1.0-v2 (#719)
+- [be6c043a](https://github.com/stashed/postgres/commit/be6c043a) Fix Makefile (#705) (#713)
+- [8805ee06](https://github.com/stashed/postgres/commit/8805ee06) TLS support for postgres (#694) (#702)
+- [517a4e20](https://github.com/stashed/postgres/commit/517a4e20) [cherry-pick] Update repository config (#683) (#691)
+- [fc935ae7](https://github.com/stashed/postgres/commit/fc935ae7) Add auto-backup doc + Restructure docs (#618) (#680)
+- [ac84e6d3](https://github.com/stashed/postgres/commit/ac84e6d3) [cherry-pick] Don't overwrite superuser password of restored database (#660) (#670)
+- [6c195dfb](https://github.com/stashed/postgres/commit/6c195dfb) Update repository config (#649) (#657)
+- [ecd22af1](https://github.com/stashed/postgres/commit/ecd22af1) Use restic 0.12.0 (#637) (#645)
+- [3a1fe354](https://github.com/stashed/postgres/commit/3a1fe354) Update Kubernetes v1.18.9 dependencies (#626) (#634)
+- [c82407f8](https://github.com/stashed/postgres/commit/c82407f8) [cherry-pick] Update repository config (#600) (#608)
+- [6432d062](https://github.com/stashed/postgres/commit/6432d062) [cherry-pick] Update repository config (#589) (#597)
+- [2fe1bdf3](https://github.com/stashed/postgres/commit/2fe1bdf3) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#578) (#586)
+- [719fb462](https://github.com/stashed/postgres/commit/719fb462) [cherry-pick] Update repository config (#566) (#574)
+- [45871d26](https://github.com/stashed/postgres/commit/45871d26) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#555) (#563)
+- [ecd689c8](https://github.com/stashed/postgres/commit/ecd689c8) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#544) (#552)
+- [ad7687a2](https://github.com/stashed/postgres/commit/ad7687a2) [cherry-pick] Update Kubernetes v1.18.9 dependencies (#534) (#542)
+- [53fdf211](https://github.com/stashed/postgres/commit/53fdf211) [cherry-pick] Update README.md template (#523) (#531)
+- [5c5e670c](https://github.com/stashed/postgres/commit/5c5e670c) [cherry-pick] Generate README.md using templates (#512) (#520)
+- [a60735d0](https://github.com/stashed/postgres/commit/a60735d0) [cherry-pick] Speed up schema generation process (#501) (#509)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.12.0](https://github.com/stashed/stash/releases/tag/v0.12.0)
+
+- [b7700c29](https://github.com/stashed/stash/commit/b7700c29) Prepare for release v0.12.0 (#1330)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.03.17
Release-tracker: https://github.com/stashed/CHANGELOG/pull/32
Signed-off-by: 1gtm <1gtm@appscode.com>