### PR TITLE
Prepare for release v2021.08.02

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -66,6 +66,7 @@ jobs:
           export WEBSITE_ROOT=$RUNNER_WORKSPACE/$(basename $WEBSITE_REPOSITORY)
           cd $WEBSITE_ROOT
           npm install
+          make assets
           hugo-tools update-branch --filename=./data/products/stash.json --branch=${{ github.event.pull_request.head.sha }}
           make docs-skip-assets
           make gen-prod

--- a/docs/CHANGELOG-v2021.08.02.md
+++ b/docs/CHANGELOG-v2021.08.02.md
@@ -1,0 +1,372 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.08.02
+    name: Changelog-v2021.08.02
+    parent: welcome
+    weight: 20210802
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.08.02/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.08.02/
+---
+
+# Stash v2021.08.02 (2021-07-31)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.15.0](https://github.com/appscode/stash-enterprise/releases/tag/v0.15.0)
+
+- [40cadc89](https://github.com/appscode/stash-enterprise/commit/40cadc89) Prepare for release v0.15.0 (#110)
+- [bd4ca856](https://github.com/appscode/stash-enterprise/commit/bd4ca856) Improve duration format in BackupSession and RestoreSession (#109)
+- [1d9cc4dd](https://github.com/appscode/stash-enterprise/commit/1d9cc4dd) Update dependencies (#108)
+- [8af6b01b](https://github.com/appscode/stash-enterprise/commit/8af6b01b) Use restic 0.12.0-ac.20210727 (#105)
+- [38dea1e2](https://github.com/appscode/stash-enterprise/commit/38dea1e2) Remove repetitive 403 errors from validator and mutators
+- [deb96432](https://github.com/appscode/stash-enterprise/commit/deb96432) Pass `region` flag in built-in Functions (#104)
+- [d7c5b0ab](https://github.com/appscode/stash-enterprise/commit/d7c5b0ab) Stop using deprecated apis in k8s 1.22 (#103)
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.15.0](https://github.com/stashed/apimachinery/releases/tag/v0.15.0)
+
+- [68cf54c0](https://github.com/stashed/apimachinery/commit/68cf54c0) Update dependencies (#108)
+- [5405dc7e](https://github.com/stashed/apimachinery/commit/5405dc7e) Use restic v0.12.0-ac.20210727 (#105)
+- [9609d465](https://github.com/stashed/apimachinery/commit/9609d465) Test crds (#104)
+- [f9affe2f](https://github.com/stashed/apimachinery/commit/f9affe2f) Add `Duration` column in BackupSession and RestoreSession (#103)
+- [0229e0bd](https://github.com/stashed/apimachinery/commit/0229e0bd) Update README.md
+- [53996371](https://github.com/stashed/apimachinery/commit/53996371) Only generate crd v1 yamls (#102)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.15.0](https://github.com/stashed/cli/releases/tag/v0.15.0)
+
+- [f5ebe84](https://github.com/stashed/cli/commit/f5ebe84) Prepare for release v0.15.0 (#129)
+- [0501282](https://github.com/stashed/cli/commit/0501282) Update dependencies (#128)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v12](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v12)
+
+- [f6cd9a3f](https://github.com/stashed/elasticsearch/commit/f6cd9a3f) Prepare for release 5.6.4-v12 (#875)
+- [6d5daef1](https://github.com/stashed/elasticsearch/commit/6d5daef1) [cherry-pick] Update repository config (#866) (#867)
+- [22b224ab](https://github.com/stashed/elasticsearch/commit/22b224ab) [cherry-pick] Update dependencies (#857) (#858)
+- [60b47d34](https://github.com/stashed/elasticsearch/commit/60b47d34) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#847)
+
+
+### [6.2.4-v12](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v12)
+
+- [113226e5](https://github.com/stashed/elasticsearch/commit/113226e5) Prepare for release 6.2.4-v12 (#876)
+- [dd90de07](https://github.com/stashed/elasticsearch/commit/dd90de07) [cherry-pick] Update repository config (#866) (#868)
+- [c93e9745](https://github.com/stashed/elasticsearch/commit/c93e9745) [cherry-pick] Update dependencies (#857) (#859)
+- [22e606ae](https://github.com/stashed/elasticsearch/commit/22e606ae) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#848)
+
+
+### [6.3.0-v12](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v12)
+
+- [3a249c88](https://github.com/stashed/elasticsearch/commit/3a249c88) Prepare for release 6.3.0-v12 (#877)
+- [41bd96ed](https://github.com/stashed/elasticsearch/commit/41bd96ed) [cherry-pick] Update repository config (#866) (#869)
+- [c718b116](https://github.com/stashed/elasticsearch/commit/c718b116) [cherry-pick] Update dependencies (#857) (#860)
+- [8c4a5c26](https://github.com/stashed/elasticsearch/commit/8c4a5c26) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#849)
+
+
+### [6.4.0-v12](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v12)
+
+- [34b940ec](https://github.com/stashed/elasticsearch/commit/34b940ec) Prepare for release 6.4.0-v12 (#878)
+- [f0b7aa39](https://github.com/stashed/elasticsearch/commit/f0b7aa39) [cherry-pick] Update repository config (#866) (#870)
+- [12a3a75d](https://github.com/stashed/elasticsearch/commit/12a3a75d) [cherry-pick] Update dependencies (#857) (#861)
+- [01ead31a](https://github.com/stashed/elasticsearch/commit/01ead31a) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#850)
+
+
+### [6.5.3-v12](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v12)
+
+- [c994843d](https://github.com/stashed/elasticsearch/commit/c994843d) Prepare for release 6.5.3-v12 (#879)
+- [5bc88545](https://github.com/stashed/elasticsearch/commit/5bc88545) [cherry-pick] Update repository config (#866) (#871)
+- [1e31a002](https://github.com/stashed/elasticsearch/commit/1e31a002) [cherry-pick] Update dependencies (#857) (#862)
+- [4d07f828](https://github.com/stashed/elasticsearch/commit/4d07f828) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#851)
+
+
+### [6.8.0-v12](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v12)
+
+- [f09dd827](https://github.com/stashed/elasticsearch/commit/f09dd827) Prepare for release 6.8.0-v12 (#880)
+- [f35f8ca3](https://github.com/stashed/elasticsearch/commit/f35f8ca3) [cherry-pick] Update repository config (#866) (#872)
+- [782c1fc4](https://github.com/stashed/elasticsearch/commit/782c1fc4) [cherry-pick] Update dependencies (#857) (#863)
+- [6e8b2884](https://github.com/stashed/elasticsearch/commit/6e8b2884) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#852)
+
+
+### [7.2.0-v12](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v12)
+
+- [b55c27fe](https://github.com/stashed/elasticsearch/commit/b55c27fe) Prepare for release 7.2.0-v12 (#881)
+- [c7f76787](https://github.com/stashed/elasticsearch/commit/c7f76787) [cherry-pick] Update repository config (#866) (#873)
+- [038294c6](https://github.com/stashed/elasticsearch/commit/038294c6) [cherry-pick] Update dependencies (#857) (#864)
+- [5cdc2c37](https://github.com/stashed/elasticsearch/commit/5cdc2c37) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#853)
+
+
+### [7.3.2-v12](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v12)
+
+- [36bd2685](https://github.com/stashed/elasticsearch/commit/36bd2685) Prepare for release 7.3.2-v12 (#882)
+- [c910d845](https://github.com/stashed/elasticsearch/commit/c910d845) [cherry-pick] Update repository config (#866) (#874)
+- [3a2c26f4](https://github.com/stashed/elasticsearch/commit/3a2c26f4) [cherry-pick] Update dependencies (#857) (#865)
+- [1082c0b4](https://github.com/stashed/elasticsearch/commit/1082c0b4) [cherry-pick] Use restic v0.12.0-ac.20210727 (#846) (#854)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2021.08.02](https://github.com/stashed/installer/releases/tag/v2021.08.02)
+
+- [a156259](https://github.com/stashed/installer/commit/a156259) Prepare for release v2021.08.02 (#191)
+- [236344e](https://github.com/stashed/installer/commit/236344e) removed duplicate yaml key (#185)
+- [e4360b9](https://github.com/stashed/installer/commit/e4360b9) Add Redis catalog (#189)
+- [8ebc75b](https://github.com/stashed/installer/commit/8ebc75b) Update repository config (#190)
+- [08533b1](https://github.com/stashed/installer/commit/08533b1) Update dependencies (#188)
+- [1dec446](https://github.com/stashed/installer/commit/1dec446) Update chart docs
+- [e538a4a](https://github.com/stashed/installer/commit/e538a4a) Update stash chart dependencies via Makefile (#184)
+- [79185b4](https://github.com/stashed/installer/commit/79185b4) Stop using deprecated apis in k8s 1.22 (#183)
+- [3cb28a0](https://github.com/stashed/installer/commit/3cb28a0) Sort crd yamls by GK
+- [2e1bc42](https://github.com/stashed/installer/commit/2e1bc42) Merge metrics chart into crds chart
+- [2f22aee](https://github.com/stashed/installer/commit/2f22aee) Test against Kubernetes 1.21.1 (#182)
+- [51b9e39](https://github.com/stashed/installer/commit/51b9e39) Allow overriding image pull secrets from unified chart (#181)
+- [bab2a32](https://github.com/stashed/installer/commit/bab2a32) Rename user-roles.yaml to metrics-user-roles.yaml
+- [7f59770](https://github.com/stashed/installer/commit/7f59770) Add stash-metrics chart (#180)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v5](https://github.com/stashed/mariadb/releases/tag/10.5.8-v5)
+
+- [4c5a5a6](https://github.com/stashed/mariadb/commit/4c5a5a6) Prepare for release 10.5.8-v5 (#120)
+- [bc22c03](https://github.com/stashed/mariadb/commit/bc22c03) [cherry-pick] Update repository config (#118) (#119)
+- [23101f3](https://github.com/stashed/mariadb/commit/23101f3) [cherry-pick] Update dependencies (#116) (#117)
+- [989e214](https://github.com/stashed/mariadb/commit/989e214) [cherry-pick] Use restic v0.12.0-ac.20210727 (#112) (#113)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v11](https://github.com/stashed/mongodb/releases/tag/3.4.17-v11)
+
+- [df1a5ee9](https://github.com/stashed/mongodb/commit/df1a5ee9) Prepare for release 3.4.17-v11 (#1061)
+- [f345dade](https://github.com/stashed/mongodb/commit/f345dade) [cherry-pick] Update repository config (#1048) (#1049)
+- [66be6780](https://github.com/stashed/mongodb/commit/66be6780) [cherry-pick] Update dependencies (#1035) (#1036)
+- [9ceabf04](https://github.com/stashed/mongodb/commit/9ceabf04) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1021)
+
+
+### [3.4.22-v11](https://github.com/stashed/mongodb/releases/tag/3.4.22-v11)
+
+- [a3b281da](https://github.com/stashed/mongodb/commit/a3b281da) Prepare for release 3.4.22-v11 (#1062)
+- [dc10d71e](https://github.com/stashed/mongodb/commit/dc10d71e) [cherry-pick] Update repository config (#1048) (#1050)
+- [fbfb625d](https://github.com/stashed/mongodb/commit/fbfb625d) [cherry-pick] Update dependencies (#1035) (#1037)
+- [2c3233ac](https://github.com/stashed/mongodb/commit/2c3233ac) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1022)
+
+
+### [3.6.8-v11](https://github.com/stashed/mongodb/releases/tag/3.6.8-v11)
+
+- [bc0d14bf](https://github.com/stashed/mongodb/commit/bc0d14bf) Prepare for release 3.6.8-v11 (#1064)
+- [011a6f25](https://github.com/stashed/mongodb/commit/011a6f25) [cherry-pick] Update repository config (#1048) (#1052)
+- [0d27847f](https://github.com/stashed/mongodb/commit/0d27847f) [cherry-pick] Update dependencies (#1035) (#1039)
+- [0f97d428](https://github.com/stashed/mongodb/commit/0f97d428) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1024)
+
+
+### [3.6.13-v11](https://github.com/stashed/mongodb/releases/tag/3.6.13-v11)
+
+- [cc1fc58f](https://github.com/stashed/mongodb/commit/cc1fc58f) Prepare for release 3.6.13-v11 (#1063)
+- [5db9d0e8](https://github.com/stashed/mongodb/commit/5db9d0e8) [cherry-pick] Update repository config (#1048) (#1051)
+- [65bb29b5](https://github.com/stashed/mongodb/commit/65bb29b5) [cherry-pick] Update dependencies (#1035) (#1038)
+- [7da6b51f](https://github.com/stashed/mongodb/commit/7da6b51f) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1023)
+
+
+### [4.0.3-v11](https://github.com/stashed/mongodb/releases/tag/4.0.3-v11)
+
+- [5bb0e7fc](https://github.com/stashed/mongodb/commit/5bb0e7fc) Prepare for release 4.0.3-v11 (#1066)
+- [790fe330](https://github.com/stashed/mongodb/commit/790fe330) [cherry-pick] Update repository config (#1048) (#1054)
+- [d98a2c49](https://github.com/stashed/mongodb/commit/d98a2c49) [cherry-pick] Update dependencies (#1035) (#1041)
+- [5415505d](https://github.com/stashed/mongodb/commit/5415505d) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1026)
+
+
+### [4.0.5-v11](https://github.com/stashed/mongodb/releases/tag/4.0.5-v11)
+
+- [8dcb1644](https://github.com/stashed/mongodb/commit/8dcb1644) Prepare for release 4.0.5-v11 (#1067)
+- [47025315](https://github.com/stashed/mongodb/commit/47025315) [cherry-pick] Update repository config (#1048) (#1055)
+- [9dfdc8f3](https://github.com/stashed/mongodb/commit/9dfdc8f3) [cherry-pick] Update dependencies (#1035) (#1042)
+- [14570445](https://github.com/stashed/mongodb/commit/14570445) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1027)
+
+
+### [4.0.11-v11](https://github.com/stashed/mongodb/releases/tag/4.0.11-v11)
+
+- [77011222](https://github.com/stashed/mongodb/commit/77011222) Prepare for release 4.0.11-v11 (#1065)
+- [ff0a8612](https://github.com/stashed/mongodb/commit/ff0a8612) [cherry-pick] Update repository config (#1048) (#1053)
+- [e0f0aa94](https://github.com/stashed/mongodb/commit/e0f0aa94) [cherry-pick] Update dependencies (#1035) (#1040)
+- [37097340](https://github.com/stashed/mongodb/commit/37097340) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1025)
+
+
+### [4.1.4-v11](https://github.com/stashed/mongodb/releases/tag/4.1.4-v11)
+
+- [124f47e8](https://github.com/stashed/mongodb/commit/124f47e8) Prepare for release 4.1.4-v11 (#1069)
+- [6f46f97e](https://github.com/stashed/mongodb/commit/6f46f97e) [cherry-pick] Update repository config (#1048) (#1057)
+- [162e6c00](https://github.com/stashed/mongodb/commit/162e6c00) [cherry-pick] Update dependencies (#1035) (#1044)
+- [b32b9b9b](https://github.com/stashed/mongodb/commit/b32b9b9b) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1029)
+
+
+### [4.1.7-v11](https://github.com/stashed/mongodb/releases/tag/4.1.7-v11)
+
+- [4f7007a4](https://github.com/stashed/mongodb/commit/4f7007a4) Prepare for release 4.1.7-v11 (#1070)
+- [021825ea](https://github.com/stashed/mongodb/commit/021825ea) [cherry-pick] Update repository config (#1048) (#1058)
+- [786843bc](https://github.com/stashed/mongodb/commit/786843bc) [cherry-pick] Update dependencies (#1035) (#1045)
+- [bb3640a0](https://github.com/stashed/mongodb/commit/bb3640a0) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1030)
+
+
+### [4.1.13-v11](https://github.com/stashed/mongodb/releases/tag/4.1.13-v11)
+
+- [d1e1bb66](https://github.com/stashed/mongodb/commit/d1e1bb66) Prepare for release 4.1.13-v11 (#1068)
+- [cf602e44](https://github.com/stashed/mongodb/commit/cf602e44) [cherry-pick] Update repository config (#1048) (#1056)
+- [617ff56d](https://github.com/stashed/mongodb/commit/617ff56d) [cherry-pick] Update dependencies (#1035) (#1043)
+- [c223aa7b](https://github.com/stashed/mongodb/commit/c223aa7b) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1028)
+
+
+### [4.2.3-v11](https://github.com/stashed/mongodb/releases/tag/4.2.3-v11)
+
+- [0565d9c9](https://github.com/stashed/mongodb/commit/0565d9c9) Prepare for release 4.2.3-v11 (#1071)
+- [3d52ffd2](https://github.com/stashed/mongodb/commit/3d52ffd2) [cherry-pick] Update repository config (#1048) (#1059)
+- [983dc6b0](https://github.com/stashed/mongodb/commit/983dc6b0) [cherry-pick] Update dependencies (#1035) (#1046)
+- [df3c1e5b](https://github.com/stashed/mongodb/commit/df3c1e5b) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1031)
+
+
+### [4.4.6-v2](https://github.com/stashed/mongodb/releases/tag/4.4.6-v2)
+
+- [ccdb092c](https://github.com/stashed/mongodb/commit/ccdb092c) [cherry-pick] Update repository config (#1048) (#1060)
+- [e54137e6](https://github.com/stashed/mongodb/commit/e54137e6) [cherry-pick] Update dependencies (#1035) (#1047)
+- [8c036539](https://github.com/stashed/mongodb/commit/8c036539) [cherry-pick] Use restic v0.12.0-ac.20210727 (#1020) (#1032)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v12](https://github.com/stashed/mysql/releases/tag/5.7.25-v12)
+
+- [48b8c389](https://github.com/stashed/mysql/commit/48b8c389) Prepare for release 5.7.25-v12 (#455)
+- [2228e027](https://github.com/stashed/mysql/commit/2228e027) [cherry-pick] Update repository config (#450) (#451)
+- [da7063a4](https://github.com/stashed/mysql/commit/da7063a4) [cherry-pick] Update dependencies (#445) (#446)
+- [6b633d68](https://github.com/stashed/mysql/commit/6b633d68) [cherry-pick] Use restic v0.12.0-ac.20210727 (#438) (#439)
+
+
+### [8.0.3-v12](https://github.com/stashed/mysql/releases/tag/8.0.3-v12)
+
+- [10f7c4b7](https://github.com/stashed/mysql/commit/10f7c4b7) Prepare for release 8.0.3-v12 (#458)
+- [eb0c962a](https://github.com/stashed/mysql/commit/eb0c962a) [cherry-pick] Update repository config (#450) (#454)
+- [cb1fa41d](https://github.com/stashed/mysql/commit/cb1fa41d) [cherry-pick] Update dependencies (#445) (#449)
+- [705a5eb3](https://github.com/stashed/mysql/commit/705a5eb3) [cherry-pick] Use restic v0.12.0-ac.20210727 (#438) (#442)
+
+
+### [8.0.14-v12](https://github.com/stashed/mysql/releases/tag/8.0.14-v12)
+
+- [8dcf9109](https://github.com/stashed/mysql/commit/8dcf9109) Prepare for release 8.0.14-v12 (#456)
+- [0b899336](https://github.com/stashed/mysql/commit/0b899336) [cherry-pick] Update repository config (#450) (#452)
+- [156e4650](https://github.com/stashed/mysql/commit/156e4650) [cherry-pick] Update dependencies (#445) (#447)
+- [373511ed](https://github.com/stashed/mysql/commit/373511ed) [cherry-pick] Use restic v0.12.0-ac.20210727 (#438) (#440)
+
+
+### [8.0.21-v6](https://github.com/stashed/mysql/releases/tag/8.0.21-v6)
+
+- [2a424f32](https://github.com/stashed/mysql/commit/2a424f32) Prepare for release 8.0.21-v6 (#457)
+- [545ab090](https://github.com/stashed/mysql/commit/545ab090) [cherry-pick] Update repository config (#450) (#453)
+- [01144457](https://github.com/stashed/mysql/commit/01144457) [cherry-pick] Update dependencies (#445) (#448)
+- [64ba0a79](https://github.com/stashed/mysql/commit/64ba0a79) [cherry-pick] Use restic v0.12.0-ac.20210727 (#438) (#441)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v7](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v7)
+
+- [4b3634a7](https://github.com/stashed/percona-xtradb/commit/4b3634a7) Prepare for release 5.7-v7 (#193)
+- [22f2e507](https://github.com/stashed/percona-xtradb/commit/22f2e507) [cherry-pick] Update repository config (#191) (#192)
+- [7a67ec51](https://github.com/stashed/percona-xtradb/commit/7a67ec51) [cherry-pick] Use restic v0.12.0-ac.20210727 (#186) (#187)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v10](https://github.com/stashed/postgres/releases/tag/9.6.19-v10)
+
+- [c87db716](https://github.com/stashed/postgres/commit/c87db716) Prepare for release 9.6.19-v10 (#843)
+- [0e241018](https://github.com/stashed/postgres/commit/0e241018) [cherry-pick] Update repository config (#833) (#838)
+- [b076f970](https://github.com/stashed/postgres/commit/b076f970) [cherry-pick] Update dependencies (#827) (#832)
+- [2e6829c1](https://github.com/stashed/postgres/commit/2e6829c1) [cherry-pick] Use restic v0.12.0-ac.20210727 (#819) (#824)
+
+
+### [10.14-v10](https://github.com/stashed/postgres/releases/tag/10.14-v10)
+
+- [3687c604](https://github.com/stashed/postgres/commit/3687c604) Prepare for release 10.14-v10 (#839)
+- [a48fb0b2](https://github.com/stashed/postgres/commit/a48fb0b2) [cherry-pick] Update repository config (#833) (#834)
+- [72793d2a](https://github.com/stashed/postgres/commit/72793d2a) [cherry-pick] Update dependencies (#827) (#828)
+- [b0ef05d7](https://github.com/stashed/postgres/commit/b0ef05d7) [cherry-pick] Use restic v0.12.0-ac.20210727 (#819) (#820)
+
+
+### [11.9-v10](https://github.com/stashed/postgres/releases/tag/11.9-v10)
+
+- [ab70837f](https://github.com/stashed/postgres/commit/ab70837f) Prepare for release 11.9-v10 (#840)
+- [496f0c91](https://github.com/stashed/postgres/commit/496f0c91) [cherry-pick] Update repository config (#833) (#835)
+- [3f0af053](https://github.com/stashed/postgres/commit/3f0af053) [cherry-pick] Update dependencies (#827) (#829)
+- [6f82d7cd](https://github.com/stashed/postgres/commit/6f82d7cd) [cherry-pick] Use restic v0.12.0-ac.20210727 (#819) (#821)
+
+
+### [12.4-v10](https://github.com/stashed/postgres/releases/tag/12.4-v10)
+
+- [1a911490](https://github.com/stashed/postgres/commit/1a911490) Prepare for release 12.4-v10 (#841)
+- [1319792a](https://github.com/stashed/postgres/commit/1319792a) [cherry-pick] Update repository config (#833) (#836)
+- [79b20b79](https://github.com/stashed/postgres/commit/79b20b79) [cherry-pick] Update dependencies (#827) (#830)
+- [a7cf8a2b](https://github.com/stashed/postgres/commit/a7cf8a2b) [cherry-pick] Use restic v0.12.0-ac.20210727 (#819) (#822)
+
+
+### [13.1-v7](https://github.com/stashed/postgres/releases/tag/13.1-v7)
+
+- [949be085](https://github.com/stashed/postgres/commit/949be085) Prepare for release 13.1-v7 (#842)
+- [2c2642d1](https://github.com/stashed/postgres/commit/2c2642d1) [cherry-pick] Update repository config (#833) (#837)
+- [2dc6e0e3](https://github.com/stashed/postgres/commit/2dc6e0e3) [cherry-pick] Update dependencies (#827) (#831)
+- [f07a6f91](https://github.com/stashed/postgres/commit/f07a6f91) [cherry-pick] Use restic v0.12.0-ac.20210727 (#819) (#823)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13](https://github.com/stashed/redis/releases/tag/5.0.13)
+
+- [8aef207](https://github.com/stashed/redis/commit/8aef207) Prepare for release 5.0.13 (#5)
+- [eef7933](https://github.com/stashed/redis/commit/eef7933) Update repository config (#2) (#3)
+- [628dbb1](https://github.com/stashed/redis/commit/628dbb1) Use redis:5.0.13 as base image
+- [7d4bfee](https://github.com/stashed/redis/commit/7d4bfee) Make Redis addon ready to use (#1)
+
+
+### [6.2.5](https://github.com/stashed/redis/releases/tag/6.2.5)
+
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.15.0](https://github.com/stashed/stash/releases/tag/v0.15.0)
+
+- [f1484b5d](https://github.com/stashed/stash/commit/f1484b5d) Prepare for release v0.15.0 (#1372)
+- [20291868](https://github.com/stashed/stash/commit/20291868) Improve duration format in BackupSession and RestoreSession (#1370)
+- [99e2624b](https://github.com/stashed/stash/commit/99e2624b) Update repository config (#1371)
+- [90686853](https://github.com/stashed/stash/commit/90686853) Update dependencies (#1369)
+- [3c7b0593](https://github.com/stashed/stash/commit/3c7b0593) Use restic v0.12.0-ac.20210727 (#1366)
+- [76715e4c](https://github.com/stashed/stash/commit/76715e4c) Remove repetitive 403 errors from validator and mutators
+- [c987ee1a](https://github.com/stashed/stash/commit/c987ee1a) Pass `region` flag in the built-in functions (#1363)
+- [fc2e7fb4](https://github.com/stashed/stash/commit/fc2e7fb4) Stop using deprecated apis in k8s 1.22 (#1362)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.08.02
Release-tracker: https://github.com/stashed/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>