### PR TITLE
Prepare for release v2022.05.12

### DIFF
--- a/docs/CHANGELOG-v2022.05.12.md
+++ b/docs/CHANGELOG-v2022.05.12.md
@@ -1,0 +1,446 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2022.05.12
+    name: Changelog-v2022.05.12
+    parent: welcome
+    weight: 20220512
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.05.12/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.05.12/
+---
+
+# Stash v2022.05.12 (2022-05-09)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.20.0](https://github.com/stashed/apimachinery/releases/tag/v0.20.0)
+
+- [59662acc](https://github.com/stashed/apimachinery/commit/59662acc) Update nats client to v1.15.0 (#168)
+- [c840c081](https://github.com/stashed/apimachinery/commit/c840c081) Use EmptyTarget when target is not specified (#156)
+- [73208310](https://github.com/stashed/apimachinery/commit/73208310) Utilize target count during calculating invoker phase + Add `backupNamespace` in BackupBlueprint (#167)
+- [61c413e1](https://github.com/stashed/apimachinery/commit/61c413e1) Add topologySpreadConstraints to RuntimeSettings (#166)
+- [dbb9ce30](https://github.com/stashed/apimachinery/commit/dbb9ce30) Add Cross-namespace target support. (#164)
+- [8d0e2056](https://github.com/stashed/apimachinery/commit/8d0e2056) Use restic 0.13.1 (#165)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.20.0](https://github.com/stashed/cli/releases/tag/v0.20.0)
+
+- [9c3e9a57](https://github.com/stashed/cli/commit/9c3e9a57) Prepare for release v0.20.0 (#163)
+- [a267d818](https://github.com/stashed/cli/commit/a267d818) Update nats client to v1.15.0 (#162)
+- [a66abe45](https://github.com/stashed/cli/commit/a66abe45) Use restic 0.13.1 (#161)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v17](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v17)
+
+- [dd7bbf09](https://github.com/stashed/elasticsearch/commit/dd7bbf09) Prepare for release 5.6.4-v17 (#1180)
+- [88bf5065](https://github.com/stashed/elasticsearch/commit/88bf5065) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1171)
+- [0a7e37fb](https://github.com/stashed/elasticsearch/commit/0a7e37fb) Add support for cross-namespace target (#1160) (#1161)
+- [c28cbac3](https://github.com/stashed/elasticsearch/commit/c28cbac3) [cherry-pick] Use restic 0.13.1 (#1151) (#1152)
+
+
+### [6.2.4-v17](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v17)
+
+- [54721c76](https://github.com/stashed/elasticsearch/commit/54721c76) Prepare for release 6.2.4-v17 (#1181)
+- [726d1ff6](https://github.com/stashed/elasticsearch/commit/726d1ff6) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1172)
+- [7e4fc91a](https://github.com/stashed/elasticsearch/commit/7e4fc91a) Add support for cross-namespace target (#1160) (#1162)
+- [5ece0776](https://github.com/stashed/elasticsearch/commit/5ece0776) [cherry-pick] Use restic 0.13.1 (#1151) (#1153)
+
+
+### [6.3.0-v17](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v17)
+
+- [c65ea376](https://github.com/stashed/elasticsearch/commit/c65ea376) Prepare for release 6.3.0-v17 (#1182)
+- [65650751](https://github.com/stashed/elasticsearch/commit/65650751) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1173)
+- [9b38d077](https://github.com/stashed/elasticsearch/commit/9b38d077) Add support for cross-namespace target (#1160) (#1163)
+- [bed66f42](https://github.com/stashed/elasticsearch/commit/bed66f42) [cherry-pick] Use restic 0.13.1 (#1151) (#1154)
+
+
+### [6.4.0-v17](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v17)
+
+- [4d4072c3](https://github.com/stashed/elasticsearch/commit/4d4072c3) Prepare for release 6.4.0-v17 (#1183)
+- [6def816f](https://github.com/stashed/elasticsearch/commit/6def816f) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1174)
+- [13362334](https://github.com/stashed/elasticsearch/commit/13362334) Add support for cross-namespace target (#1160) (#1164)
+- [109f5a4a](https://github.com/stashed/elasticsearch/commit/109f5a4a) [cherry-pick] Use restic 0.13.1 (#1151) (#1155)
+
+
+### [6.5.3-v17](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v17)
+
+- [e422361c](https://github.com/stashed/elasticsearch/commit/e422361c) Prepare for release 6.5.3-v17 (#1184)
+- [c3bc2044](https://github.com/stashed/elasticsearch/commit/c3bc2044) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1175)
+- [ad39246d](https://github.com/stashed/elasticsearch/commit/ad39246d) Add support for cross-namespace target (#1160) (#1165)
+- [94c472f3](https://github.com/stashed/elasticsearch/commit/94c472f3) [cherry-pick] Use restic 0.13.1 (#1151) (#1156)
+
+
+### [6.8.0-v17](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v17)
+
+- [2a2eccd8](https://github.com/stashed/elasticsearch/commit/2a2eccd8) Prepare for release 6.8.0-v17 (#1185)
+- [133e8dfd](https://github.com/stashed/elasticsearch/commit/133e8dfd) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1176)
+- [0ddc79b2](https://github.com/stashed/elasticsearch/commit/0ddc79b2) Add support for cross-namespace target (#1160) (#1166)
+- [0cc4d57c](https://github.com/stashed/elasticsearch/commit/0cc4d57c) [cherry-pick] Use restic 0.13.1 (#1151) (#1157)
+
+
+### [7.2.0-v17](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v17)
+
+- [7c388a05](https://github.com/stashed/elasticsearch/commit/7c388a05) Prepare for release 7.2.0-v17 (#1187)
+- [f344f507](https://github.com/stashed/elasticsearch/commit/f344f507) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1178)
+- [0d8256bf](https://github.com/stashed/elasticsearch/commit/0d8256bf) [cherry-pick] Add support for cross-namespace target (#1160) (#1168)
+
+
+### [7.3.2-v17](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v17)
+
+- [4f45b187](https://github.com/stashed/elasticsearch/commit/4f45b187) Prepare for release 7.3.2-v17 (#1188)
+- [fc8920a7](https://github.com/stashed/elasticsearch/commit/fc8920a7) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1179)
+- [fd63fd18](https://github.com/stashed/elasticsearch/commit/fd63fd18) Add support for cross-namespace target (#1160) (#1169)
+- [7389d64d](https://github.com/stashed/elasticsearch/commit/7389d64d) [cherry-pick] Use restic 0.13.1 (#1151) (#1159)
+
+
+### [7.14.0-v3](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v3)
+
+- [f67cef25](https://github.com/stashed/elasticsearch/commit/f67cef25) Prepare for release 7.14.0-v3 (#1186)
+- [3e98ed36](https://github.com/stashed/elasticsearch/commit/3e98ed36) [cherry-pick] Update nats client to v1.15.0 (#1170) (#1177)
+- [6b7522e3](https://github.com/stashed/elasticsearch/commit/6b7522e3) Add support for cross-namespace target (#1160) (#1167)
+- [8cf47e9f](https://github.com/stashed/elasticsearch/commit/8cf47e9f) [cherry-pick] Use restic 0.13.1 (#1151) (#1158)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.20.0](https://github.com/stashed/enterprise/releases/tag/v0.20.0)
+
+- [b6f3fac2](https://github.com/stashed/enterprise/commit/b6f3fac2) Prepare for release v0.20.0 (#170)
+- [180a6360](https://github.com/stashed/enterprise/commit/180a6360) Update nats client to v1.15.0 (#169)
+- [a315a1f6](https://github.com/stashed/enterprise/commit/a315a1f6) Support empty target ref (#151)
+- [75e07270](https://github.com/stashed/enterprise/commit/75e07270) Fix errors caught in the e2e tests. (#168)
+- [c8a574d5](https://github.com/stashed/enterprise/commit/c8a574d5) Add support for cross-namespace target. (#164)
+- [94d51f57](https://github.com/stashed/enterprise/commit/94d51f57) Pass TopologySpreadConstraints in ApplyPodRuntimeSettings()
+- [f3b333ae](https://github.com/stashed/enterprise/commit/f3b333ae) Update requirements for VolumeSnapshotter (#167)
+- [fb63db1d](https://github.com/stashed/enterprise/commit/fb63db1d) Use restic 0.13.1 (#166)
+- [97d5e06d](https://github.com/stashed/enterprise/commit/97d5e06d) Update `RoleBinding` name (#165)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v4](https://github.com/stashed/etcd/releases/tag/3.5.0-v4)
+
+- [f48c690](https://github.com/stashed/etcd/commit/f48c690) Prepare for release 3.5.0-v4 (#43)
+- [119ce00](https://github.com/stashed/etcd/commit/119ce00) [cherry-pick] Update nats client to v1.15.0 (#41) (#42)
+- [d17c3e8](https://github.com/stashed/etcd/commit/d17c3e8) Add support for cross-namespace target (#39) (#40)
+- [8300c3a](https://github.com/stashed/etcd/commit/8300c3a) [cherry-pick] Use restic 0.13.1 (#37) (#38)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2022.05.12](https://github.com/stashed/installer/releases/tag/v2022.05.12)
+
+- [5cbe698c](https://github.com/stashed/installer/commit/5cbe698c) Prepare for release v2022.05.12 (#251)
+- [046a8f2d](https://github.com/stashed/installer/commit/046a8f2d) Update nats client to v1.15.0 (#250)
+- [55b9a5d5](https://github.com/stashed/installer/commit/55b9a5d5) Add catalogs for manifest-backup addon (#248)
+- [e07115b2](https://github.com/stashed/installer/commit/e07115b2) Update grafana dashboard to use updated panopticon metrics format (#249)
+- [3e7a25f8](https://github.com/stashed/installer/commit/3e7a25f8) Update MetricsConfiguration (#247)
+- [13cefa64](https://github.com/stashed/installer/commit/13cefa64) Add `appbbinding-namespace` flag to backup and restore functions (#246)
+- [e2900e0f](https://github.com/stashed/installer/commit/e2900e0f) Use restic 0.13.1 (#245)
+- [015b099e](https://github.com/stashed/installer/commit/015b099e) Fix ui-server schema (#244)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0](https://github.com/stashed/kubedump/releases/tag/0.1.0)
+
+- [7db2e3e](https://github.com/stashed/kubedump/commit/7db2e3e) Prepare for release 0.1.0 (#4)
+- [3914bbe](https://github.com/stashed/kubedump/commit/3914bbe) Remove .idea folder
+- [08ae97c](https://github.com/stashed/kubedump/commit/08ae97c) Update nats client to v1.15.0 (#3)
+- [b742e9b](https://github.com/stashed/kubedump/commit/b742e9b) Use Go 1.18 (#2)
+- [0368858](https://github.com/stashed/kubedump/commit/0368858) Merge pull request #1 from stashed/implement-plugin
+- [b5b1ae0](https://github.com/stashed/kubedump/commit/b5b1ae0) Fix CI
+- [80eb90e](https://github.com/stashed/kubedump/commit/80eb90e) test ci
+- [103a512](https://github.com/stashed/kubedump/commit/103a512) test ci
+- [5c84f7c](https://github.com/stashed/kubedump/commit/5c84f7c) test ci
+- [c00c5d9](https://github.com/stashed/kubedump/commit/c00c5d9) test ci
+- [82d7168](https://github.com/stashed/kubedump/commit/82d7168) test ci
+- [d550477](https://github.com/stashed/kubedump/commit/d550477) Debug CI failure Signed-off-by: Emruz Hossain <emruz@appscode.com>
+- [143f06b](https://github.com/stashed/kubedump/commit/143f06b) Create kind cluster in ci
+- [ce7cdd7](https://github.com/stashed/kubedump/commit/ce7cdd7) Rename components from manifest-backup to kubedump
+- [d2a417e](https://github.com/stashed/kubedump/commit/d2a417e) Fix target matcher
+- [8c33614](https://github.com/stashed/kubedump/commit/8c33614) Update flags
+- [9dbfd9f](https://github.com/stashed/kubedump/commit/9dbfd9f) Finish implementing the plugin
+- [103434d](https://github.com/stashed/kubedump/commit/103434d) Refactor code
+- [ad144f2](https://github.com/stashed/kubedump/commit/ad144f2) Add appication backup logic
+- [8baf9f7](https://github.com/stashed/kubedump/commit/8baf9f7) Implement namespace level backup
+- [57a4c48](https://github.com/stashed/kubedump/commit/57a4c48) WIP: Add namespace level backup Signed-off-by: Emruz Hossain <emruz@appscode.com>
+- [a0a61a7](https://github.com/stashed/kubedump/commit/a0a61a7) Implement cluster backup interface
+- [18612c3](https://github.com/stashed/kubedump/commit/18612c3) Added all
+- [eadc54a](https://github.com/stashed/kubedump/commit/eadc54a) added all
+- [c700514](https://github.com/stashed/kubedump/commit/c700514) Implement manifest backup plugin
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v10](https://github.com/stashed/mariadb/releases/tag/10.5.8-v10)
+
+- [38e5f0b](https://github.com/stashed/mariadb/commit/38e5f0b) Prepare for release 10.5.8-v10 (#185)
+- [786a415](https://github.com/stashed/mariadb/commit/786a415) [cherry-pick] Update nats client to v1.15.0 (#183) (#184)
+- [35c8298](https://github.com/stashed/mariadb/commit/35c8298) Add support for cross-namespace target (#181) (#182)
+- [cdd168d](https://github.com/stashed/mariadb/commit/cdd168d) [cherry-pick] Use restic 0.13.1 (#179) (#180)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v16](https://github.com/stashed/mongodb/releases/tag/3.4.17-v16)
+
+- [0e639f61](https://github.com/stashed/mongodb/commit/0e639f61) Prepare for release 3.4.17-v16 (#1540)
+- [fb90dbf0](https://github.com/stashed/mongodb/commit/fb90dbf0) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1527)
+- [02f8442b](https://github.com/stashed/mongodb/commit/02f8442b) Add support for cross-namespace target (#1512) (#1513)
+- [27aa698b](https://github.com/stashed/mongodb/commit/27aa698b) [cherry-pick] Use restic 0.13.1 (#1499) (#1500)
+
+
+### [3.4.22-v16](https://github.com/stashed/mongodb/releases/tag/3.4.22-v16)
+
+- [bd347f29](https://github.com/stashed/mongodb/commit/bd347f29) Prepare for release 3.4.22-v16 (#1541)
+- [eadd2e6c](https://github.com/stashed/mongodb/commit/eadd2e6c) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1528)
+- [039c7147](https://github.com/stashed/mongodb/commit/039c7147) Add support for cross-namespace target (#1512) (#1514)
+- [a1f3d87e](https://github.com/stashed/mongodb/commit/a1f3d87e) [cherry-pick] Use restic 0.13.1 (#1499) (#1501)
+
+
+### [3.6.8-v16](https://github.com/stashed/mongodb/releases/tag/3.6.8-v16)
+
+- [f0fadf84](https://github.com/stashed/mongodb/commit/f0fadf84) Prepare for release 3.6.8-v16 (#1543)
+- [786684e1](https://github.com/stashed/mongodb/commit/786684e1) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1530)
+- [c662ea7c](https://github.com/stashed/mongodb/commit/c662ea7c) Add support for cross-namespace target (#1512) (#1516)
+- [0085bc6b](https://github.com/stashed/mongodb/commit/0085bc6b) [cherry-pick] Use restic 0.13.1 (#1499) (#1503)
+
+
+### [3.6.13-v16](https://github.com/stashed/mongodb/releases/tag/3.6.13-v16)
+
+- [4113f8e6](https://github.com/stashed/mongodb/commit/4113f8e6) Prepare for release 3.6.13-v16 (#1542)
+- [df373044](https://github.com/stashed/mongodb/commit/df373044) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1529)
+- [9e453aa4](https://github.com/stashed/mongodb/commit/9e453aa4) Add support for cross-namespace target (#1512) (#1515)
+- [2f3c7cdc](https://github.com/stashed/mongodb/commit/2f3c7cdc) [cherry-pick] Use restic 0.13.1 (#1499) (#1502)
+
+
+### [4.0.3-v16](https://github.com/stashed/mongodb/releases/tag/4.0.3-v16)
+
+- [155311ce](https://github.com/stashed/mongodb/commit/155311ce) Prepare for release 4.0.3-v16 (#1545)
+- [b577ae9b](https://github.com/stashed/mongodb/commit/b577ae9b) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1532)
+- [9fa69e76](https://github.com/stashed/mongodb/commit/9fa69e76) [cherry-pick] Add support for cross-namespace target (#1512) (#1518)
+
+
+### [4.0.5-v16](https://github.com/stashed/mongodb/releases/tag/4.0.5-v16)
+
+- [8734aca2](https://github.com/stashed/mongodb/commit/8734aca2) Prepare for release 4.0.5-v16 (#1546)
+- [a16532df](https://github.com/stashed/mongodb/commit/a16532df) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1533)
+- [db963072](https://github.com/stashed/mongodb/commit/db963072) Add support for cross-namespace target (#1512) (#1519)
+- [8efe9034](https://github.com/stashed/mongodb/commit/8efe9034) [cherry-pick] Use restic 0.13.1 (#1499) (#1505)
+
+
+### [4.0.11-v16](https://github.com/stashed/mongodb/releases/tag/4.0.11-v16)
+
+- [62a11848](https://github.com/stashed/mongodb/commit/62a11848) Prepare for release 4.0.11-v16 (#1544)
+- [4c7ce065](https://github.com/stashed/mongodb/commit/4c7ce065) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1531)
+- [731a900f](https://github.com/stashed/mongodb/commit/731a900f) Add support for cross-namespace target (#1512) (#1517)
+- [d4e7f6df](https://github.com/stashed/mongodb/commit/d4e7f6df) [cherry-pick] Use restic 0.13.1 (#1499) (#1504)
+
+
+### [4.1.4-v16](https://github.com/stashed/mongodb/releases/tag/4.1.4-v16)
+
+- [e849db61](https://github.com/stashed/mongodb/commit/e849db61) Prepare for release 4.1.4-v16 (#1548)
+- [32576241](https://github.com/stashed/mongodb/commit/32576241) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1535)
+- [16601091](https://github.com/stashed/mongodb/commit/16601091) Add support for cross-namespace target (#1512) (#1521)
+- [c7c78813](https://github.com/stashed/mongodb/commit/c7c78813) [cherry-pick] Use restic 0.13.1 (#1499) (#1507)
+
+
+### [4.1.7-v16](https://github.com/stashed/mongodb/releases/tag/4.1.7-v16)
+
+- [a4697d1b](https://github.com/stashed/mongodb/commit/a4697d1b) Prepare for release 4.1.7-v16 (#1549)
+- [3effe3ec](https://github.com/stashed/mongodb/commit/3effe3ec) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1536)
+- [07ea7e1a](https://github.com/stashed/mongodb/commit/07ea7e1a) Add support for cross-namespace target (#1512) (#1522)
+- [2495ebb1](https://github.com/stashed/mongodb/commit/2495ebb1) [cherry-pick] Use restic 0.13.1 (#1499) (#1508)
+
+
+### [4.1.13-v16](https://github.com/stashed/mongodb/releases/tag/4.1.13-v16)
+
+- [b7a7701b](https://github.com/stashed/mongodb/commit/b7a7701b) Prepare for release 4.1.13-v16 (#1547)
+- [39a5c0ea](https://github.com/stashed/mongodb/commit/39a5c0ea) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1534)
+- [eca54d4d](https://github.com/stashed/mongodb/commit/eca54d4d) Add support for cross-namespace target (#1512) (#1520)
+- [7e77a7d1](https://github.com/stashed/mongodb/commit/7e77a7d1) [cherry-pick] Use restic 0.13.1 (#1499) (#1506)
+
+
+### [4.2.3-v16](https://github.com/stashed/mongodb/releases/tag/4.2.3-v16)
+
+- [8661ee65](https://github.com/stashed/mongodb/commit/8661ee65) Prepare for release 4.2.3-v16 (#1550)
+- [612d78ec](https://github.com/stashed/mongodb/commit/612d78ec) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1537)
+- [ae60a061](https://github.com/stashed/mongodb/commit/ae60a061) Add support for cross-namespace target (#1512) (#1523)
+- [ad4b202b](https://github.com/stashed/mongodb/commit/ad4b202b) [cherry-pick] Use restic 0.13.1 (#1499) (#1509)
+
+
+### [4.4.6-v7](https://github.com/stashed/mongodb/releases/tag/4.4.6-v7)
+
+- [12d5d20f](https://github.com/stashed/mongodb/commit/12d5d20f) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1538)
+- [1d007579](https://github.com/stashed/mongodb/commit/1d007579) Add support for cross-namespace target (#1512) (#1524)
+- [d1660f7f](https://github.com/stashed/mongodb/commit/d1660f7f) [cherry-pick] Use restic 0.13.1 (#1499) (#1510)
+
+
+### [5.0.3-v4](https://github.com/stashed/mongodb/releases/tag/5.0.3-v4)
+
+- [4cf40adb](https://github.com/stashed/mongodb/commit/4cf40adb) [cherry-pick] Update nats client to v1.15.0 (#1526) (#1539)
+- [1c739adb](https://github.com/stashed/mongodb/commit/1c739adb) Add support for cross-namespace target (#1512) (#1525)
+- [8a6f7fb1](https://github.com/stashed/mongodb/commit/8a6f7fb1) [cherry-pick] Use restic 0.13.1 (#1499) (#1511)
+- [5bc21111](https://github.com/stashed/mongodb/commit/5bc21111) Prepare for release 5.0.3-v3 (#1497)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v17](https://github.com/stashed/mysql/releases/tag/5.7.25-v17)
+
+- [6818869f](https://github.com/stashed/mysql/commit/6818869f) Prepare for release 5.7.25-v17 (#617)
+- [73139959](https://github.com/stashed/mysql/commit/73139959) [cherry-pick] Update nats client to v1.15.0 (#612) (#613)
+- [f0a6b8e0](https://github.com/stashed/mysql/commit/f0a6b8e0) Add support for cross-namespace target. (#607) (#608)
+- [060f151a](https://github.com/stashed/mysql/commit/060f151a) [cherry-pick] Use restic 0.13.1 (#604) (#605)
+
+
+### [8.0.3-v17](https://github.com/stashed/mysql/releases/tag/8.0.3-v17)
+
+- [9e7d3a11](https://github.com/stashed/mysql/commit/9e7d3a11) Prepare for release 8.0.3-v17 (#620)
+- [42ba01a5](https://github.com/stashed/mysql/commit/42ba01a5) [cherry-pick] Update nats client to v1.15.0 (#612) (#616)
+- [d8a0eb4e](https://github.com/stashed/mysql/commit/d8a0eb4e) [cherry-pick] Add support for cross-namespace target. (#607) (#611)
+
+
+### [8.0.14-v17](https://github.com/stashed/mysql/releases/tag/8.0.14-v17)
+
+- [408bad82](https://github.com/stashed/mysql/commit/408bad82) Prepare for release 8.0.14-v17 (#618)
+- [27fc0d17](https://github.com/stashed/mysql/commit/27fc0d17) [cherry-pick] Update nats client to v1.15.0 (#612) (#614)
+- [3106710c](https://github.com/stashed/mysql/commit/3106710c) Add support for cross-namespace target. (#607) (#609)
+- [ea8c60ec](https://github.com/stashed/mysql/commit/ea8c60ec) [cherry-pick] Use restic 0.13.1 (#604) (#606)
+
+
+### [8.0.21-v11](https://github.com/stashed/mysql/releases/tag/8.0.21-v11)
+
+- [39f458ec](https://github.com/stashed/mysql/commit/39f458ec) Prepare for release 8.0.21-v11 (#619)
+- [92ce6a21](https://github.com/stashed/mysql/commit/92ce6a21) [cherry-pick] Update nats client to v1.15.0 (#612) (#615)
+- [6ad9564f](https://github.com/stashed/mysql/commit/6ad9564f) [cherry-pick] Add support for cross-namespace target. (#607) (#610)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v4](https://github.com/stashed/nats/releases/tag/2.6.1-v4)
+
+- [6539d98](https://github.com/stashed/nats/commit/6539d98) Prepare for release 2.6.1-v4 (#46)
+- [596b907](https://github.com/stashed/nats/commit/596b907) [cherry-pick] Update nats client to v1.15.0 (#44) (#45)
+- [2ab3cb0](https://github.com/stashed/nats/commit/2ab3cb0) Add support for cross-namespace target (#42) (#43)
+- [e8cc6a4](https://github.com/stashed/nats/commit/e8cc6a4) [cherry-pick] Use restic 0.13.1 (#40) (#41)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v12](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v12)
+
+- [fca0f716](https://github.com/stashed/percona-xtradb/commit/fca0f716) Prepare for release 5.7-v12 (#256)
+- [3c6c291e](https://github.com/stashed/percona-xtradb/commit/3c6c291e) [cherry-pick] Update nats client to v1.15.0 (#254) (#255)
+- [71212215](https://github.com/stashed/percona-xtradb/commit/71212215) Add support for cross-namespace target (#252) (#253)
+- [e7a31aea](https://github.com/stashed/percona-xtradb/commit/e7a31aea) [cherry-pick] Use restic 0.13.1 (#250) (#251)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v15](https://github.com/stashed/postgres/releases/tag/9.6.19-v15)
+
+- [827b4e06](https://github.com/stashed/postgres/commit/827b4e06) Prepare for release 9.6.19-v15 (#1051)
+- [b89c3611](https://github.com/stashed/postgres/commit/b89c3611) [cherry-pick] Update nats client to v1.15.0 (#1039) (#1045)
+- [59f69a03](https://github.com/stashed/postgres/commit/59f69a03) Add support for cross-namespace target (#1032) (#1038)
+- [8b064613](https://github.com/stashed/postgres/commit/8b064613) [cherry-pick] Use restic 0.13.1 (#1027) (#1031)
+
+
+### [10.14-v15](https://github.com/stashed/postgres/releases/tag/10.14-v15)
+
+- [97bbc626](https://github.com/stashed/postgres/commit/97bbc626) Prepare for release 10.14-v15 (#1046)
+- [b8a36039](https://github.com/stashed/postgres/commit/b8a36039) [cherry-pick] Update nats client to v1.15.0 (#1039) (#1040)
+- [730ce380](https://github.com/stashed/postgres/commit/730ce380) Add support for cross-namespace target (#1032) (#1033)
+- [df8339af](https://github.com/stashed/postgres/commit/df8339af) [cherry-pick] Use restic 0.13.1 (#1027) (#1028)
+
+
+### [11.9-v15](https://github.com/stashed/postgres/releases/tag/11.9-v15)
+
+- [61dbe6ef](https://github.com/stashed/postgres/commit/61dbe6ef) Prepare for release 11.9-v15 (#1047)
+- [20bb0dce](https://github.com/stashed/postgres/commit/20bb0dce) [cherry-pick] Update nats client to v1.15.0 (#1039) (#1041)
+- [b450f154](https://github.com/stashed/postgres/commit/b450f154) Add support for cross-namespace target (#1032) (#1034)
+- [eef99803](https://github.com/stashed/postgres/commit/eef99803) [cherry-pick] Use restic 0.13.1 (#1027) (#1029)
+
+
+### [12.4-v15](https://github.com/stashed/postgres/releases/tag/12.4-v15)
+
+- [4055f1b2](https://github.com/stashed/postgres/commit/4055f1b2) Prepare for release 12.4-v15 (#1048)
+- [cccf210e](https://github.com/stashed/postgres/commit/cccf210e) [cherry-pick] Update nats client to v1.15.0 (#1039) (#1042)
+- [6b106d50](https://github.com/stashed/postgres/commit/6b106d50) Add support for cross-namespace target (#1032) (#1035)
+- [26099d08](https://github.com/stashed/postgres/commit/26099d08) [cherry-pick] Use restic 0.13.1 (#1027) (#1030)
+
+
+### [13.1-v12](https://github.com/stashed/postgres/releases/tag/13.1-v12)
+
+- [6a452173](https://github.com/stashed/postgres/commit/6a452173) Prepare for release 13.1-v12 (#1049)
+- [140a00e8](https://github.com/stashed/postgres/commit/140a00e8) [cherry-pick] Update nats client to v1.15.0 (#1039) (#1043)
+- [1a7f5854](https://github.com/stashed/postgres/commit/1a7f5854) [cherry-pick] Add support for cross-namespace target (#1032) (#1036)
+
+
+### [14.0-v4](https://github.com/stashed/postgres/releases/tag/14.0-v4)
+
+- [9b91f298](https://github.com/stashed/postgres/commit/9b91f298) Prepare for release 14.0-v4 (#1050)
+- [2afdd9e7](https://github.com/stashed/postgres/commit/2afdd9e7) [cherry-pick] Update nats client to v1.15.0 (#1039) (#1044)
+- [196fd0fd](https://github.com/stashed/postgres/commit/196fd0fd) [cherry-pick] Add support for cross-namespace target (#1032) (#1037)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v5](https://github.com/stashed/redis/releases/tag/5.0.13-v5)
+
+- [b3f3395](https://github.com/stashed/redis/commit/b3f3395) Prepare for release 5.0.13-v5 (#103)
+- [6d37e9c](https://github.com/stashed/redis/commit/6d37e9c) [cherry-pick] Update nats client to v1.15.0 (#100) (#101)
+- [429b312](https://github.com/stashed/redis/commit/429b312) Add support for cross-namespace target (#99)
+- [b2af9aa](https://github.com/stashed/redis/commit/b2af9aa) [cherry-pick] Use restic 0.13.1 (#96) (#97)
+
+
+### [6.2.5-v5](https://github.com/stashed/redis/releases/tag/6.2.5-v5)
+
+- [73c4af8](https://github.com/stashed/redis/commit/73c4af8) Prepare for release 6.2.5-v5 (#104)
+- [165f4a3](https://github.com/stashed/redis/commit/165f4a3) [cherry-pick] Update nats client to v1.15.0 (#100) (#102)
+- [757f2a7](https://github.com/stashed/redis/commit/757f2a7) Add support for cross-namespace target (#99)
+- [b4bfe91](https://github.com/stashed/redis/commit/b4bfe91) [cherry-pick] Use restic 0.13.1 (#96) (#98)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.20.0](https://github.com/stashed/stash/releases/tag/v0.20.0)
+
+- [6a3680ec](https://github.com/stashed/stash/commit/6a3680ec) Prepare for release v0.20.0 (#1443)
+- [a56bfc73](https://github.com/stashed/stash/commit/a56bfc73) Update nats client to v1.15.0 (#1442)
+- [2d0b4e97](https://github.com/stashed/stash/commit/2d0b4e97) Port Cross-namespace target support related change from enterprise repo (#1441)
+- [4927bcef](https://github.com/stashed/stash/commit/4927bcef) Pass `TopologySpreadConstraints` in `ApplyPodRuntimeSettings()` (#1440)
+- [ca8ef3be](https://github.com/stashed/stash/commit/ca8ef3be) Update requirements for `VolumeSnapshotter`
+- [93b93361](https://github.com/stashed/stash/commit/93b93361) Update requirements for VolumeSnapshotter
+- [82de61a2](https://github.com/stashed/stash/commit/82de61a2) Update RoleBinding name (#1437)
+- [2e328b9e](https://github.com/stashed/stash/commit/2e328b9e) Use restic 0.13.1 (#1438)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.05.12
Release-tracker: https://github.com/stashed/CHANGELOG/pull/47
Signed-off-by: 1gtm <1gtm@appscode.com>