### PR TITLE
Prepare for release v2021.04.09

### DIFF
--- a/docs/CHANGELOG-v2021.04.09.md
+++ b/docs/CHANGELOG-v2021.04.09.md
@@ -1,0 +1,309 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.04.09
+    name: Changelog-v2021.04.09
+    parent: welcome
+    weight: 20210409
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.04.09/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.04.09/
+---
+
+# Stash v2021.04.09 (2021-04-09)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.12.2](https://github.com/appscode/stash-enterprise/releases/tag/v0.12.2)
+
+- [8692accb](https://github.com/appscode/stash-enterprise/commit/8692accb) Prepare for release v0.12.2 (#90)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.12.2](https://github.com/stashed/apimachinery/releases/tag/v0.12.2)
+
+- [2a0eefc6](https://github.com/stashed/apimachinery/commit/2a0eefc6) Update readme
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.12.2](https://github.com/stashed/cli/releases/tag/v0.12.2)
+
+- [9c95d5e](https://github.com/stashed/cli/commit/9c95d5e) Prepare for release v0.12.2 (#116)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v8](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v8)
+
+- [3267fe97](https://github.com/stashed/elasticsearch/commit/3267fe97) Prepare for release 5.6.4-v8 (#735)
+- [301c5556](https://github.com/stashed/elasticsearch/commit/301c5556) [cherry-pick] Update license verifier to v0.8.0 (#727)
+- [7f7dcc51](https://github.com/stashed/elasticsearch/commit/7f7dcc51) [cherry-pick] Update license verifier (#719)
+- [0676a68c](https://github.com/stashed/elasticsearch/commit/0676a68c) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [6.2.4-v8](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v8)
+
+- [3ff81b34](https://github.com/stashed/elasticsearch/commit/3ff81b34) Prepare for release 6.2.4-v8 (#736)
+- [49c75ffb](https://github.com/stashed/elasticsearch/commit/49c75ffb) [cherry-pick] Update license verifier to v0.8.0 (#728)
+- [abe48a84](https://github.com/stashed/elasticsearch/commit/abe48a84) [cherry-pick] Update license verifier (#720)
+- [0912790c](https://github.com/stashed/elasticsearch/commit/0912790c) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [6.3.0-v8](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v8)
+
+- [6018f259](https://github.com/stashed/elasticsearch/commit/6018f259) Prepare for release 6.3.0-v8 (#737)
+- [d479c0dd](https://github.com/stashed/elasticsearch/commit/d479c0dd) [cherry-pick] Update license verifier to v0.8.0 (#729)
+- [5e96c2ba](https://github.com/stashed/elasticsearch/commit/5e96c2ba) [cherry-pick] Update license verifier (#721)
+- [1e6f0d63](https://github.com/stashed/elasticsearch/commit/1e6f0d63) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [6.4.0-v8](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v8)
+
+- [cf4b7e4a](https://github.com/stashed/elasticsearch/commit/cf4b7e4a) Prepare for release 6.4.0-v8 (#738)
+- [b84ce80b](https://github.com/stashed/elasticsearch/commit/b84ce80b) [cherry-pick] Update license verifier to v0.8.0 (#730)
+- [ddab0380](https://github.com/stashed/elasticsearch/commit/ddab0380) [cherry-pick] Update license verifier (#722)
+- [1abd1cb8](https://github.com/stashed/elasticsearch/commit/1abd1cb8) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [6.5.3-v8](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v8)
+
+- [c095b0af](https://github.com/stashed/elasticsearch/commit/c095b0af) Prepare for release 6.5.3-v8 (#739)
+- [d5b9fc25](https://github.com/stashed/elasticsearch/commit/d5b9fc25) [cherry-pick] Update license verifier to v0.8.0 (#731)
+- [00ee62a7](https://github.com/stashed/elasticsearch/commit/00ee62a7) [cherry-pick] Update license verifier (#723)
+- [f12778ec](https://github.com/stashed/elasticsearch/commit/f12778ec) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [6.8.0-v8](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v8)
+
+- [0bce530d](https://github.com/stashed/elasticsearch/commit/0bce530d) Prepare for release 6.8.0-v8 (#740)
+- [983efdcf](https://github.com/stashed/elasticsearch/commit/983efdcf) [cherry-pick] Update license verifier to v0.8.0 (#732)
+- [b2238d19](https://github.com/stashed/elasticsearch/commit/b2238d19) [cherry-pick] Update license verifier (#724)
+- [8099ace3](https://github.com/stashed/elasticsearch/commit/8099ace3) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [7.2.0-v8](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v8)
+
+- [c3777969](https://github.com/stashed/elasticsearch/commit/c3777969) Prepare for release 7.2.0-v8 (#741)
+- [efbd66ba](https://github.com/stashed/elasticsearch/commit/efbd66ba) [cherry-pick] Update license verifier to v0.8.0 (#733)
+- [120bef54](https://github.com/stashed/elasticsearch/commit/120bef54) [cherry-pick] Update license verifier (#725)
+- [142238e6](https://github.com/stashed/elasticsearch/commit/142238e6) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+### [7.3.2-v8](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v8)
+
+- [0d2ba065](https://github.com/stashed/elasticsearch/commit/0d2ba065) Prepare for release 7.3.2-v8 (#742)
+- [7252f84c](https://github.com/stashed/elasticsearch/commit/7252f84c) [cherry-pick] Update license verifier to v0.8.0 (#734)
+- [fdaa39d3](https://github.com/stashed/elasticsearch/commit/fdaa39d3) [cherry-pick] Update license verifier (#726)
+- [e28fcc97](https://github.com/stashed/elasticsearch/commit/e28fcc97) Move docs into stashed/docs repo + Cleanup (#718)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2021.04.09](https://github.com/stashed/installer/releases/tag/v2021.04.09)
+
+- [39bdc8e](https://github.com/stashed/installer/commit/39bdc8e) Prepare for release v2021.04.09 (#172)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v2](https://github.com/stashed/mariadb/releases/tag/10.5.8-v2)
+
+- [cb2457b](https://github.com/stashed/mariadb/commit/cb2457b) Prepare for release 10.5.8-v2 (#92)
+- [9ad8d65](https://github.com/stashed/mariadb/commit/9ad8d65) [cherry-pick] Update license verifier to v0.8.0 (#91)
+- [32d8eab](https://github.com/stashed/mariadb/commit/32d8eab) [cherry-pick] Update license verifier (#90)
+- [99e66bf](https://github.com/stashed/mariadb/commit/99e66bf) Move docs into stashed/docs repo + Cleanup (#89)
+- [017f7dc](https://github.com/stashed/mariadb/commit/017f7dc) [cherry-pick] Update MariaDB Image version from 10.5 to 10.5.8 (#85) (#86)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v7](https://github.com/stashed/mongodb/releases/tag/3.4.17-v7)
+
+- [c330b36d](https://github.com/stashed/mongodb/commit/c330b36d) Prepare for release 3.4.17-v7 (#874)
+- [7cc2dc3a](https://github.com/stashed/mongodb/commit/7cc2dc3a) [cherry-pick] Update license verifier to v0.8.0 (#864)
+- [819ae84e](https://github.com/stashed/mongodb/commit/819ae84e) [cherry-pick] Update license verifier (#856)
+- [04461734](https://github.com/stashed/mongodb/commit/04461734) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [3.4.22-v7](https://github.com/stashed/mongodb/releases/tag/3.4.22-v7)
+
+- [cf3b8d58](https://github.com/stashed/mongodb/commit/cf3b8d58) Prepare for release 3.4.22-v7 (#875)
+- [009e15c7](https://github.com/stashed/mongodb/commit/009e15c7) [cherry-pick] Update license verifier to v0.8.0 (#865)
+- [a9ac247a](https://github.com/stashed/mongodb/commit/a9ac247a) [cherry-pick] Update license verifier (#857)
+- [fcef85e4](https://github.com/stashed/mongodb/commit/fcef85e4) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [3.6.8-v7](https://github.com/stashed/mongodb/releases/tag/3.6.8-v7)
+
+- [b8e59d9f](https://github.com/stashed/mongodb/commit/b8e59d9f) Prepare for release 3.6.8-v7 (#877)
+- [5854bdcb](https://github.com/stashed/mongodb/commit/5854bdcb) [cherry-pick] Update license verifier (#859)
+- [7c5b032d](https://github.com/stashed/mongodb/commit/7c5b032d) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [3.6.13-v7](https://github.com/stashed/mongodb/releases/tag/3.6.13-v7)
+
+- [bf2677df](https://github.com/stashed/mongodb/commit/bf2677df) Prepare for release 3.6.13-v7 (#876)
+- [54301fe1](https://github.com/stashed/mongodb/commit/54301fe1) [cherry-pick] Update license verifier to v0.8.0 (#866)
+- [1de5beaf](https://github.com/stashed/mongodb/commit/1de5beaf) [cherry-pick] Update license verifier (#858)
+- [25d23e5e](https://github.com/stashed/mongodb/commit/25d23e5e) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.0.3-v7](https://github.com/stashed/mongodb/releases/tag/4.0.3-v7)
+
+- [9ec6ccd0](https://github.com/stashed/mongodb/commit/9ec6ccd0) Prepare for release 4.0.3-v7 (#879)
+- [cf982cca](https://github.com/stashed/mongodb/commit/cf982cca) [cherry-pick] Update license verifier to v0.8.0 (#868)
+- [e8cdd177](https://github.com/stashed/mongodb/commit/e8cdd177) [cherry-pick] Update license verifier (#861)
+- [fc2e6da5](https://github.com/stashed/mongodb/commit/fc2e6da5) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.0.5-v7](https://github.com/stashed/mongodb/releases/tag/4.0.5-v7)
+
+- [4976afaf](https://github.com/stashed/mongodb/commit/4976afaf) Prepare for release 4.0.5-v7 (#880)
+- [091ba134](https://github.com/stashed/mongodb/commit/091ba134) [cherry-pick] Update license verifier to v0.8.0 (#869)
+- [f3b618ac](https://github.com/stashed/mongodb/commit/f3b618ac) [cherry-pick] Update license verifier (#862)
+- [69d29d04](https://github.com/stashed/mongodb/commit/69d29d04) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.0.11-v7](https://github.com/stashed/mongodb/releases/tag/4.0.11-v7)
+
+- [7c9f57cf](https://github.com/stashed/mongodb/commit/7c9f57cf) Prepare for release 4.0.11-v7 (#878)
+- [e7346419](https://github.com/stashed/mongodb/commit/e7346419) [cherry-pick] Update license verifier to v0.8.0 (#867)
+- [02e4dfb3](https://github.com/stashed/mongodb/commit/02e4dfb3) [cherry-pick] Update license verifier (#860)
+- [d0dee643](https://github.com/stashed/mongodb/commit/d0dee643) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.1.4-v7](https://github.com/stashed/mongodb/releases/tag/4.1.4-v7)
+
+- [a4961009](https://github.com/stashed/mongodb/commit/a4961009) Prepare for release 4.1.4-v7 (#882)
+- [2d167d67](https://github.com/stashed/mongodb/commit/2d167d67) [cherry-pick] Update license verifier to v0.8.0 (#871)
+- [27ae4cc2](https://github.com/stashed/mongodb/commit/27ae4cc2) Update license verifier
+- [0cd2fb73](https://github.com/stashed/mongodb/commit/0cd2fb73) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.1.7-v7](https://github.com/stashed/mongodb/releases/tag/4.1.7-v7)
+
+- [b8323b2f](https://github.com/stashed/mongodb/commit/b8323b2f) Prepare for release 4.1.7-v7 (#883)
+- [1ccc8c61](https://github.com/stashed/mongodb/commit/1ccc8c61) [cherry-pick] Update license verifier to v0.8.0 (#872)
+- [d03df49b](https://github.com/stashed/mongodb/commit/d03df49b) Update license verifier
+- [d1808ec4](https://github.com/stashed/mongodb/commit/d1808ec4) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.1.13-v7](https://github.com/stashed/mongodb/releases/tag/4.1.13-v7)
+
+- [53eb5dc1](https://github.com/stashed/mongodb/commit/53eb5dc1) Prepare for release 4.1.13-v7 (#881)
+- [3419f461](https://github.com/stashed/mongodb/commit/3419f461) [cherry-pick] Update license verifier to v0.8.0 (#870)
+- [16d315f6](https://github.com/stashed/mongodb/commit/16d315f6) [cherry-pick] Update license verifier (#863)
+- [118fd042](https://github.com/stashed/mongodb/commit/118fd042) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+### [4.2.3-v7](https://github.com/stashed/mongodb/releases/tag/4.2.3-v7)
+
+- [4e45e4ca](https://github.com/stashed/mongodb/commit/4e45e4ca) Prepare for release 4.2.3-v7 (#884)
+- [7271e889](https://github.com/stashed/mongodb/commit/7271e889) [cherry-pick] Update license verifier to v0.8.0 (#873)
+- [ddeff341](https://github.com/stashed/mongodb/commit/ddeff341) Update license verifier
+- [2806781c](https://github.com/stashed/mongodb/commit/2806781c) Move docs into stashed/docs repo + Cleanup (#855)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v8](https://github.com/stashed/mysql/releases/tag/5.7.25-v8)
+
+- [43e5c9f](https://github.com/stashed/mysql/commit/43e5c9f) Prepare for release 5.7.25-v8 (#364)
+- [251608d](https://github.com/stashed/mysql/commit/251608d) [cherry-pick] Update license verifier to v0.8.0 (#360)
+- [2c41000](https://github.com/stashed/mysql/commit/2c41000) [cherry-pick] Update license verifier (#356)
+- [9ee9e47](https://github.com/stashed/mysql/commit/9ee9e47) Move docs into stashed/docs repo + Cleanup (#355)
+
+
+### [8.0.3-v8](https://github.com/stashed/mysql/releases/tag/8.0.3-v8)
+
+- [363bcab](https://github.com/stashed/mysql/commit/363bcab) Prepare for release 8.0.3-v8 (#367)
+- [174f01c](https://github.com/stashed/mysql/commit/174f01c) [cherry-pick] Update license verifier to v0.8.0 (#363)
+- [42f6d9d](https://github.com/stashed/mysql/commit/42f6d9d) [cherry-pick] Update license verifier (#359)
+- [10c6a6f](https://github.com/stashed/mysql/commit/10c6a6f) Move docs into stashed/docs repo + Cleanup (#355)
+
+
+### [8.0.14-v8](https://github.com/stashed/mysql/releases/tag/8.0.14-v8)
+
+- [ef07360](https://github.com/stashed/mysql/commit/ef07360) Prepare for release 8.0.14-v8 (#365)
+- [4567286](https://github.com/stashed/mysql/commit/4567286) [cherry-pick] Update license verifier to v0.8.0 (#361)
+- [12336f3](https://github.com/stashed/mysql/commit/12336f3) [cherry-pick] Update license verifier (#357)
+- [3131282](https://github.com/stashed/mysql/commit/3131282) Move docs into stashed/docs repo + Cleanup (#355)
+
+
+### [8.0.21-v2](https://github.com/stashed/mysql/releases/tag/8.0.21-v2)
+
+- [a1fd10f](https://github.com/stashed/mysql/commit/a1fd10f) Prepare for release 8.0.21-v2 (#366)
+- [63f2184](https://github.com/stashed/mysql/commit/63f2184) [cherry-pick] Update license verifier to v0.8.0 (#362)
+- [24ebab1](https://github.com/stashed/mysql/commit/24ebab1) [cherry-pick] Update license verifier (#358)
+- [47ff7a2](https://github.com/stashed/mysql/commit/47ff7a2) Move docs into stashed/docs repo + Cleanup (#355)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v6](https://github.com/stashed/postgres/releases/tag/9.6.19-v6)
+
+- [952e50a2](https://github.com/stashed/postgres/commit/952e50a2) Prepare for release 9.6.19-v6 (#744)
+- [271c6399](https://github.com/stashed/postgres/commit/271c6399) [cherry-pick] Update license verifier to v0.8.0 (#739)
+- [a4f8fdfd](https://github.com/stashed/postgres/commit/a4f8fdfd) [cherry-pick] Update license verifier (#734)
+- [7deba428](https://github.com/stashed/postgres/commit/7deba428) Prepare for release 9.6.19-v5 (#728)
+- [372ed379](https://github.com/stashed/postgres/commit/372ed379) Move docs into stashed/docs repo + Cleanup (#723)
+
+
+### [10.14-v6](https://github.com/stashed/postgres/releases/tag/10.14-v6)
+
+- [6e5e02c0](https://github.com/stashed/postgres/commit/6e5e02c0) Prepare for release 10.14-v6 (#740)
+- [dc5cea73](https://github.com/stashed/postgres/commit/dc5cea73) [cherry-pick] Update license verifier to v0.8.0 (#735)
+- [1578dde5](https://github.com/stashed/postgres/commit/1578dde5) [cherry-pick] Update license verifier (#730)
+- [c08f7b46](https://github.com/stashed/postgres/commit/c08f7b46) Prepare for release 10.14-v5 (#724)
+- [23e24762](https://github.com/stashed/postgres/commit/23e24762) Move docs into stashed/docs repo + Cleanup (#723)
+
+
+### [11.9-v6](https://github.com/stashed/postgres/releases/tag/11.9-v6)
+
+- [ccf2b20e](https://github.com/stashed/postgres/commit/ccf2b20e) Prepare for release 11.9-v6 (#741)
+- [9f1c4f5e](https://github.com/stashed/postgres/commit/9f1c4f5e) [cherry-pick] Update license verifier to v0.8.0 (#736)
+- [59907d93](https://github.com/stashed/postgres/commit/59907d93) [cherry-pick] Update license verifier (#731)
+- [45ecd27f](https://github.com/stashed/postgres/commit/45ecd27f) Prepare for release 11.9-v5 (#725)
+- [e7c1360f](https://github.com/stashed/postgres/commit/e7c1360f) Move docs into stashed/docs repo + Cleanup (#723)
+
+
+### [12.4-v6](https://github.com/stashed/postgres/releases/tag/12.4-v6)
+
+- [582fb725](https://github.com/stashed/postgres/commit/582fb725) Prepare for release 12.4-v6 (#742)
+- [b21ade58](https://github.com/stashed/postgres/commit/b21ade58) [cherry-pick] Update license verifier to v0.8.0 (#737)
+- [4c0126bf](https://github.com/stashed/postgres/commit/4c0126bf) [cherry-pick] Update license verifier (#732)
+
+
+### [13.1-v3](https://github.com/stashed/postgres/releases/tag/13.1-v3)
+
+- [2d214d15](https://github.com/stashed/postgres/commit/2d214d15) Prepare for release 13.1-v3 (#743)
+- [2da7f9fb](https://github.com/stashed/postgres/commit/2da7f9fb) [cherry-pick] Update license verifier to v0.8.0 (#738)
+- [842effc0](https://github.com/stashed/postgres/commit/842effc0) [cherry-pick] Update license verifier (#733)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.12.2](https://github.com/stashed/stash/releases/tag/v0.12.2)
+
+- [50f8a075](https://github.com/stashed/stash/commit/50f8a075) Prepare for release v0.12.2 (#1338)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.04.09
Release-tracker: https://github.com/stashed/CHANGELOG/pull/34
Signed-off-by: 1gtm <1gtm@appscode.com>