### PR TITLE
Prepare for release v2022.05.18

### DIFF
--- a/docs/CHANGELOG-v2022.05.18.md
+++ b/docs/CHANGELOG-v2022.05.18.md
@@ -1,0 +1,72 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2022.05.18
+    name: Changelog-v2022.05.18
+    parent: welcome
+    weight: 20220518
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.05.18/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.05.18/
+---
+
+# Stash v2022.05.18 (2022-05-18)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.20.1](https://github.com/stashed/apimachinery/releases/tag/v0.20.1)
+
+- [9d802e3a](https://github.com/stashed/apimachinery/commit/9d802e3a) Make commit
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.20.1](https://github.com/stashed/enterprise/releases/tag/v0.20.1)
+
+- [948438a9](https://github.com/stashed/enterprise/commit/948438a9) Prepare for release v0.20.1 (#174)
+- [e2fde1aa](https://github.com/stashed/enterprise/commit/e2fde1aa) Fix ImagePullSecrets not passing to the backup job properly (#172)
+- [6f871d57](https://github.com/stashed/enterprise/commit/6f871d57) Update BackupConfiguration webhook to make the target immutable (#171)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2022.05.18](https://github.com/stashed/installer/releases/tag/v2022.05.18)
+
+- [3b45a21b](https://github.com/stashed/installer/commit/3b45a21b) Prepare for release v2022.05.18 (#255)
+- [fc961396](https://github.com/stashed/installer/commit/fc961396) Add support for Elasticsearch 8.2.0 (#254)
+- [41561f81](https://github.com/stashed/installer/commit/41561f81) Update registry templates to support custom default registry (ghcr.io)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v5](https://github.com/stashed/nats/releases/tag/2.6.1-v5)
+
+- [3fe0e88](https://github.com/stashed/nats/commit/3fe0e88) Prepare for release 2.6.1-v4 (#49)
+
+
+### [2.8.2](https://github.com/stashed/nats/releases/tag/2.8.2)
+
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.20.1](https://github.com/stashed/stash/releases/tag/v0.20.1)
+
+- [9771f5db](https://github.com/stashed/stash/commit/9771f5db) Prepare for release v0.20.1 (#1446)
+- [58168343](https://github.com/stashed/stash/commit/58168343) Merge pull request #1445 from stashed/fix-imagepull-secrets
+- [d6290dd7](https://github.com/stashed/stash/commit/d6290dd7) Fix ImagePullSecrets not passing to the backup job properly
+- [86342a7e](https://github.com/stashed/stash/commit/86342a7e) Update BackupConfiguration webhook to make the target immutable (#1444)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.05.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/48
Signed-off-by: 1gtm <1gtm@appscode.com>