### PR TITLE
Prepare for release v2021.04.12

### DIFF
--- a/docs/CHANGELOG-v2021.04.12.md
+++ b/docs/CHANGELOG-v2021.04.12.md
@@ -1,0 +1,245 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.04.12
+    name: Changelog-v2021.04.12
+    parent: welcome
+    weight: 20210412
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.04.12/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.04.12/
+---
+
+# Stash v2021.04.12 (2021-04-10)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.12.3](https://github.com/appscode/stash-enterprise/releases/tag/v0.12.3)
+
+- [4511a60f](https://github.com/appscode/stash-enterprise/commit/4511a60f) Prepare for release v0.12.3 (#91)
+- [d84a4d5b](https://github.com/appscode/stash-enterprise/commit/d84a4d5b) Use license-verifier v0.8.1
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.12.3](https://github.com/stashed/apimachinery/releases/tag/v0.12.3)
+
+- [02428080](https://github.com/stashed/apimachinery/commit/02428080) Update readme
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.12.3](https://github.com/stashed/cli/releases/tag/v0.12.3)
+
+- [2dfae90](https://github.com/stashed/cli/commit/2dfae90) Prepare for release v0.12.3 (#117)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v9](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v9)
+
+- [4418b9be](https://github.com/stashed/elasticsearch/commit/4418b9be) Prepare for release 5.6.4-v9 (#749)
+- [4472510b](https://github.com/stashed/elasticsearch/commit/4472510b) [cherry-pick] Use license-verifier v0.8.1 (#744)
+
+
+### [6.2.4-v9](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v9)
+
+- [20b4c3ad](https://github.com/stashed/elasticsearch/commit/20b4c3ad) Prepare for release 6.2.4-v9 (#750)
+- [dbd0843d](https://github.com/stashed/elasticsearch/commit/dbd0843d) [cherry-pick] Use license-verifier v0.8.1 (#745)
+
+
+### [6.3.0-v9](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v9)
+
+- [f2a8bfd1](https://github.com/stashed/elasticsearch/commit/f2a8bfd1) Prepare for release 6.3.0-v9 (#751)
+- [13983884](https://github.com/stashed/elasticsearch/commit/13983884) [cherry-pick] Use license-verifier v0.8.1 (#746)
+
+
+### [6.4.0-v9](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v9)
+
+- [c24d3b01](https://github.com/stashed/elasticsearch/commit/c24d3b01) Prepare for release 6.4.0-v9 (#752)
+- [6852abf1](https://github.com/stashed/elasticsearch/commit/6852abf1) [cherry-pick] Use license-verifier v0.8.1 (#747)
+
+
+### [6.5.3-v9](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v9)
+
+- [7a6fbe57](https://github.com/stashed/elasticsearch/commit/7a6fbe57) Prepare for release 6.5.3-v9 (#753)
+- [66955dcb](https://github.com/stashed/elasticsearch/commit/66955dcb) [cherry-pick] Use license-verifier v0.8.1 (#748)
+
+
+### [6.8.0-v9](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v9)
+
+- [94e32907](https://github.com/stashed/elasticsearch/commit/94e32907) Prepare for release 6.8.0-v9 (#754)
+
+
+### [7.2.0-v9](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v9)
+
+- [4830e6d2](https://github.com/stashed/elasticsearch/commit/4830e6d2) Prepare for release 7.2.0-v9 (#755)
+
+
+### [7.3.2-v9](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v9)
+
+- [9dc99760](https://github.com/stashed/elasticsearch/commit/9dc99760) Prepare for release 7.3.2-v9 (#756)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2021.04.12](https://github.com/stashed/installer/releases/tag/v2021.04.12)
+
+- [2814743](https://github.com/stashed/installer/commit/2814743) Prepare for release v2021.04.12 (#173)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v3](https://github.com/stashed/mariadb/releases/tag/10.5.8-v3)
+
+- [978701f](https://github.com/stashed/mariadb/commit/978701f) Prepare for release 10.5.8-v3 (#95)
+- [365ef64](https://github.com/stashed/mariadb/commit/365ef64) [cherry-pick] Use license-verifier v0.8.1 (#94)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v8](https://github.com/stashed/mongodb/releases/tag/3.4.17-v8)
+
+- [08dbb5de](https://github.com/stashed/mongodb/commit/08dbb5de) Prepare for release 3.4.17-v8 (#895)
+- [4794aac5](https://github.com/stashed/mongodb/commit/4794aac5) [cherry-pick] Use license-verifier v0.8.1 (#887)
+
+
+### [3.4.22-v8](https://github.com/stashed/mongodb/releases/tag/3.4.22-v8)
+
+- [fd4313cf](https://github.com/stashed/mongodb/commit/fd4313cf) Prepare for release 3.4.22-v8 (#896)
+- [cc166dc9](https://github.com/stashed/mongodb/commit/cc166dc9) [cherry-pick] Use license-verifier v0.8.1 (#888)
+
+
+### [3.6.8-v8](https://github.com/stashed/mongodb/releases/tag/3.6.8-v8)
+
+- [5a1413b3](https://github.com/stashed/mongodb/commit/5a1413b3) Prepare for release 3.6.8-v8 (#898)
+- [3188dd06](https://github.com/stashed/mongodb/commit/3188dd06) [cherry-pick] Use license-verifier v0.8.1 (#890)
+- [1687801d](https://github.com/stashed/mongodb/commit/1687801d) Update license verifier to v0.8.0 (#885)
+
+
+### [3.6.13-v8](https://github.com/stashed/mongodb/releases/tag/3.6.13-v8)
+
+- [1ed5ecde](https://github.com/stashed/mongodb/commit/1ed5ecde) Prepare for release 3.6.13-v8 (#897)
+- [e41bdcaf](https://github.com/stashed/mongodb/commit/e41bdcaf) [cherry-pick] Use license-verifier v0.8.1 (#889)
+
+
+### [4.0.3-v8](https://github.com/stashed/mongodb/releases/tag/4.0.3-v8)
+
+- [8df38a7f](https://github.com/stashed/mongodb/commit/8df38a7f) Prepare for release 4.0.3-v8 (#900)
+- [8ac8b340](https://github.com/stashed/mongodb/commit/8ac8b340) [cherry-pick] Use license-verifier v0.8.1 (#892)
+
+
+### [4.0.5-v8](https://github.com/stashed/mongodb/releases/tag/4.0.5-v8)
+
+- [e7ce9e4b](https://github.com/stashed/mongodb/commit/e7ce9e4b) Prepare for release 4.0.5-v8 (#901)
+- [90f5bb72](https://github.com/stashed/mongodb/commit/90f5bb72) [cherry-pick] Use license-verifier v0.8.1 (#893)
+
+
+### [4.0.11-v8](https://github.com/stashed/mongodb/releases/tag/4.0.11-v8)
+
+- [2000f928](https://github.com/stashed/mongodb/commit/2000f928) Prepare for release 4.0.11-v8 (#899)
+- [3e95bb83](https://github.com/stashed/mongodb/commit/3e95bb83) [cherry-pick] Use license-verifier v0.8.1 (#891)
+
+
+### [4.1.4-v8](https://github.com/stashed/mongodb/releases/tag/4.1.4-v8)
+
+- [be030cab](https://github.com/stashed/mongodb/commit/be030cab) Use license-verifier v0.8.1 (#905)
+- [0f0c448e](https://github.com/stashed/mongodb/commit/0f0c448e) Prepare for release 4.1.4-v8 (#903)
+
+
+### [4.1.7-v8](https://github.com/stashed/mongodb/releases/tag/4.1.7-v8)
+
+- [584b22c9](https://github.com/stashed/mongodb/commit/584b22c9) Use license-verifier v0.8.1 (#906)
+- [c37c8f8d](https://github.com/stashed/mongodb/commit/c37c8f8d) Prepare for release 4.1.7-v8 (#904)
+
+
+### [4.1.13-v8](https://github.com/stashed/mongodb/releases/tag/4.1.13-v8)
+
+- [391d1cd5](https://github.com/stashed/mongodb/commit/391d1cd5) Use license-verifier v0.8.1 (#907)
+- [f6519aa2](https://github.com/stashed/mongodb/commit/f6519aa2) Prepare for release 4.1.13-v8 (#902)
+
+
+### [4.2.3-v8](https://github.com/stashed/mongodb/releases/tag/4.2.3-v8)
+
+- [67b1ba2d](https://github.com/stashed/mongodb/commit/67b1ba2d) Prepare for release 4.2.3-v8 (#908)
+- [2a2a8e00](https://github.com/stashed/mongodb/commit/2a2a8e00) [cherry-pick] Use license-verifier v0.8.1 (#894)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v9](https://github.com/stashed/mysql/releases/tag/5.7.25-v9)
+
+- [1a963f9](https://github.com/stashed/mysql/commit/1a963f9) Prepare for release 5.7.25-v9 (#372)
+- [da866ee](https://github.com/stashed/mysql/commit/da866ee) [cherry-pick] Use license-verifier v0.8.1 (#369)
+
+
+### [8.0.3-v9](https://github.com/stashed/mysql/releases/tag/8.0.3-v9)
+
+- [3f2b1b0](https://github.com/stashed/mysql/commit/3f2b1b0) Prepare for release 8.0.3-v9 (#375)
+
+
+### [8.0.14-v9](https://github.com/stashed/mysql/releases/tag/8.0.14-v9)
+
+- [5af1e60](https://github.com/stashed/mysql/commit/5af1e60) Prepare for release 8.0.14-v9 (#373)
+- [0ebdaa8](https://github.com/stashed/mysql/commit/0ebdaa8) [cherry-pick] Use license-verifier v0.8.1 (#370)
+
+
+### [8.0.21-v3](https://github.com/stashed/mysql/releases/tag/8.0.21-v3)
+
+- [9ca99ac](https://github.com/stashed/mysql/commit/9ca99ac) Prepare for release 8.0.21-v3 (#374)
+- [b953faf](https://github.com/stashed/mysql/commit/b953faf) [cherry-pick] Use license-verifier v0.8.1 (#371)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v7](https://github.com/stashed/postgres/releases/tag/9.6.19-v7)
+
+- [a1704ca0](https://github.com/stashed/postgres/commit/a1704ca0) Prepare for release 9.6.19-v7 (#751)
+
+
+### [10.14-v7](https://github.com/stashed/postgres/releases/tag/10.14-v7)
+
+- [b55e8661](https://github.com/stashed/postgres/commit/b55e8661) Prepare for release 10.14-v7 (#747)
+- [33b87ceb](https://github.com/stashed/postgres/commit/33b87ceb) [cherry-pick] Use license-verifier v0.8.1 (#746)
+
+
+### [11.9-v7](https://github.com/stashed/postgres/releases/tag/11.9-v7)
+
+- [b93b6c20](https://github.com/stashed/postgres/commit/b93b6c20) Prepare for release 11.9-v7 (#748)
+
+
+### [12.4-v7](https://github.com/stashed/postgres/releases/tag/12.4-v7)
+
+- [2461f64e](https://github.com/stashed/postgres/commit/2461f64e) Prepare for release 12.4-v7 (#749)
+
+
+### [13.1-v4](https://github.com/stashed/postgres/releases/tag/13.1-v4)
+
+- [b324dc20](https://github.com/stashed/postgres/commit/b324dc20) Prepare for release 13.1-v4 (#750)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.12.3](https://github.com/stashed/stash/releases/tag/v0.12.3)
+
+- [28a86cae](https://github.com/stashed/stash/commit/28a86cae) Prepare for release v0.12.3 (#1339)
+- [2af7d576](https://github.com/stashed/stash/commit/2af7d576) Use license-verifier v0.8.1
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.04.12
Release-tracker: https://github.com/stashed/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>