### PR TITLE
Prepare for release v2022.06.27

### DIFF
--- a/docs/CHANGELOG-v2022.06.27.md
+++ b/docs/CHANGELOG-v2022.06.27.md
@@ -1,0 +1,130 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2022.06.27
+    name: Changelog-v2022.06.27
+    parent: welcome
+    weight: 20220627
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.06.27/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.06.27/
+---
+
+# Stash v2022.06.27 (2022-06-27)
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2022.06.27](https://github.com/stashed/installer/releases/tag/v2022.06.27)
+
+- [e8a6472b](https://github.com/stashed/installer/commit/e8a6472b) Prepare for release v2022.06.27 (#265)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v18](https://github.com/stashed/mongodb/releases/tag/3.4.17-v18)
+
+- [aff82bdd](https://github.com/stashed/mongodb/commit/aff82bdd) [cherry-pick] Fix license checking error. (#1593) (#1594)
+
+
+### [3.4.22-v18](https://github.com/stashed/mongodb/releases/tag/3.4.22-v18)
+
+- [789d9b33](https://github.com/stashed/mongodb/commit/789d9b33) [cherry-pick] Fix license checking error. (#1593) (#1595)
+
+
+### [3.6.8-v18](https://github.com/stashed/mongodb/releases/tag/3.6.8-v18)
+
+- [97a59fcf](https://github.com/stashed/mongodb/commit/97a59fcf) [cherry-pick] Fix license checking error. (#1593) (#1597)
+
+
+### [3.6.13-v18](https://github.com/stashed/mongodb/releases/tag/3.6.13-v18)
+
+- [9a5ffacb](https://github.com/stashed/mongodb/commit/9a5ffacb) [cherry-pick] Fix license checking error. (#1593) (#1596)
+
+
+### [4.0.3-v18](https://github.com/stashed/mongodb/releases/tag/4.0.3-v18)
+
+- [c8873280](https://github.com/stashed/mongodb/commit/c8873280) [cherry-pick] Fix license checking error. (#1593) (#1599)
+
+
+### [4.0.5-v18](https://github.com/stashed/mongodb/releases/tag/4.0.5-v18)
+
+- [49ed6399](https://github.com/stashed/mongodb/commit/49ed6399) [cherry-pick] Fix license checking error. (#1593) (#1600)
+
+
+### [4.0.11-v18](https://github.com/stashed/mongodb/releases/tag/4.0.11-v18)
+
+- [368ef71b](https://github.com/stashed/mongodb/commit/368ef71b) [cherry-pick] Fix license checking error. (#1593) (#1598)
+
+
+### [4.1.4-v18](https://github.com/stashed/mongodb/releases/tag/4.1.4-v18)
+
+- [f8b92ad8](https://github.com/stashed/mongodb/commit/f8b92ad8) [cherry-pick] Fix license checking error. (#1593) (#1602)
+
+
+### [4.1.7-v18](https://github.com/stashed/mongodb/releases/tag/4.1.7-v18)
+
+- [199e37cd](https://github.com/stashed/mongodb/commit/199e37cd) [cherry-pick] Fix license checking error. (#1593) (#1603)
+
+
+### [4.1.13-v18](https://github.com/stashed/mongodb/releases/tag/4.1.13-v18)
+
+- [f3eacd9f](https://github.com/stashed/mongodb/commit/f3eacd9f) [cherry-pick] Fix license checking error. (#1593) (#1601)
+
+
+### [4.2.3-v18](https://github.com/stashed/mongodb/releases/tag/4.2.3-v18)
+
+- [15bc3f6b](https://github.com/stashed/mongodb/commit/15bc3f6b) [cherry-pick] Fix license checking error. (#1593) (#1604)
+
+
+### [4.4.6-v9](https://github.com/stashed/mongodb/releases/tag/4.4.6-v9)
+
+- [710a47ca](https://github.com/stashed/mongodb/commit/710a47ca) [cherry-pick] Fix license checking error. (#1593) (#1605)
+
+
+### [5.0.3-v6](https://github.com/stashed/mongodb/releases/tag/5.0.3-v6)
+
+- [fa9cb3cb](https://github.com/stashed/mongodb/commit/fa9cb3cb) [cherry-pick] Fix license checking error. (#1593) (#1606)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v17](https://github.com/stashed/postgres/releases/tag/9.6.19-v17)
+
+- [9ec2f296](https://github.com/stashed/postgres/commit/9ec2f296) [cherry-pick] Fix license checking error. (#1077) (#1083)
+
+
+### [10.14-v17](https://github.com/stashed/postgres/releases/tag/10.14-v17)
+
+- [dc2b85ce](https://github.com/stashed/postgres/commit/dc2b85ce) [cherry-pick] Fix license checking error. (#1077) (#1078)
+
+
+### [11.9-v17](https://github.com/stashed/postgres/releases/tag/11.9-v17)
+
+- [ab3747db](https://github.com/stashed/postgres/commit/ab3747db) [cherry-pick] Fix license checking error. (#1077) (#1079)
+
+
+### [12.4-v17](https://github.com/stashed/postgres/releases/tag/12.4-v17)
+
+- [9d5645cd](https://github.com/stashed/postgres/commit/9d5645cd) [cherry-pick] Fix license checking error. (#1077) (#1080)
+
+
+### [13.1-v14](https://github.com/stashed/postgres/releases/tag/13.1-v14)
+
+- [9cafed82](https://github.com/stashed/postgres/commit/9cafed82) [cherry-pick] Fix license checking error. (#1077) (#1081)
+
+
+### [14.0-v6](https://github.com/stashed/postgres/releases/tag/14.0-v6)
+
+- [093044d7](https://github.com/stashed/postgres/commit/093044d7) [cherry-pick] Fix license checking error. (#1077) (#1082)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.06.27
Release-tracker: https://github.com/stashed/CHANGELOG/pull/50
Signed-off-by: 1gtm <1gtm@appscode.com>