### PR TITLE
Prepare for release v2021.04.07

### DIFF
--- a/docs/CHANGELOG-v2021.04.07.md
+++ b/docs/CHANGELOG-v2021.04.07.md
@@ -1,0 +1,74 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.04.07
+    name: Changelog-v2021.04.07
+    parent: welcome
+    weight: 20210407
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.04.07/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.04.07/
+---
+
+# Stash v2021.04.07 (2021-04-08)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.12.1](https://github.com/appscode/stash-enterprise/releases/tag/v0.12.1)
+
+- [e684150a](https://github.com/appscode/stash-enterprise/commit/e684150a) Prepare for release v0.12.1 (#89)
+- [8c03495c](https://github.com/appscode/stash-enterprise/commit/8c03495c) Don't use global registry for installing operator from Makefile (#88)
+- [fdf7b6d3](https://github.com/appscode/stash-enterprise/commit/fdf7b6d3) Use combined chart to install from Makefile (#87)
+- [3d1a2193](https://github.com/appscode/stash-enterprise/commit/3d1a2193) Update license verifier to v0.8.0
+- [4be954f0](https://github.com/appscode/stash-enterprise/commit/4be954f0) Update license verifier
+- [9a4f98db](https://github.com/appscode/stash-enterprise/commit/9a4f98db) Fix spelling
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.12.1](https://github.com/stashed/apimachinery/releases/tag/v0.12.1)
+
+- [2a71cd73](https://github.com/stashed/apimachinery/commit/2a71cd73) Fix spelling
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.12.1](https://github.com/stashed/cli/releases/tag/v0.12.1)
+
+- [2532f94](https://github.com/stashed/cli/commit/2532f94) Prepare for release v0.12.1 (#115)
+- [05bbfb4](https://github.com/stashed/cli/commit/05bbfb4) Fix spelling
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v0.12.1](https://github.com/stashed/installer/releases/tag/v0.12.1)
+
+- [9ec212c](https://github.com/stashed/installer/commit/9ec212c) Prepare for release v0.12.1 (#171)
+- [20a78f1](https://github.com/stashed/installer/commit/20a78f1) Allow passing registry fqdn (#170)
+- [f2688f6](https://github.com/stashed/installer/commit/f2688f6) Fix spelling
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.12.1](https://github.com/stashed/stash/releases/tag/v0.12.1)
+
+- [5c2f6eba](https://github.com/stashed/stash/commit/5c2f6eba) Prepare for release v0.12.1 (#1337)
+- [5b8b134f](https://github.com/stashed/stash/commit/5b8b134f) Don't use global resgistry to install operator from Makefile (#1336)
+- [32bc9f82](https://github.com/stashed/stash/commit/32bc9f82) Register RestoreBatch CRD + Fix Makefile (#1331)
+- [c42b3aee](https://github.com/stashed/stash/commit/c42b3aee) Update license verifier to v0.8.0
+- [083ec543](https://github.com/stashed/stash/commit/083ec543) Update license verifier
+- [db1668ba](https://github.com/stashed/stash/commit/db1668ba) Fix spelling
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.04.07
Release-tracker: https://github.com/stashed/CHANGELOG/pull/33
Signed-off-by: 1gtm <1gtm@appscode.com>