### PR TITLE
Prepare for release v2021.06.23

### DIFF
--- a/docs/CHANGELOG-v2021.06.23.md
+++ b/docs/CHANGELOG-v2021.06.23.md
@@ -1,0 +1,302 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.06.23
+    name: Changelog-v2021.06.23
+    parent: welcome
+    weight: 20210623
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.06.23/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.06.23/
+---
+
+# Stash v2021.06.23 (2021-06-18)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.14.1](https://github.com/appscode/stash-enterprise/releases/tag/v0.14.1)
+
+- [324ca10e](https://github.com/appscode/stash-enterprise/commit/324ca10e) Prepare for release v0.14.1 (#102)
+- [917d2608](https://github.com/appscode/stash-enterprise/commit/917d2608) Update audit event attributes
+- [8ecfe211](https://github.com/appscode/stash-enterprise/commit/8ecfe211) Use dynamic resource mapper
+- [4e0584d5](https://github.com/appscode/stash-enterprise/commit/4e0584d5) Use Kubernetes 1.21.1 toolchain
+- [4a9ace9c](https://github.com/appscode/stash-enterprise/commit/4a9ace9c) Update dependencies
+- [960c4dbc](https://github.com/appscode/stash-enterprise/commit/960c4dbc) Create resilient event publisher (#101)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.14.1](https://github.com/stashed/apimachinery/releases/tag/v0.14.1)
+
+- [0cae462d](https://github.com/stashed/apimachinery/commit/0cae462d) Use Kubernetes 1.21.1 toolchain
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.14.1](https://github.com/stashed/cli/releases/tag/v0.14.1)
+
+- [cd0a22a](https://github.com/stashed/cli/commit/cd0a22a) Prepare for release v0.14.1 (#125)
+- [f8937bb](https://github.com/stashed/cli/commit/f8937bb) Use Kubernetes 1.21.1 toolchain
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v11](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v11)
+
+- [7bc688cc](https://github.com/stashed/elasticsearch/commit/7bc688cc) Prepare for release 5.6.4-v11 (#837)
+- [cb7338af](https://github.com/stashed/elasticsearch/commit/cb7338af) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#829)
+- [9dfe4c77](https://github.com/stashed/elasticsearch/commit/9dfe4c77) Update README.md
+
+
+### [6.2.4-v11](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v11)
+
+- [fda1bafa](https://github.com/stashed/elasticsearch/commit/fda1bafa) Prepare for release 6.2.4-v11 (#838)
+- [678023d8](https://github.com/stashed/elasticsearch/commit/678023d8) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#830)
+- [738515d8](https://github.com/stashed/elasticsearch/commit/738515d8) Update README.md
+
+
+### [6.3.0-v11](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v11)
+
+- [d3ab747e](https://github.com/stashed/elasticsearch/commit/d3ab747e) Prepare for release 6.3.0-v11 (#839)
+- [02ed39b4](https://github.com/stashed/elasticsearch/commit/02ed39b4) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#831)
+- [0ec95b34](https://github.com/stashed/elasticsearch/commit/0ec95b34) Update README.md
+
+
+### [6.4.0-v11](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v11)
+
+- [a2bcfc9e](https://github.com/stashed/elasticsearch/commit/a2bcfc9e) Prepare for release 6.4.0-v11 (#840)
+- [d91b7e05](https://github.com/stashed/elasticsearch/commit/d91b7e05) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#832)
+- [8349500c](https://github.com/stashed/elasticsearch/commit/8349500c) Update README.md
+
+
+### [6.5.3-v11](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v11)
+
+- [651f9a49](https://github.com/stashed/elasticsearch/commit/651f9a49) Prepare for release 6.5.3-v11 (#841)
+- [34491027](https://github.com/stashed/elasticsearch/commit/34491027) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#833)
+- [506d776e](https://github.com/stashed/elasticsearch/commit/506d776e) Update README.md
+
+
+### [6.8.0-v11](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v11)
+
+- [a577ae04](https://github.com/stashed/elasticsearch/commit/a577ae04) Prepare for release 6.8.0-v11 (#842)
+- [8c39d538](https://github.com/stashed/elasticsearch/commit/8c39d538) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#834)
+- [d0dddbe5](https://github.com/stashed/elasticsearch/commit/d0dddbe5) Update README.md
+
+
+### [7.2.0-v11](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v11)
+
+- [6ba76941](https://github.com/stashed/elasticsearch/commit/6ba76941) Prepare for release 7.2.0-v11 (#843)
+- [919991cd](https://github.com/stashed/elasticsearch/commit/919991cd) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#835)
+- [dc90a100](https://github.com/stashed/elasticsearch/commit/dc90a100) Update README.md
+
+
+### [7.3.2-v11](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v11)
+
+- [40e5c14d](https://github.com/stashed/elasticsearch/commit/40e5c14d) Prepare for release 7.3.2-v11 (#844)
+- [94c66a0a](https://github.com/stashed/elasticsearch/commit/94c66a0a) [cherry-pick] Use k8s 1.21.1 toolchain (#828) (#836)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2021.06.23](https://github.com/stashed/installer/releases/tag/v2021.06.23)
+
+- [3667d8a](https://github.com/stashed/installer/commit/3667d8a) Prepare for release v2021.06.23 (#179)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v4](https://github.com/stashed/mariadb/releases/tag/10.5.8-v4)
+
+- [87947d2](https://github.com/stashed/mariadb/commit/87947d2) Prepare for release 10.5.8-v4 (#110)
+- [32b93aa](https://github.com/stashed/mariadb/commit/32b93aa) [cherry-pick] Use k8s 1.21.1 toolchain (#108) (#109)
+- [35f57b9](https://github.com/stashed/mariadb/commit/35f57b9) [cherry-pick] Use klog/v2 (#106) (#107)
+- [318f49c](https://github.com/stashed/mariadb/commit/318f49c) Use k8s 1.21.0 toolchain
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v10](https://github.com/stashed/mongodb/releases/tag/3.4.17-v10)
+
+- [d80bee20](https://github.com/stashed/mongodb/commit/d80bee20) Prepare for release 3.4.17-v10 (#1007)
+- [97e2e07f](https://github.com/stashed/mongodb/commit/97e2e07f) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#995)
+- [e7a3161a](https://github.com/stashed/mongodb/commit/e7a3161a) Update README.md
+
+
+### [3.4.22-v10](https://github.com/stashed/mongodb/releases/tag/3.4.22-v10)
+
+- [5b3c7c83](https://github.com/stashed/mongodb/commit/5b3c7c83) Prepare for release 3.4.22-v10 (#1008)
+- [b98e6cad](https://github.com/stashed/mongodb/commit/b98e6cad) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#996)
+- [36abd30e](https://github.com/stashed/mongodb/commit/36abd30e) Update README.md
+
+
+### [3.6.8-v10](https://github.com/stashed/mongodb/releases/tag/3.6.8-v10)
+
+- [9b3182f1](https://github.com/stashed/mongodb/commit/9b3182f1) Prepare for release 3.6.8-v10 (#1010)
+- [b07985df](https://github.com/stashed/mongodb/commit/b07985df) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#998)
+- [0455e209](https://github.com/stashed/mongodb/commit/0455e209) Update README.md
+
+
+### [3.6.13-v10](https://github.com/stashed/mongodb/releases/tag/3.6.13-v10)
+
+- [52b38e73](https://github.com/stashed/mongodb/commit/52b38e73) Prepare for release 3.6.13-v10 (#1009)
+- [822cdadb](https://github.com/stashed/mongodb/commit/822cdadb) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#997)
+- [a83b7764](https://github.com/stashed/mongodb/commit/a83b7764) Update README.md
+
+
+### [4.0.3-v10](https://github.com/stashed/mongodb/releases/tag/4.0.3-v10)
+
+- [b3f4d1d6](https://github.com/stashed/mongodb/commit/b3f4d1d6) Prepare for release 4.0.3-v10 (#1012)
+- [adf02d15](https://github.com/stashed/mongodb/commit/adf02d15) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1000)
+- [4510d54e](https://github.com/stashed/mongodb/commit/4510d54e) Update README.md
+
+
+### [4.0.5-v10](https://github.com/stashed/mongodb/releases/tag/4.0.5-v10)
+
+- [5f1cc079](https://github.com/stashed/mongodb/commit/5f1cc079) Prepare for release 4.0.5-v10 (#1013)
+- [5b05f3a3](https://github.com/stashed/mongodb/commit/5b05f3a3) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1001)
+- [036fde58](https://github.com/stashed/mongodb/commit/036fde58) Update README.md
+
+
+### [4.0.11-v10](https://github.com/stashed/mongodb/releases/tag/4.0.11-v10)
+
+- [ca1407ef](https://github.com/stashed/mongodb/commit/ca1407ef) Prepare for release 4.0.11-v10 (#1011)
+- [8bda3737](https://github.com/stashed/mongodb/commit/8bda3737) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#999)
+- [3a773347](https://github.com/stashed/mongodb/commit/3a773347) Update README.md
+
+
+### [4.1.4-v10](https://github.com/stashed/mongodb/releases/tag/4.1.4-v10)
+
+- [77d5a66e](https://github.com/stashed/mongodb/commit/77d5a66e) Prepare for release 4.1.4-v10 (#1015)
+- [442197d9](https://github.com/stashed/mongodb/commit/442197d9) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1003)
+- [3bb97952](https://github.com/stashed/mongodb/commit/3bb97952) Update README.md
+
+
+### [4.1.7-v10](https://github.com/stashed/mongodb/releases/tag/4.1.7-v10)
+
+- [1a0160a2](https://github.com/stashed/mongodb/commit/1a0160a2) Prepare for release 4.1.7-v10 (#1016)
+- [1e47a843](https://github.com/stashed/mongodb/commit/1e47a843) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1004)
+- [5f1a80f5](https://github.com/stashed/mongodb/commit/5f1a80f5) Update README.md
+
+
+### [4.1.13-v10](https://github.com/stashed/mongodb/releases/tag/4.1.13-v10)
+
+- [01e88ef5](https://github.com/stashed/mongodb/commit/01e88ef5) Prepare for release 4.1.13-v10 (#1014)
+- [56de5495](https://github.com/stashed/mongodb/commit/56de5495) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1002)
+
+
+### [4.2.3-v10](https://github.com/stashed/mongodb/releases/tag/4.2.3-v10)
+
+- [0dbaebb9](https://github.com/stashed/mongodb/commit/0dbaebb9) Prepare for release 4.2.3-v10 (#1017)
+- [b2fcf2a0](https://github.com/stashed/mongodb/commit/b2fcf2a0) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1005)
+- [49254247](https://github.com/stashed/mongodb/commit/49254247) Update README.md
+
+
+### [4.4.6-v1](https://github.com/stashed/mongodb/releases/tag/4.4.6-v1)
+
+- [13dd847b](https://github.com/stashed/mongodb/commit/13dd847b) Prepare for release 4.4.6-v1 (#1018)
+- [fc0f1c1a](https://github.com/stashed/mongodb/commit/fc0f1c1a) [cherry-pick] Use k8s 1.21.1 toolchain (#994) (#1006)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v11](https://github.com/stashed/mysql/releases/tag/5.7.25-v11)
+
+- [f8e0fdc9](https://github.com/stashed/mysql/commit/f8e0fdc9) Prepare for release 5.7.25-v11 (#433)
+- [12edbc10](https://github.com/stashed/mysql/commit/12edbc10) [cherry-pick] Use k8s 1.21.1 toolchain (#428) (#429)
+
+
+### [8.0.3-v11](https://github.com/stashed/mysql/releases/tag/8.0.3-v11)
+
+- [100bede4](https://github.com/stashed/mysql/commit/100bede4) Prepare for release 8.0.3-v11 (#436)
+- [0c38d8b4](https://github.com/stashed/mysql/commit/0c38d8b4) [cherry-pick] Use k8s 1.21.1 toolchain (#428) (#432)
+
+
+### [8.0.14-v11](https://github.com/stashed/mysql/releases/tag/8.0.14-v11)
+
+- [98b64068](https://github.com/stashed/mysql/commit/98b64068) Prepare for release 8.0.14-v11 (#434)
+- [3d73812c](https://github.com/stashed/mysql/commit/3d73812c) [cherry-pick] Use k8s 1.21.1 toolchain (#428) (#430)
+
+
+### [8.0.21-v5](https://github.com/stashed/mysql/releases/tag/8.0.21-v5)
+
+- [52ee3f21](https://github.com/stashed/mysql/commit/52ee3f21) Prepare for release 8.0.21-v5 (#435)
+- [89fc5316](https://github.com/stashed/mysql/commit/89fc5316) [cherry-pick] Use k8s 1.21.1 toolchain (#428) (#431)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v6](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v6)
+
+- [33b788d](https://github.com/stashed/percona-xtradb/commit/33b788d) Prepare for release 5.7-v6 (#184)
+- [7809f18](https://github.com/stashed/percona-xtradb/commit/7809f18) [cherry-pick] Use k8s 1.21.1 toolchain (#183)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v9](https://github.com/stashed/postgres/releases/tag/9.6.19-v9)
+
+- [07ed8ee1](https://github.com/stashed/postgres/commit/07ed8ee1) Prepare for release 9.6.19-v9 (#817)
+- [45bfe257](https://github.com/stashed/postgres/commit/45bfe257) [cherry-pick] Use k8s 1.21.1 toolchain (#807) (#812)
+- [b30cecfe](https://github.com/stashed/postgres/commit/b30cecfe) Update README.md
+- [d91ecdbf](https://github.com/stashed/postgres/commit/d91ecdbf) [cherry-pick] Only set "PGSSLMODE" mode env variable when SSL is enabled (#801) (#806)
+
+
+### [10.14-v9](https://github.com/stashed/postgres/releases/tag/10.14-v9)
+
+- [457e2b3c](https://github.com/stashed/postgres/commit/457e2b3c) Prepare for release 10.14-v9 (#813)
+- [75f06514](https://github.com/stashed/postgres/commit/75f06514) [cherry-pick] Use k8s 1.21.1 toolchain (#807) (#808)
+- [d7999008](https://github.com/stashed/postgres/commit/d7999008) Update README.md
+- [8ae4a408](https://github.com/stashed/postgres/commit/8ae4a408) [cherry-pick] Only set "PGSSLMODE" mode env variable when SSL is enabled (#801) (#802)
+
+
+### [11.9-v9](https://github.com/stashed/postgres/releases/tag/11.9-v9)
+
+- [de7d67f5](https://github.com/stashed/postgres/commit/de7d67f5) Prepare for release 11.9-v9 (#814)
+- [e866dbfd](https://github.com/stashed/postgres/commit/e866dbfd) [cherry-pick] Use k8s 1.21.1 toolchain (#807) (#809)
+- [893fad13](https://github.com/stashed/postgres/commit/893fad13) [cherry-pick] Only set "PGSSLMODE" mode env variable when SSL is enabled (#801) (#803)
+
+
+### [12.4-v9](https://github.com/stashed/postgres/releases/tag/12.4-v9)
+
+- [29bf3c21](https://github.com/stashed/postgres/commit/29bf3c21) Prepare for release 12.4-v9 (#815)
+- [1599bb4a](https://github.com/stashed/postgres/commit/1599bb4a) [cherry-pick] Use k8s 1.21.1 toolchain (#807) (#810)
+- [3148acf1](https://github.com/stashed/postgres/commit/3148acf1) [cherry-pick] Only set "PGSSLMODE" mode env variable when SSL is enabled (#801) (#804)
+
+
+### [13.1-v6](https://github.com/stashed/postgres/releases/tag/13.1-v6)
+
+- [473db0aa](https://github.com/stashed/postgres/commit/473db0aa) Prepare for release 13.1-v6 (#816)
+- [dd4c2230](https://github.com/stashed/postgres/commit/dd4c2230) [cherry-pick] Use k8s 1.21.1 toolchain (#807) (#811)
+- [c9d8f903](https://github.com/stashed/postgres/commit/c9d8f903) Update README.md
+- [5b0142cf](https://github.com/stashed/postgres/commit/5b0142cf) [cherry-pick] Only set "PGSSLMODE" mode env variable when SSL is enabled (#801) (#805)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.14.1](https://github.com/stashed/stash/releases/tag/v0.14.1)
+
+- [03aba1ac](https://github.com/stashed/stash/commit/03aba1ac) Prepare for release v0.14.1 (#1356)
+- [78147be0](https://github.com/stashed/stash/commit/78147be0) Make audit event attributes match cloudevents spec
+- [f49850d4](https://github.com/stashed/stash/commit/f49850d4) Use dynamic resource mapper
+- [147525ef](https://github.com/stashed/stash/commit/147525ef) Use Kubernetes 1.21.1 toolchain
+- [f86c22bf](https://github.com/stashed/stash/commit/f86c22bf) Create resilient event publisher (#1355)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.06.23
Release-tracker: https://github.com/stashed/CHANGELOG/pull/38
Signed-off-by: 1gtm <1gtm@appscode.com>