### PR TITLE
Prepare for release v2021.11.24

### DIFF
--- a/docs/CHANGELOG-v2021.11.24.md
+++ b/docs/CHANGELOG-v2021.11.24.md
@@ -1,0 +1,449 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2021.11.24
+    name: Changelog-v2021.11.24
+    parent: welcome
+    weight: 20211124
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.11.24/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.11.24/
+---
+
+# Stash v2021.11.24 (2021-11-24)
+
+
+## [appscode/stash-enterprise](https://github.com/appscode/stash-enterprise)
+
+### [v0.17.0](https://github.com/appscode/stash-enterprise/releases/tag/v0.17.0)
+
+- [85b094e2](https://github.com/appscode/stash-enterprise/commit/85b094e2) Prepare for release v0.17.0 (#135)
+- [d1a1d9ae](https://github.com/appscode/stash-enterprise/commit/d1a1d9ae) Fix SiteInfo publishing (#134)
+- [c2a4af81](https://github.com/appscode/stash-enterprise/commit/c2a4af81) Update license verifier (#132)
+- [d14efa79](https://github.com/appscode/stash-enterprise/commit/d14efa79) Update license header
+- [402386a8](https://github.com/appscode/stash-enterprise/commit/402386a8) Remove Google Analytics (#131)
+- [4e9d2787](https://github.com/appscode/stash-enterprise/commit/4e9d2787) Update repository config (#130)
+- [0a8bd900](https://github.com/appscode/stash-enterprise/commit/0a8bd900) Update dependencies (#129)
+- [ec75311b](https://github.com/appscode/stash-enterprise/commit/ec75311b) Fix satori/go.uuid security vulnerability (#128)
+- [66e31a4d](https://github.com/appscode/stash-enterprise/commit/66e31a4d) Apply all the pod level runtime settings to the CronJob
+- [ce457efc](https://github.com/appscode/stash-enterprise/commit/ce457efc) Apply all the pod level runtime settings to the CronJob
+
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.17.0](https://github.com/stashed/apimachinery/releases/tag/v0.17.0)
+
+- [dce6be25](https://github.com/stashed/apimachinery/commit/dce6be25) Update dependencies (#133)
+- [dcf13de6](https://github.com/stashed/apimachinery/commit/dcf13de6) Update Makefile for controller-tools@v0.7.0
+- [82122921](https://github.com/stashed/apimachinery/commit/82122921) Update repository config (#132)
+- [30fa542d](https://github.com/stashed/apimachinery/commit/30fa542d) Update dependencies (#131)
+- [026be21a](https://github.com/stashed/apimachinery/commit/026be21a) Fix satori/go.uuid security vulnerability (#130)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.17.0](https://github.com/stashed/cli/releases/tag/v0.17.0)
+
+- [7060e6f](https://github.com/stashed/cli/commit/7060e6f) Prepare for release v0.17.0 (#147)
+- [de80418](https://github.com/stashed/cli/commit/de80418) Update dependencies (#146)
+- [ed6657a](https://github.com/stashed/cli/commit/ed6657a) Remove Google Analytics (#145)
+- [f2c9aa4](https://github.com/stashed/cli/commit/f2c9aa4) Update dependencies (#144)
+- [a1fcc30](https://github.com/stashed/cli/commit/a1fcc30) Fix satori/go.uuid security vulnerability (#143)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v14](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v14)
+
+- [0e144118](https://github.com/stashed/elasticsearch/commit/0e144118) Prepare for release 5.6.4-v14 (#1059)
+- [ab859dbf](https://github.com/stashed/elasticsearch/commit/ab859dbf) [cherry-pick] Fix SiteInfo publishing (#1049) (#1050)
+- [9379b2b1](https://github.com/stashed/elasticsearch/commit/9379b2b1) [cherry-pick] Update dependencies (#1040) (#1041)
+- [3ee7e34c](https://github.com/stashed/elasticsearch/commit/3ee7e34c) [cherry-pick] Remove Google Analytics (#1031) (#1032)
+- [9fc75414](https://github.com/stashed/elasticsearch/commit/9fc75414) [cherry-pick] Update dependencies (#1021) (#1022)
+- [6aad03dd](https://github.com/stashed/elasticsearch/commit/6aad03dd) [cherry-pick] Fix satori/go.uuid security vulnerability (#1017) (#1018)
+
+
+### [6.2.4-v14](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v14)
+
+- [5ba72d61](https://github.com/stashed/elasticsearch/commit/5ba72d61) Prepare for release 6.2.4-v14 (#1060)
+- [b9d05541](https://github.com/stashed/elasticsearch/commit/b9d05541) [cherry-pick] Fix SiteInfo publishing (#1049) (#1051)
+- [e6d3eae2](https://github.com/stashed/elasticsearch/commit/e6d3eae2) [cherry-pick] Update dependencies (#1040) (#1042)
+- [c8a14048](https://github.com/stashed/elasticsearch/commit/c8a14048) [cherry-pick] Remove Google Analytics (#1031) (#1033)
+- [3d05b804](https://github.com/stashed/elasticsearch/commit/3d05b804) Update dependencies (#1021) (#1023)
+- [e7e8c52a](https://github.com/stashed/elasticsearch/commit/e7e8c52a) [cherry-pick] Fix satori/go.uuid security vulnerability (#1017) (#1019)
+
+
+### [6.3.0-v14](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v14)
+
+- [d4201b7e](https://github.com/stashed/elasticsearch/commit/d4201b7e) Prepare for release 6.3.0-v14 (#1061)
+- [0b729a37](https://github.com/stashed/elasticsearch/commit/0b729a37) [cherry-pick] Fix SiteInfo publishing (#1049) (#1052)
+- [5ce16921](https://github.com/stashed/elasticsearch/commit/5ce16921) [cherry-pick] Remove Google Analytics (#1031) (#1034)
+- [49a75d1d](https://github.com/stashed/elasticsearch/commit/49a75d1d) Update dependencies (#1021) (#1024)
+- [546aa0c5](https://github.com/stashed/elasticsearch/commit/546aa0c5) [cherry-pick] Fix satori/go.uuid security vulnerability (#1017) (#1020)
+
+
+### [6.4.0-v14](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v14)
+
+- [7d7da202](https://github.com/stashed/elasticsearch/commit/7d7da202) Prepare for release 6.4.0-v14 (#1062)
+- [50e2e801](https://github.com/stashed/elasticsearch/commit/50e2e801) [cherry-pick] Fix SiteInfo publishing (#1049) (#1053)
+- [48209723](https://github.com/stashed/elasticsearch/commit/48209723) [cherry-pick] Update dependencies (#1040) (#1043)
+- [dae6bf84](https://github.com/stashed/elasticsearch/commit/dae6bf84) [cherry-pick] Remove Google Analytics (#1031) (#1035)
+- [4aaab48e](https://github.com/stashed/elasticsearch/commit/4aaab48e) Update dependencies (#1021) (#1025)
+
+
+### [6.5.3-v14](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v14)
+
+- [35ef5d49](https://github.com/stashed/elasticsearch/commit/35ef5d49) Prepare for release 6.5.3-v14 (#1063)
+- [d8a4c476](https://github.com/stashed/elasticsearch/commit/d8a4c476) [cherry-pick] Fix SiteInfo publishing (#1049) (#1054)
+- [9512b200](https://github.com/stashed/elasticsearch/commit/9512b200) [cherry-pick] Update dependencies (#1040) (#1044)
+- [3d3d0783](https://github.com/stashed/elasticsearch/commit/3d3d0783) [cherry-pick] Remove Google Analytics (#1031) (#1036)
+- [5d45c1c6](https://github.com/stashed/elasticsearch/commit/5d45c1c6) Update dependencies (#1021) (#1026)
+
+
+### [6.8.0-v14](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v14)
+
+- [c253b5d2](https://github.com/stashed/elasticsearch/commit/c253b5d2) Prepare for release 6.8.0-v14 (#1064)
+- [716e21ec](https://github.com/stashed/elasticsearch/commit/716e21ec) [cherry-pick] Fix SiteInfo publishing (#1049) (#1055)
+- [4bc83924](https://github.com/stashed/elasticsearch/commit/4bc83924) [cherry-pick] Update dependencies (#1040) (#1045)
+- [97e40f8d](https://github.com/stashed/elasticsearch/commit/97e40f8d) [cherry-pick] Remove Google Analytics (#1031) (#1037)
+- [1a764e16](https://github.com/stashed/elasticsearch/commit/1a764e16) [cherry-pick] Update dependencies (#1021) (#1027)
+
+
+### [7.2.0-v14](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v14)
+
+- [7ddc15df](https://github.com/stashed/elasticsearch/commit/7ddc15df) Prepare for release 7.2.0-v14 (#1066)
+- [8b83e76f](https://github.com/stashed/elasticsearch/commit/8b83e76f) Fix SiteInfo publishing (#1049) (#1057)
+- [295c2092](https://github.com/stashed/elasticsearch/commit/295c2092) [cherry-pick] Update dependencies (#1040) (#1047)
+- [0efd2e29](https://github.com/stashed/elasticsearch/commit/0efd2e29) [cherry-pick] Remove Google Analytics (#1031) (#1038)
+- [199bd4da](https://github.com/stashed/elasticsearch/commit/199bd4da) [cherry-pick] Update dependencies (#1021) (#1028)
+
+
+### [7.3.2-v14](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v14)
+
+- [3e524ee1](https://github.com/stashed/elasticsearch/commit/3e524ee1) [cherry-pick] Fix SiteInfo publishing (#1049) (#1056)
+- [b052040a](https://github.com/stashed/elasticsearch/commit/b052040a) [cherry-pick] Update dependencies (#1040) (#1048)
+- [42ca2c7a](https://github.com/stashed/elasticsearch/commit/42ca2c7a) [cherry-pick] Remove Google Analytics (#1031) (#1039)
+- [efd3d876](https://github.com/stashed/elasticsearch/commit/efd3d876) [cherry-pick] Update dependencies (#1021) (#1029)
+
+
+### [7.14.0](https://github.com/stashed/elasticsearch/releases/tag/7.14.0)
+
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v1](https://github.com/stashed/etcd/releases/tag/3.5.0-v1)
+
+- [b9ce791](https://github.com/stashed/etcd/commit/b9ce791) Prepare for release 3.5.0-v1 (#18)
+- [fbaaa64](https://github.com/stashed/etcd/commit/fbaaa64) [cherry-pick] Fix SiteInfo publishing (#16) (#17)
+- [38d8c50](https://github.com/stashed/etcd/commit/38d8c50) [cherry-pick] Update dependencies (#14) (#15)
+- [450272c](https://github.com/stashed/etcd/commit/450272c) [cherry-pick] Remove Google Analytics (#12) (#13)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2021.11.24](https://github.com/stashed/installer/releases/tag/v2021.11.24)
+
+- [4dd8553](https://github.com/stashed/installer/commit/4dd8553) Prepare for release v2021.11.24 (#217)
+- [e1f85c4](https://github.com/stashed/installer/commit/e1f85c4) Update dependencies (#216)
+- [d35bb37](https://github.com/stashed/installer/commit/d35bb37) Remove Google Analytics (#215)
+- [bcbb9ea](https://github.com/stashed/installer/commit/bcbb9ea) Add support for Elasticsearch 7.14.0 (#214)
+- [f31eaaf](https://github.com/stashed/installer/commit/f31eaaf) Update Makefile for controller-tools@v0.7.0
+- [6f10ba7](https://github.com/stashed/installer/commit/6f10ba7) Update repository config (#213)
+- [7d86750](https://github.com/stashed/installer/commit/7d86750) Update dependencies (#212)
+- [d957af5](https://github.com/stashed/installer/commit/d957af5) Fix satori/go.uuid security vulnerability (#211)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v7](https://github.com/stashed/mariadb/releases/tag/10.5.8-v7)
+
+- [c31170b](https://github.com/stashed/mariadb/commit/c31170b) Prepare for release 10.5.8-v7 (#159)
+- [c428c5a](https://github.com/stashed/mariadb/commit/c428c5a) [cherry-pick] Fix SiteInfo publishing (#157) (#158)
+- [fb9ea57](https://github.com/stashed/mariadb/commit/fb9ea57) [cherry-pick] Update dependencies (#155) (#156)
+- [16bb2df](https://github.com/stashed/mariadb/commit/16bb2df) [cherry-pick] Remove Google Analytics (#153) (#154)
+- [263083f](https://github.com/stashed/mariadb/commit/263083f) [cherry-pick] Update dependencies (#151) (#152)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v13](https://github.com/stashed/mongodb/releases/tag/3.4.17-v13)
+
+- [bebf0289](https://github.com/stashed/mongodb/commit/bebf0289) Prepare for release 3.4.17-v13 (#1337)
+- [c3be77d2](https://github.com/stashed/mongodb/commit/c3be77d2) [cherry-pick] Fix SiteInfo publishing (#1323) (#1324)
+- [2b1d2af8](https://github.com/stashed/mongodb/commit/2b1d2af8) [cherry-pick] Update dependencies (#1310) (#1311)
+- [af5f4646](https://github.com/stashed/mongodb/commit/af5f4646) [cherry-pick] Remove Google Analytics (#1296) (#1297)
+- [4092dd65](https://github.com/stashed/mongodb/commit/4092dd65) [cherry-pick] Update dependencies (#1282) (#1283)
+- [4a607d83](https://github.com/stashed/mongodb/commit/4a607d83) [cherry-pick] Fix satori/go.uuid security vulnerability (#1278) (#1279)
+
+
+### [3.4.22-v13](https://github.com/stashed/mongodb/releases/tag/3.4.22-v13)
+
+- [57a441dd](https://github.com/stashed/mongodb/commit/57a441dd) Prepare for release 3.4.22-v13 (#1338)
+- [f2ecc5b2](https://github.com/stashed/mongodb/commit/f2ecc5b2) [cherry-pick] Fix SiteInfo publishing (#1323) (#1325)
+- [e252351d](https://github.com/stashed/mongodb/commit/e252351d) [cherry-pick] Update dependencies (#1310) (#1312)
+- [8b24f555](https://github.com/stashed/mongodb/commit/8b24f555) [cherry-pick] Remove Google Analytics (#1296) (#1298)
+- [919b8342](https://github.com/stashed/mongodb/commit/919b8342) [cherry-pick] Update dependencies (#1282) (#1284)
+- [712b63d5](https://github.com/stashed/mongodb/commit/712b63d5) [cherry-pick] Fix satori/go.uuid security vulnerability (#1278) (#1280)
+
+
+### [3.6.8-v13](https://github.com/stashed/mongodb/releases/tag/3.6.8-v13)
+
+- [46bb9249](https://github.com/stashed/mongodb/commit/46bb9249) Prepare for release 3.6.8-v13 (#1340)
+- [d57604e8](https://github.com/stashed/mongodb/commit/d57604e8) [cherry-pick] Fix SiteInfo publishing (#1323) (#1327)
+- [db3a4260](https://github.com/stashed/mongodb/commit/db3a4260) [cherry-pick] Update dependencies (#1310) (#1314)
+- [5d46225e](https://github.com/stashed/mongodb/commit/5d46225e) [cherry-pick] Remove Google Analytics (#1296) (#1300)
+- [ab7f7d38](https://github.com/stashed/mongodb/commit/ab7f7d38) [cherry-pick] Update dependencies (#1282) (#1286)
+
+
+### [3.6.13-v13](https://github.com/stashed/mongodb/releases/tag/3.6.13-v13)
+
+- [1b56e134](https://github.com/stashed/mongodb/commit/1b56e134) Prepare for release 3.6.13-v13 (#1339)
+- [610c36e4](https://github.com/stashed/mongodb/commit/610c36e4) [cherry-pick] Fix SiteInfo publishing (#1323) (#1326)
+- [59231f32](https://github.com/stashed/mongodb/commit/59231f32) [cherry-pick] Update dependencies (#1310) (#1313)
+- [b3a2048e](https://github.com/stashed/mongodb/commit/b3a2048e) [cherry-pick] Remove Google Analytics (#1296) (#1299)
+- [9b4f53bc](https://github.com/stashed/mongodb/commit/9b4f53bc) [cherry-pick] Update dependencies (#1282) (#1285)
+- [76c701a1](https://github.com/stashed/mongodb/commit/76c701a1) [cherry-pick] Fix satori/go.uuid security vulnerability (#1278) (#1281)
+
+
+### [4.0.3-v13](https://github.com/stashed/mongodb/releases/tag/4.0.3-v13)
+
+- [5c1bde68](https://github.com/stashed/mongodb/commit/5c1bde68) Prepare for release 4.0.3-v13 (#1342)
+- [2de0c6c3](https://github.com/stashed/mongodb/commit/2de0c6c3) [cherry-pick] Fix SiteInfo publishing (#1323) (#1328)
+- [88ce93c2](https://github.com/stashed/mongodb/commit/88ce93c2) [cherry-pick] Update dependencies (#1310) (#1315)
+- [836f5dc0](https://github.com/stashed/mongodb/commit/836f5dc0) [cherry-pick] Remove Google Analytics (#1296) (#1302)
+- [721fcf81](https://github.com/stashed/mongodb/commit/721fcf81) [cherry-pick] Update dependencies (#1282) (#1288)
+
+
+### [4.0.5-v13](https://github.com/stashed/mongodb/releases/tag/4.0.5-v13)
+
+- [db7f658c](https://github.com/stashed/mongodb/commit/db7f658c) Prepare for release 4.0.5-v13 (#1343)
+- [403f30c5](https://github.com/stashed/mongodb/commit/403f30c5) [cherry-pick] Fix SiteInfo publishing (#1323) (#1329)
+- [2514268e](https://github.com/stashed/mongodb/commit/2514268e) [cherry-pick] Update dependencies (#1310) (#1316)
+- [fdeb0ff2](https://github.com/stashed/mongodb/commit/fdeb0ff2) [cherry-pick] Remove Google Analytics (#1296) (#1303)
+- [dfc34ecc](https://github.com/stashed/mongodb/commit/dfc34ecc) [cherry-pick] Update dependencies (#1282) (#1289)
+
+
+### [4.0.11-v13](https://github.com/stashed/mongodb/releases/tag/4.0.11-v13)
+
+- [9e7ba040](https://github.com/stashed/mongodb/commit/9e7ba040) Prepare for release 4.0.11-v13 (#1341)
+- [16ca1fa2](https://github.com/stashed/mongodb/commit/16ca1fa2) Fix SiteInfo publishing (#1323) (#1336)
+- [f65fdb46](https://github.com/stashed/mongodb/commit/f65fdb46) [cherry-pick] Remove Google Analytics (#1296) (#1301)
+- [af34b99f](https://github.com/stashed/mongodb/commit/af34b99f) [cherry-pick] Update dependencies (#1282) (#1287)
+
+
+### [4.1.4-v13](https://github.com/stashed/mongodb/releases/tag/4.1.4-v13)
+
+- [7ae5a2ad](https://github.com/stashed/mongodb/commit/7ae5a2ad) Prepare for release 4.1.4-v13 (#1345)
+- [1fbfdc18](https://github.com/stashed/mongodb/commit/1fbfdc18) [cherry-pick] Fix SiteInfo publishing (#1323) (#1331)
+- [3e4c83b4](https://github.com/stashed/mongodb/commit/3e4c83b4) [cherry-pick] Update dependencies (#1310) (#1318)
+- [556bfba7](https://github.com/stashed/mongodb/commit/556bfba7) [cherry-pick] Remove Google Analytics (#1296) (#1305)
+- [45a4763d](https://github.com/stashed/mongodb/commit/45a4763d) [cherry-pick] Update dependencies (#1282) (#1291)
+
+
+### [4.1.7-v13](https://github.com/stashed/mongodb/releases/tag/4.1.7-v13)
+
+- [d6a8db2d](https://github.com/stashed/mongodb/commit/d6a8db2d) Prepare for release 4.1.7-v13 (#1346)
+- [4778b673](https://github.com/stashed/mongodb/commit/4778b673) [cherry-pick] Fix SiteInfo publishing (#1323) (#1332)
+- [309254e4](https://github.com/stashed/mongodb/commit/309254e4) [cherry-pick] Update dependencies (#1310) (#1319)
+- [b5023e73](https://github.com/stashed/mongodb/commit/b5023e73) [cherry-pick] Remove Google Analytics (#1296) (#1306)
+- [97ae840f](https://github.com/stashed/mongodb/commit/97ae840f) [cherry-pick] Update dependencies (#1282) (#1292)
+
+
+### [4.1.13-v13](https://github.com/stashed/mongodb/releases/tag/4.1.13-v13)
+
+- [23386af7](https://github.com/stashed/mongodb/commit/23386af7) Prepare for release 4.1.13-v13 (#1344)
+- [3d729113](https://github.com/stashed/mongodb/commit/3d729113) [cherry-pick] Fix SiteInfo publishing (#1323) (#1330)
+- [64d99f5e](https://github.com/stashed/mongodb/commit/64d99f5e) [cherry-pick] Update dependencies (#1310) (#1317)
+- [75f44f15](https://github.com/stashed/mongodb/commit/75f44f15) [cherry-pick] Remove Google Analytics (#1296) (#1304)
+- [e0f1430a](https://github.com/stashed/mongodb/commit/e0f1430a) [cherry-pick] Update dependencies (#1282) (#1290)
+
+
+### [4.2.3-v13](https://github.com/stashed/mongodb/releases/tag/4.2.3-v13)
+
+- [b939c08e](https://github.com/stashed/mongodb/commit/b939c08e) [cherry-pick] Fix SiteInfo publishing (#1323) (#1333)
+- [90919d62](https://github.com/stashed/mongodb/commit/90919d62) [cherry-pick] Update dependencies (#1310) (#1320)
+- [71bf43c6](https://github.com/stashed/mongodb/commit/71bf43c6) [cherry-pick] Remove Google Analytics (#1296) (#1307)
+- [2de25d86](https://github.com/stashed/mongodb/commit/2de25d86) [cherry-pick] Update dependencies (#1282) (#1293)
+
+
+### [4.4.6-v4](https://github.com/stashed/mongodb/releases/tag/4.4.6-v4)
+
+- [6659f5bc](https://github.com/stashed/mongodb/commit/6659f5bc) [cherry-pick] Fix SiteInfo publishing (#1323) (#1334)
+- [b3ad89fd](https://github.com/stashed/mongodb/commit/b3ad89fd) [cherry-pick] Update dependencies (#1310) (#1321)
+- [a6744d43](https://github.com/stashed/mongodb/commit/a6744d43) [cherry-pick] Remove Google Analytics (#1296) (#1308)
+- [8ef2690c](https://github.com/stashed/mongodb/commit/8ef2690c) [cherry-pick] Update dependencies (#1282) (#1294)
+- [a138a55c](https://github.com/stashed/mongodb/commit/a138a55c) Prepare for release 4.4.6-v3 (#1275)
+
+
+### [5.0.3-v1](https://github.com/stashed/mongodb/releases/tag/5.0.3-v1)
+
+- [362d74c5](https://github.com/stashed/mongodb/commit/362d74c5) [cherry-pick] Fix SiteInfo publishing (#1323) (#1335)
+- [7243d8e6](https://github.com/stashed/mongodb/commit/7243d8e6) [cherry-pick] Update dependencies (#1310) (#1322)
+- [232ecd8c](https://github.com/stashed/mongodb/commit/232ecd8c) [cherry-pick] Remove Google Analytics (#1296) (#1309)
+- [dca0617b](https://github.com/stashed/mongodb/commit/dca0617b) [cherry-pick] Update dependencies (#1282) (#1295)
+- [7fb75a3a](https://github.com/stashed/mongodb/commit/7fb75a3a) Prepare for release 5.0.3 (#1276)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v14](https://github.com/stashed/mysql/releases/tag/5.7.25-v14)
+
+- [264b3f89](https://github.com/stashed/mysql/commit/264b3f89) Prepare for release 5.7.25-v14 (#554)
+- [c711f471](https://github.com/stashed/mysql/commit/c711f471) [cherry-pick] Fix SiteInfo publishing (#549) (#550)
+- [5a5dca7d](https://github.com/stashed/mysql/commit/5a5dca7d) [cherry-pick] Update dependencies (#544) (#545)
+- [3f7d49ec](https://github.com/stashed/mysql/commit/3f7d49ec) [cherry-pick] Remove Google Analytics (#539) (#540)
+- [45e25c49](https://github.com/stashed/mysql/commit/45e25c49) [cherry-pick] Update dependencies (#534) (#535)
+
+
+### [8.0.3-v14](https://github.com/stashed/mysql/releases/tag/8.0.3-v14)
+
+- [3cea90bb](https://github.com/stashed/mysql/commit/3cea90bb) Prepare for release 8.0.3-v14 (#557)
+- [680c3392](https://github.com/stashed/mysql/commit/680c3392) Fix SiteInfo publishing (#549) (#553)
+- [7c7e3048](https://github.com/stashed/mysql/commit/7c7e3048) [cherry-pick] Update dependencies (#544) (#548)
+- [d4de462d](https://github.com/stashed/mysql/commit/d4de462d) [cherry-pick] Remove Google Analytics (#539) (#543)
+- [cb20e05d](https://github.com/stashed/mysql/commit/cb20e05d) [cherry-pick] Update dependencies (#534) (#538)
+
+
+### [8.0.14-v14](https://github.com/stashed/mysql/releases/tag/8.0.14-v14)
+
+- [9364b2bf](https://github.com/stashed/mysql/commit/9364b2bf) Prepare for release 8.0.14-v14 (#555)
+- [9c30475f](https://github.com/stashed/mysql/commit/9c30475f) [cherry-pick] Fix SiteInfo publishing (#549) (#551)
+- [ca2762a4](https://github.com/stashed/mysql/commit/ca2762a4) [cherry-pick] Update dependencies (#544) (#546)
+- [77358f6e](https://github.com/stashed/mysql/commit/77358f6e) [cherry-pick] Remove Google Analytics (#539) (#541)
+- [fcc79b69](https://github.com/stashed/mysql/commit/fcc79b69) [cherry-pick] Update dependencies (#534) (#536)
+
+
+### [8.0.21-v8](https://github.com/stashed/mysql/releases/tag/8.0.21-v8)
+
+- [494bf1ba](https://github.com/stashed/mysql/commit/494bf1ba) Prepare for release 8.0.21-v8 (#556)
+- [7cede8cb](https://github.com/stashed/mysql/commit/7cede8cb) [cherry-pick] Fix SiteInfo publishing (#549) (#552)
+- [712512d6](https://github.com/stashed/mysql/commit/712512d6) [cherry-pick] Update dependencies (#544) (#547)
+- [3b2abd07](https://github.com/stashed/mysql/commit/3b2abd07) [cherry-pick] Remove Google Analytics (#539) (#542)
+- [b672201c](https://github.com/stashed/mysql/commit/b672201c) [cherry-pick] Update dependencies (#534) (#537)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v1](https://github.com/stashed/nats/releases/tag/2.6.1-v1)
+
+- [f806fbb](https://github.com/stashed/nats/commit/f806fbb) Prepare for release 2.6.1-v1 (#19)
+- [b78d2bb](https://github.com/stashed/nats/commit/b78d2bb) [cherry-pick] Fix SiteInfo publishing (#17) (#18)
+- [fe9d006](https://github.com/stashed/nats/commit/fe9d006) [cherry-pick] Update dependencies (#15) (#16)
+- [7c794b4](https://github.com/stashed/nats/commit/7c794b4) [cherry-pick] Remove Google Analytics (#13) (#14)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v9](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v9)
+
+- [72372b84](https://github.com/stashed/percona-xtradb/commit/72372b84) Prepare for release 5.7-v9 (#230)
+- [b70396c7](https://github.com/stashed/percona-xtradb/commit/b70396c7) [cherry-pick] Fix SiteInfo publishing (#228) (#229)
+- [ee91a0a4](https://github.com/stashed/percona-xtradb/commit/ee91a0a4) [cherry-pick] Update dependencies (#226) (#227)
+- [010bc77e](https://github.com/stashed/percona-xtradb/commit/010bc77e) [cherry-pick] Remove Google Analytics (#224) (#225)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v12](https://github.com/stashed/postgres/releases/tag/9.6.19-v12)
+
+- [42c89586](https://github.com/stashed/postgres/commit/42c89586) Prepare for release 9.6.19-v12 (#964)
+- [b7deaf65](https://github.com/stashed/postgres/commit/b7deaf65) [cherry-pick] Fix SiteInfo publishing (#952) (#956)
+- [45fd4b54](https://github.com/stashed/postgres/commit/45fd4b54) [cherry-pick] Update dependencies (#945) (#951)
+- [6b0eed64](https://github.com/stashed/postgres/commit/6b0eed64) [cherry-pick] Remove Google Analytics (#938) (#944)
+
+
+### [10.14-v12](https://github.com/stashed/postgres/releases/tag/10.14-v12)
+
+- [ebdef975](https://github.com/stashed/postgres/commit/ebdef975) Prepare for release 10.14-v12 (#959)
+- [3c4118cf](https://github.com/stashed/postgres/commit/3c4118cf) [cherry-pick] Fix SiteInfo publishing (#952) (#953)
+- [e0c893c6](https://github.com/stashed/postgres/commit/e0c893c6) [cherry-pick] Update dependencies (#945) (#946)
+- [5a773cde](https://github.com/stashed/postgres/commit/5a773cde) [cherry-pick] Remove Google Analytics (#938) (#939)
+
+
+### [11.9-v12](https://github.com/stashed/postgres/releases/tag/11.9-v12)
+
+- [c98dd3fa](https://github.com/stashed/postgres/commit/c98dd3fa) Prepare for release 11.9-v12 (#960)
+- [323002ba](https://github.com/stashed/postgres/commit/323002ba) [cherry-pick] Fix SiteInfo publishing (#952) (#954)
+- [07b87ef8](https://github.com/stashed/postgres/commit/07b87ef8) [cherry-pick] Update dependencies (#945) (#947)
+- [f7e632c1](https://github.com/stashed/postgres/commit/f7e632c1) [cherry-pick] Remove Google Analytics (#938) (#940)
+
+
+### [12.4-v12](https://github.com/stashed/postgres/releases/tag/12.4-v12)
+
+- [8bfeb538](https://github.com/stashed/postgres/commit/8bfeb538) Prepare for release 12.4-v12 (#961)
+- [7ab310cb](https://github.com/stashed/postgres/commit/7ab310cb) Fix SiteInfo publishing (#952) (#957)
+- [dd32b9eb](https://github.com/stashed/postgres/commit/dd32b9eb) [cherry-pick] Update dependencies (#945) (#948)
+- [4004b647](https://github.com/stashed/postgres/commit/4004b647) [cherry-pick] Remove Google Analytics (#938) (#941)
+
+
+### [13.1-v9](https://github.com/stashed/postgres/releases/tag/13.1-v9)
+
+- [b2ab0cec](https://github.com/stashed/postgres/commit/b2ab0cec) Prepare for release 13.1-v9 (#962)
+- [a912d10f](https://github.com/stashed/postgres/commit/a912d10f) Fix SiteInfo publishing (#952) (#958)
+- [6dbbfce1](https://github.com/stashed/postgres/commit/6dbbfce1) [cherry-pick] Update dependencies (#945) (#949)
+- [5f8ea3d8](https://github.com/stashed/postgres/commit/5f8ea3d8) [cherry-pick] Remove Google Analytics (#938) (#942)
+
+
+### [14.0-v1](https://github.com/stashed/postgres/releases/tag/14.0-v1)
+
+- [94c0d679](https://github.com/stashed/postgres/commit/94c0d679) Prepare for release 14.0-v1 (#963)
+- [ced1f471](https://github.com/stashed/postgres/commit/ced1f471) [cherry-pick] Fix SiteInfo publishing (#952) (#955)
+- [aba33b34](https://github.com/stashed/postgres/commit/aba33b34) [cherry-pick] Update dependencies (#945) (#950)
+- [f5f2db00](https://github.com/stashed/postgres/commit/f5f2db00) [cherry-pick] Remove Google Analytics (#938) (#943)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v2](https://github.com/stashed/redis/releases/tag/5.0.13-v2)
+
+- [9191462](https://github.com/stashed/redis/commit/9191462) Prepare for release 5.0.13-v2 (#67)
+- [d1be27a](https://github.com/stashed/redis/commit/d1be27a) [cherry-pick] Fix SiteInfo publishing (#64) (#65)
+- [c529e8d](https://github.com/stashed/redis/commit/c529e8d) [cherry-pick] Update dependencies (#61) (#62)
+- [759c04e](https://github.com/stashed/redis/commit/759c04e) [cherry-pick] Remove Google Analytics (#58) (#59)
+- [e563da6](https://github.com/stashed/redis/commit/e563da6) [cherry-pick] Fix satori/go.uuid security vulnerability (#55) (#56)
+
+
+### [6.2.5-v2](https://github.com/stashed/redis/releases/tag/6.2.5-v2)
+
+- [a27b1fb](https://github.com/stashed/redis/commit/a27b1fb) Prepare for release 6.2.5-v2 (#68)
+- [88133a9](https://github.com/stashed/redis/commit/88133a9) [cherry-pick] Fix SiteInfo publishing (#64) (#66)
+- [e346fc8](https://github.com/stashed/redis/commit/e346fc8) [cherry-pick] Update dependencies (#61) (#63)
+- [5895da7](https://github.com/stashed/redis/commit/5895da7) [cherry-pick] Remove Google Analytics (#58) (#60)
+- [7f3dfff](https://github.com/stashed/redis/commit/7f3dfff) [cherry-pick] Fix satori/go.uuid security vulnerability (#55) (#57)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.17.0](https://github.com/stashed/stash/releases/tag/v0.17.0)
+
+- [56eeabab](https://github.com/stashed/stash/commit/56eeabab) Prepare for release v0.17.0 (#1403)
+- [57fea237](https://github.com/stashed/stash/commit/57fea237) Fix SiteInfo publishing (#1402)
+- [a3acd499](https://github.com/stashed/stash/commit/a3acd499) Update dependencies (#1401)
+- [f06740a2](https://github.com/stashed/stash/commit/f06740a2) Update license verifier (#1400)
+- [ff417d95](https://github.com/stashed/stash/commit/ff417d95) Remove Google Analytics (#1399)
+- [4e24ba6a](https://github.com/stashed/stash/commit/4e24ba6a) Update repository config (#1398)
+- [514e79b9](https://github.com/stashed/stash/commit/514e79b9) Fix satori/go.uuid security vulnerability (#1397)
+- [a5b7398d](https://github.com/stashed/stash/commit/a5b7398d) Apply all pod level runtime settings to CronJob (#1396)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.11.24
Release-tracker: https://github.com/stashed/CHANGELOG/pull/43
Signed-off-by: 1gtm <1gtm@appscode.com>