### PR TITLE
Prepare for release v2022.12.11

### DIFF
--- a/docs/CHANGELOG-v2022.12.11.md
+++ b/docs/CHANGELOG-v2022.12.11.md
@@ -1,0 +1,370 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2022.12.11
+    name: Changelog-v2022.12.11
+    parent: welcome
+    weight: 20221211
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.12.11/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.12.11/
+---
+
+# Stash v2022.12.11 (2022-12-11)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.24.0](https://github.com/stashed/apimachinery/releases/tag/v0.24.0)
+
+- [8be49b48](https://github.com/stashed/apimachinery/commit/8be49b48) Update vulnerable deps (#195)
+- [a7a5533d](https://github.com/stashed/apimachinery/commit/a7a5533d) Run GH actions on ubuntu-20.04 (#194)
+- [dfd6e64f](https://github.com/stashed/apimachinery/commit/dfd6e64f) Add `--no-lock` flag for read operations (#192)
+- [d6d88798](https://github.com/stashed/apimachinery/commit/d6d88798) Indicate repository required backend fields (#191)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.24.0](https://github.com/stashed/cli/releases/tag/v0.24.0)
+
+- [827ee17a](https://github.com/stashed/cli/commit/827ee17a) Prepare for release v0.24.0 (#173)
+- [b481ee3b](https://github.com/stashed/cli/commit/b481ee3b) Update vulnerable deps
+- [7b3e18a0](https://github.com/stashed/cli/commit/7b3e18a0) Run GH actions on ubuntu-20.04 (#172)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v20](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v20)
+
+- [65a2d53e](https://github.com/stashed/elasticsearch/commit/65a2d53e) Prepare for release 5.6.4-v20 (#1289)
+- [291684ce](https://github.com/stashed/elasticsearch/commit/291684ce) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1279)
+
+
+### [6.2.4-v20](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v20)
+
+- [1b9be669](https://github.com/stashed/elasticsearch/commit/1b9be669) Prepare for release 6.2.4-v20 (#1290)
+- [5aa4a261](https://github.com/stashed/elasticsearch/commit/5aa4a261) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1280)
+
+
+### [6.3.0-v20](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v20)
+
+- [f0c50dc5](https://github.com/stashed/elasticsearch/commit/f0c50dc5) Prepare for release 6.3.0-v20 (#1291)
+- [13521327](https://github.com/stashed/elasticsearch/commit/13521327) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1281)
+
+
+### [6.4.0-v20](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v20)
+
+- [f7f7f8ba](https://github.com/stashed/elasticsearch/commit/f7f7f8ba) Prepare for release 6.4.0-v20 (#1292)
+- [0058df29](https://github.com/stashed/elasticsearch/commit/0058df29) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1282)
+
+
+### [6.5.3-v20](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v20)
+
+- [95916905](https://github.com/stashed/elasticsearch/commit/95916905) Prepare for release 6.5.3-v20 (#1293)
+- [6d372fd5](https://github.com/stashed/elasticsearch/commit/6d372fd5) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1283)
+
+
+### [6.8.0-v20](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v20)
+
+- [265999ff](https://github.com/stashed/elasticsearch/commit/265999ff) Prepare for release 6.8.0-v20 (#1294)
+- [fbd522f9](https://github.com/stashed/elasticsearch/commit/fbd522f9) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1284)
+
+
+### [7.2.0-v20](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v20)
+
+- [e5fac39f](https://github.com/stashed/elasticsearch/commit/e5fac39f) Prepare for release 7.2.0-v20 (#1296)
+- [562e07c2](https://github.com/stashed/elasticsearch/commit/562e07c2) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1286)
+
+
+### [7.3.2-v20](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v20)
+
+- [a142cc89](https://github.com/stashed/elasticsearch/commit/a142cc89) Prepare for release 7.3.2-v20 (#1297)
+- [82d44ebd](https://github.com/stashed/elasticsearch/commit/82d44ebd) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1287)
+
+
+### [7.14.0-v6](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v6)
+
+- [73bd77a1](https://github.com/stashed/elasticsearch/commit/73bd77a1) Prepare for release 7.14.0-v6 (#1295)
+- [bd3f7b0a](https://github.com/stashed/elasticsearch/commit/bd3f7b0a) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1285)
+
+
+### [8.2.0-v3](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v3)
+
+- [fbe1a6b4](https://github.com/stashed/elasticsearch/commit/fbe1a6b4) Prepare for release 8.2.0-v3 (#1298)
+- [9148d4ee](https://github.com/stashed/elasticsearch/commit/9148d4ee) [cherry-pick] Run GH actions on ubuntu-20.04 (#1278) (#1288)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.24.0](https://github.com/stashed/enterprise/releases/tag/v0.24.0)
+
+- [362a77ca](https://github.com/stashed/enterprise/commit/362a77ca) Prepare for release v0.24.0 (#213)
+- [c477c2f4](https://github.com/stashed/enterprise/commit/c477c2f4) Update vulnerable deps (#212)
+- [6ccc066f](https://github.com/stashed/enterprise/commit/6ccc066f) Run GH actions on ubuntu-20.04 (#211)
+- [890948b2](https://github.com/stashed/enterprise/commit/890948b2) Update RBAC for VaultServer Backup & Restore (#208)
+- [7ffc5ecd](https://github.com/stashed/enterprise/commit/7ffc5ecd) Acquire license from proxyserver (#209)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v7](https://github.com/stashed/etcd/releases/tag/3.5.0-v7)
+
+- [056c220](https://github.com/stashed/etcd/commit/056c220) Prepare for release 3.5.0-v7 (#63)
+- [bec459d](https://github.com/stashed/etcd/commit/bec459d) [cherry-pick] Run GH actions on ubuntu-20.04 (#61) (#62)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2022.12.11](https://github.com/stashed/installer/releases/tag/v2022.12.11)
+
+- [5162994b](https://github.com/stashed/installer/commit/5162994b) Prepare for release v2022.12.11 (#288)
+- [8d43a822](https://github.com/stashed/installer/commit/8d43a822) Run GH actions on ubuntu-20.04 (#287)
+- [b68bcaa2](https://github.com/stashed/installer/commit/b68bcaa2) Update ClusterRole for Vault Backup & Restore (#285)
+- [8a6bbf45](https://github.com/stashed/installer/commit/8a6bbf45) Add Plugin for Postgres 15 (#286)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v3](https://github.com/stashed/kubedump/releases/tag/0.1.0-v3)
+
+- [f8ce289](https://github.com/stashed/kubedump/commit/f8ce289) Prepare for release 0.1.0-v3 (#23)
+- [5da34c4](https://github.com/stashed/kubedump/commit/5da34c4) Run GH actions on ubuntu-20.04 (#22)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v13](https://github.com/stashed/mariadb/releases/tag/10.5.8-v13)
+
+- [8147cc1](https://github.com/stashed/mariadb/commit/8147cc1) Prepare for release 10.5.8-v13 (#206)
+- [4fca73b](https://github.com/stashed/mariadb/commit/4fca73b) Run GH actions on ubuntu-20.04 (#204) (#205)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v20](https://github.com/stashed/mongodb/releases/tag/3.4.17-v20)
+
+- [286d6ec2](https://github.com/stashed/mongodb/commit/286d6ec2) Prepare for release 3.4.17-v20 (#1690)
+- [eb1e21ca](https://github.com/stashed/mongodb/commit/eb1e21ca) Run GH actions on ubuntu-20.04 (#1677) (#1689)
+
+
+### [3.4.22-v20](https://github.com/stashed/mongodb/releases/tag/3.4.22-v20)
+
+- [2b6a2925](https://github.com/stashed/mongodb/commit/2b6a2925) Prepare for release 3.4.22-v20 (#1691)
+- [11386500](https://github.com/stashed/mongodb/commit/11386500) Run GH actions on ubuntu-20.04 (#1677) (#1688)
+
+
+### [3.6.8-v20](https://github.com/stashed/mongodb/releases/tag/3.6.8-v20)
+
+- [38d327b3](https://github.com/stashed/mongodb/commit/38d327b3) Prepare for release 3.6.8-v20 (#1693)
+- [d814c266](https://github.com/stashed/mongodb/commit/d814c266) Run GH actions on ubuntu-20.04 (#1677) (#1686)
+
+
+### [3.6.13-v20](https://github.com/stashed/mongodb/releases/tag/3.6.13-v20)
+
+- [c0212417](https://github.com/stashed/mongodb/commit/c0212417) Prepare for release 3.6.13-v20 (#1692)
+- [ac655744](https://github.com/stashed/mongodb/commit/ac655744) Run GH actions on ubuntu-20.04 (#1677) (#1687)
+
+
+### [4.0.3-v20](https://github.com/stashed/mongodb/releases/tag/4.0.3-v20)
+
+- [c197e5a3](https://github.com/stashed/mongodb/commit/c197e5a3) Prepare for release 4.0.3-v20 (#1695)
+- [a1b5a29e](https://github.com/stashed/mongodb/commit/a1b5a29e) Run GH actions on ubuntu-20.04 (#1677) (#1684)
+
+
+### [4.0.5-v20](https://github.com/stashed/mongodb/releases/tag/4.0.5-v20)
+
+- [2e3e02c0](https://github.com/stashed/mongodb/commit/2e3e02c0) Prepare for release 4.0.5-v20 (#1696)
+- [74ba8bb0](https://github.com/stashed/mongodb/commit/74ba8bb0) Run GH actions on ubuntu-20.04 (#1677) (#1683)
+
+
+### [4.0.11-v20](https://github.com/stashed/mongodb/releases/tag/4.0.11-v20)
+
+- [2a196426](https://github.com/stashed/mongodb/commit/2a196426) Prepare for release 4.0.11-v20 (#1694)
+- [df8566b4](https://github.com/stashed/mongodb/commit/df8566b4) Run GH actions on ubuntu-20.04 (#1677) (#1685)
+
+
+### [4.1.4-v20](https://github.com/stashed/mongodb/releases/tag/4.1.4-v20)
+
+- [482cbb9f](https://github.com/stashed/mongodb/commit/482cbb9f) Prepare for release 4.1.4-v20 (#1698)
+- [19d35fa3](https://github.com/stashed/mongodb/commit/19d35fa3) Run GH actions on ubuntu-20.04 (#1677) (#1682)
+
+
+### [4.1.7-v20](https://github.com/stashed/mongodb/releases/tag/4.1.7-v20)
+
+- [daeea0d2](https://github.com/stashed/mongodb/commit/daeea0d2) Prepare for release 4.1.7-v20 (#1699)
+- [935f0b54](https://github.com/stashed/mongodb/commit/935f0b54) Run GH actions on ubuntu-20.04 (#1677) (#1678)
+
+
+### [4.1.13-v20](https://github.com/stashed/mongodb/releases/tag/4.1.13-v20)
+
+- [3dc0dba9](https://github.com/stashed/mongodb/commit/3dc0dba9) Prepare for release 4.1.13-v20 (#1697)
+- [15979e9f](https://github.com/stashed/mongodb/commit/15979e9f) Run GH actions on ubuntu-20.04
+
+
+### [4.2.3-v20](https://github.com/stashed/mongodb/releases/tag/4.2.3-v20)
+
+- [88d01c6e](https://github.com/stashed/mongodb/commit/88d01c6e) Prepare for release 4.2.3-v20 (#1701)
+- [5132c6c2](https://github.com/stashed/mongodb/commit/5132c6c2) Run GH actions on ubuntu-20.04 (#1677) (#1681)
+
+
+### [4.4.6-v11](https://github.com/stashed/mongodb/releases/tag/4.4.6-v11)
+
+- [d7ef7330](https://github.com/stashed/mongodb/commit/d7ef7330) Run GH actions on ubuntu-20.04 (#1677) (#1680)
+
+
+### [5.0.3-v8](https://github.com/stashed/mongodb/releases/tag/5.0.3-v8)
+
+- [230ddc83](https://github.com/stashed/mongodb/commit/230ddc83) Run GH actions on ubuntu-20.04 (#1677) (#1679)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v20](https://github.com/stashed/mysql/releases/tag/5.7.25-v20)
+
+- [6e909b5c](https://github.com/stashed/mysql/commit/6e909b5c) Prepare for release 5.7.25-v20 (#666)
+- [c0444876](https://github.com/stashed/mysql/commit/c0444876) [cherry-pick] Run GH actions on ubuntu-20.04 (#661) (#662)
+
+
+### [8.0.3-v20](https://github.com/stashed/mysql/releases/tag/8.0.3-v20)
+
+- [2df6a148](https://github.com/stashed/mysql/commit/2df6a148) Prepare for release 8.0.3-v20 (#669)
+- [5def6186](https://github.com/stashed/mysql/commit/5def6186) [cherry-pick] Run GH actions on ubuntu-20.04 (#661) (#665)
+
+
+### [8.0.14-v20](https://github.com/stashed/mysql/releases/tag/8.0.14-v20)
+
+- [7c73243d](https://github.com/stashed/mysql/commit/7c73243d) Prepare for release 8.0.14-v20 (#667)
+- [6b745e21](https://github.com/stashed/mysql/commit/6b745e21) [cherry-pick] Run GH actions on ubuntu-20.04 (#661) (#663)
+
+
+### [8.0.21-v14](https://github.com/stashed/mysql/releases/tag/8.0.21-v14)
+
+- [e145e190](https://github.com/stashed/mysql/commit/e145e190) Prepare for release 8.0.21-v14 (#668)
+- [50af3373](https://github.com/stashed/mysql/commit/50af3373) [cherry-pick] Run GH actions on ubuntu-20.04 (#661) (#664)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v8](https://github.com/stashed/nats/releases/tag/2.6.1-v8)
+
+- [148b347](https://github.com/stashed/nats/commit/148b347) Prepare for release 2.6.1-v8 (#78)
+- [f13cacd](https://github.com/stashed/nats/commit/f13cacd) [cherry-pick] Run GH actions on ubuntu-20.04 (#75) (#76)
+
+
+### [2.8.2-v3](https://github.com/stashed/nats/releases/tag/2.8.2-v3)
+
+- [8565844](https://github.com/stashed/nats/commit/8565844) Prepare for release 2.8.2-v3 (#79)
+- [860bda2](https://github.com/stashed/nats/commit/860bda2) [cherry-pick] Run GH actions on ubuntu-20.04 (#75) (#77)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v15](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v15)
+
+- [b7a3bb56](https://github.com/stashed/percona-xtradb/commit/b7a3bb56) Prepare for release 5.7-v15 (#276)
+- [751522d9](https://github.com/stashed/percona-xtradb/commit/751522d9) [cherry-pick] Run GH actions on ubuntu-20.04 (#274) (#275)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v19](https://github.com/stashed/postgres/releases/tag/9.6.19-v19)
+
+- [faee608a](https://github.com/stashed/postgres/commit/faee608a) Prepare for release 9.6.19-v19 (#1134)
+- [5d466cf8](https://github.com/stashed/postgres/commit/5d466cf8) [cherry-pick] Run GH actions on ubuntu-20.04 (#1120) (#1127)
+
+
+### [10.14-v19](https://github.com/stashed/postgres/releases/tag/10.14-v19)
+
+- [1d0cdfb7](https://github.com/stashed/postgres/commit/1d0cdfb7) Prepare for release 10.14-v19 (#1128)
+- [23308405](https://github.com/stashed/postgres/commit/23308405) [cherry-pick] Run GH actions on ubuntu-20.04 (#1120) (#1121)
+
+
+### [11.9-v19](https://github.com/stashed/postgres/releases/tag/11.9-v19)
+
+- [458a24a6](https://github.com/stashed/postgres/commit/458a24a6) Prepare for release 11.9-v19 (#1129)
+- [f13f0d8b](https://github.com/stashed/postgres/commit/f13f0d8b) [cherry-pick] Run GH actions on ubuntu-20.04 (#1120) (#1122)
+
+
+### [12.4-v19](https://github.com/stashed/postgres/releases/tag/12.4-v19)
+
+- [5ac61672](https://github.com/stashed/postgres/commit/5ac61672) Prepare for release 12.4-v19 (#1130)
+- [0b32f4e3](https://github.com/stashed/postgres/commit/0b32f4e3) [cherry-pick] Run GH actions on ubuntu-20.04 (#1120) (#1123)
+
+
+### [13.1-v16](https://github.com/stashed/postgres/releases/tag/13.1-v16)
+
+- [33c9a9a4](https://github.com/stashed/postgres/commit/33c9a9a4) Prepare for release 13.1-v16 (#1131)
+- [fdd75a0d](https://github.com/stashed/postgres/commit/fdd75a0d) [cherry-pick] Run GH actions on ubuntu-20.04 (#1120) (#1124)
+
+
+### [14.0-v8](https://github.com/stashed/postgres/releases/tag/14.0-v8)
+
+- [a94f2d59](https://github.com/stashed/postgres/commit/a94f2d59) Prepare for release 14.0-v8 (#1132)
+- [dfd4aea9](https://github.com/stashed/postgres/commit/dfd4aea9) [cherry-pick] Run GH actions on ubuntu-20.04 (#1120) (#1125)
+
+
+### [15.1](https://github.com/stashed/postgres/releases/tag/15.1)
+
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v8](https://github.com/stashed/redis/releases/tag/5.0.13-v8)
+
+- [2f3ecde](https://github.com/stashed/redis/commit/2f3ecde) Prepare for release 5.0.13-v8 (#136)
+- [76a64b2](https://github.com/stashed/redis/commit/76a64b2) Run GH actions on ubuntu-20.04 (#132) (#135)
+
+
+### [6.2.5-v8](https://github.com/stashed/redis/releases/tag/6.2.5-v8)
+
+- [e09e2c7](https://github.com/stashed/redis/commit/e09e2c7) Prepare for release 6.2.5-v8 (#137)
+- [3f84ac4](https://github.com/stashed/redis/commit/3f84ac4) Run GH actions on ubuntu-20.04 (#132) (#134)
+
+
+### [7.0.5-v1](https://github.com/stashed/redis/releases/tag/7.0.5-v1)
+
+- [de8306f](https://github.com/stashed/redis/commit/de8306f) Prepare for release 7.0.5-v1 (#138)
+- [46304f4](https://github.com/stashed/redis/commit/46304f4) Run GH actions on ubuntu-20.04 (#132) (#133)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.24.0](https://github.com/stashed/stash/releases/tag/v0.24.0)
+
+- [000aceb4](https://github.com/stashed/stash/commit/000aceb4f) Prepare for release v0.24.0 (#1496)
+- [c1288849](https://github.com/stashed/stash/commit/c12888498) Update vulnerable deps (#1495)
+- [f64ec230](https://github.com/stashed/stash/commit/f64ec2309) Run GH actions on ubuntu-20.04 (#1494)
+- [82baf7fb](https://github.com/stashed/stash/commit/82baf7fb3) Acquire license from proxyserver (#1491)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.6.0](https://github.com/stashed/ui-server/releases/tag/v0.6.0)
+
+- [5fef8c3](https://github.com/stashed/ui-server/commit/5fef8c3) Prepare for release v0.6.0 (#19)
+- [2fa4b08](https://github.com/stashed/ui-server/commit/2fa4b08) Update vulnerable deps
+- [2c846f5](https://github.com/stashed/ui-server/commit/2c846f5) Run GH actions on ubuntu-20.04 (#18)
+
+
+
+

--- a/docs/addons/elasticsearch/kubedb/index.md
+++ b/docs/addons/elasticsearch/kubedb/index.md
@@ -778,7 +778,7 @@ namespace/restored created
 
 #### Install `stash` kubectl plugin
 
-Now, we are going to use `stash` kubectl plugin to help us copying the `Repository` and backend `Secret` from our `demo` namespace into `restored` namespace. If you haven't already installed the `stash` kubectl-plugin, please install it by following the guide from [here](https://stash.run/docs/{{< param "info.version" >}}/setup/install/kubectl_plugin/).
+Now, we are going to use `stash` kubectl plugin to help us copying the `Repository` and backend `Secret` from our `demo` namespace into `restored` namespace. If you haven't already installed the `stash` kubectl-plugin, please install it by following the guide from [here](https://stash.run/docs/{{< param "info.version" >}}/setup/install/kubectl-plugin/).
 
 Verify that the `stash` kubectl plugin has been installed properly,
 

--- a/docs/guides/troubleshooting/repo-locked/index.md
+++ b/docs/guides/troubleshooting/repo-locked/index.md
@@ -58,7 +58,7 @@ If your repository gets locked, you have to unlock it manually. You can use one 
 
 ### Use Stash kubectl plugin
 
-At first, install the Stash `kubectl` plugin by following the instruction [here](https://stash.run/docs/{{< param "info.version" >}}/setup/install/kubectl_plugin/).
+At first, install the Stash `kubectl` plugin by following the instruction [here](https://stash.run/docs/{{< param "info.version" >}}/setup/install/kubectl-plugin/).
 
 Then, run the following command to unlock the repository:
 

--- a/docs/guides/use-cases/exclude-include-files/index.md
+++ b/docs/guides/use-cases/exclude-include-files/index.md
@@ -20,7 +20,7 @@ This guide will show you how to exclude/include subset of files during backup/re
 
 - At first, you need to have a Kubernetes cluster, and the `kubectl` command-line tool must be configured to communicate with your cluster. If you do not already have a cluster, you can create one by using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 - Install `Stash` in your cluster following the steps [here](/docs/setup/README.md).
-- Install Stash `kubectl` plugin following the steps [here](https://stash.run/docs/latest/setup/install/kubectl_plugin/).
+- Install Stash `kubectl` plugin following the steps [here](https://stash.run/docs/latest/setup/install/kubectl-plugin/).
 - You should be familiar with the following `Stash` concepts:
   - [BackupConfiguration](/docs/concepts/crds/backupconfiguration/index.md)
   - [BackupSession](/docs/concepts/crds/backupsession/index.md)


### PR DESCRIPTION
ProductLine: Stash
Release: v2022.12.11
Release-tracker: https://github.com/stashed/CHANGELOG/pull/59
Signed-off-by: 1gtm <1gtm@appscode.com>