### PR TITLE
Prepare for release v2022.07.09

### DIFF
--- a/docs/CHANGELOG-v2022.07.09.md
+++ b/docs/CHANGELOG-v2022.07.09.md
@@ -1,0 +1,75 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2022.07.09
+    name: Changelog-v2022.07.09
+    parent: welcome
+    weight: 20220709
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.07.09/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.07.09/
+---
+
+# Stash v2022.07.09 (2022-07-09)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.22.0](https://github.com/stashed/apimachinery/releases/tag/v0.22.0)
+
+- [0d8b4a6b](https://github.com/stashed/apimachinery/commit/0d8b4a6b) Don't mark session phase completed until all step executes (#176)
+- [eda5d7b6](https://github.com/stashed/apimachinery/commit/eda5d7b6) Add `executionPolicy` for controlling Hook execution (#175)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.22.0](https://github.com/stashed/cli/releases/tag/v0.22.0)
+
+- [48205e7b](https://github.com/stashed/cli/commit/48205e7b) Prepare for release v0.22.0 (#165)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.22.0](https://github.com/stashed/enterprise/releases/tag/v0.22.0)
+
+- [22673dec](https://github.com/stashed/enterprise/commit/22673dec) Prepare for release v0.22.0 (#183)
+- [d0c08788](https://github.com/stashed/enterprise/commit/d0c08788) Add support for hook executionPolicy (#181)
+- [d183ca59](https://github.com/stashed/enterprise/commit/d183ca59) Add RBAC permissions for finalizers (#182)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2022.07.09](https://github.com/stashed/installer/releases/tag/v2022.07.09)
+
+- [6516d4a2](https://github.com/stashed/installer/commit/6516d4a2) Prepare for release v2022.07.09 (#268)
+- [72439121](https://github.com/stashed/installer/commit/72439121) Add RBAC permissions for finalizers (#267)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.22.0](https://github.com/stashed/stash/releases/tag/v0.22.0)
+
+- [b7f17c08](https://github.com/stashed/stash/commit/b7f17c08) Prepare for release v0.22.0 (#1459)
+- [98d35685](https://github.com/stashed/stash/commit/98d35685) Add support for hook executionPolicy (#1457)
+- [85d6c506](https://github.com/stashed/stash/commit/85d6c506) Add RBAC permissions for finalizers (#1458)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.4.0](https://github.com/stashed/ui-server/releases/tag/v0.4.0)
+
+- [fe19a0f](https://github.com/stashed/ui-server/commit/fe19a0f) Prepare for release v0.4.0 (#15)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.07.09
Release-tracker: https://github.com/stashed/CHANGELOG/pull/53
Signed-off-by: 1gtm <1gtm@appscode.com>