### PR TITLE
Prepare for release v2023.01.05

### DIFF
--- a/docs/CHANGELOG-v2023.01.05.md
+++ b/docs/CHANGELOG-v2023.01.05.md
@@ -1,0 +1,331 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.01.05
+    name: Changelog-v2023.01.05
+    parent: welcome
+    weight: 20230105
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.01.05/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.01.05/
+---
+
+# Stash v2023.01.05 (2023-01-03)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.25.0](https://github.com/stashed/apimachinery/releases/tag/v0.25.0)
+
+- [3f20f5fe](https://github.com/stashed/apimachinery/commit/3f20f5fe) Add stash prefix for temp directory (#196)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.25.0](https://github.com/stashed/cli/releases/tag/v0.25.0)
+
+- [c8dabb77](https://github.com/stashed/cli/commit/c8dabb77) Prepare for release v0.25.0 (#174)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v21](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v21)
+
+- [b121b807](https://github.com/stashed/elasticsearch/commit/b121b807) Prepare for release 5.6.4-v21 (#1300)
+
+
+### [6.2.4-v21](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v21)
+
+- [a94d6ef3](https://github.com/stashed/elasticsearch/commit/a94d6ef3) Prepare for release 6.2.4-v21 (#1301)
+
+
+### [6.3.0-v21](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v21)
+
+- [73bb53f0](https://github.com/stashed/elasticsearch/commit/73bb53f0) Prepare for release 6.3.0-v21 (#1302)
+
+
+### [6.4.0-v21](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v21)
+
+- [583f64fe](https://github.com/stashed/elasticsearch/commit/583f64fe) Prepare for release 6.4.0-v21 (#1303)
+
+
+### [6.5.3-v21](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v21)
+
+- [c49eec09](https://github.com/stashed/elasticsearch/commit/c49eec09) Prepare for release 6.5.3-v21 (#1304)
+
+
+### [6.8.0-v21](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v21)
+
+- [29b29eb6](https://github.com/stashed/elasticsearch/commit/29b29eb6) Prepare for release 6.8.0-v21 (#1305)
+
+
+### [7.2.0-v21](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v21)
+
+- [c50a0904](https://github.com/stashed/elasticsearch/commit/c50a0904) Prepare for release 7.2.0-v21 (#1307)
+
+
+### [7.3.2-v21](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v21)
+
+- [9288c6fb](https://github.com/stashed/elasticsearch/commit/9288c6fb) Prepare for release 7.3.2-v21 (#1308)
+
+
+### [7.14.0-v7](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v7)
+
+- [5130f2a4](https://github.com/stashed/elasticsearch/commit/5130f2a4) Prepare for release 7.14.0-v7 (#1306)
+
+
+### [8.2.0-v4](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v4)
+
+- [4807ee49](https://github.com/stashed/elasticsearch/commit/4807ee49) Prepare for release 8.2.0-v4 (#1309)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.25.0](https://github.com/stashed/enterprise/releases/tag/v0.25.0)
+
+- [762ebb4e](https://github.com/stashed/enterprise/commit/762ebb4eb) Prepare for release v0.25.0 (#216)
+- [8cb82074](https://github.com/stashed/enterprise/commit/8cb82074a) Fix upserting temporary volume (#215)
+- [57d0906c](https://github.com/stashed/enterprise/commit/57d0906c8) Fix NPE using license-proxyserver (#214)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v8](https://github.com/stashed/etcd/releases/tag/3.5.0-v8)
+
+- [523fc8f](https://github.com/stashed/etcd/commit/523fc8f) Prepare for release 3.5.0-v8 (#65)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.01.05](https://github.com/stashed/installer/releases/tag/v2023.01.05)
+
+- [33a11ef1](https://github.com/stashed/installer/commit/33a11ef1) Prepare for release v2023.01.05 (#290)
+- [358d9bf9](https://github.com/stashed/installer/commit/358d9bf9) Add `stash` prefix in temporary directory (#289)
+- [8c09e3f5](https://github.com/stashed/installer/commit/8c09e3f5) Update publish-oci.yml
+- [38568dfc](https://github.com/stashed/installer/commit/38568dfc) Publish helm charts as OCI artifacts
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v4](https://github.com/stashed/kubedump/releases/tag/0.1.0-v4)
+
+- [77c648c](https://github.com/stashed/kubedump/commit/77c648c) Prepare for release 0.1.0-v4 (#25)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v14](https://github.com/stashed/mariadb/releases/tag/10.5.8-v14)
+
+- [c86d3d8](https://github.com/stashed/mariadb/commit/c86d3d8) Prepare for release 10.5.8-v14 (#208)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v21](https://github.com/stashed/mongodb/releases/tag/3.4.17-v21)
+
+- [05ebbe8c](https://github.com/stashed/mongodb/commit/05ebbe8c) Prepare for release 3.4.17-v21 (#1705)
+
+
+### [3.4.22-v21](https://github.com/stashed/mongodb/releases/tag/3.4.22-v21)
+
+- [cd8f3b79](https://github.com/stashed/mongodb/commit/cd8f3b79) Prepare for release 3.4.22-v21 (#1706)
+
+
+### [3.6.8-v21](https://github.com/stashed/mongodb/releases/tag/3.6.8-v21)
+
+- [78218444](https://github.com/stashed/mongodb/commit/78218444) Prepare for release 3.6.8-v21 (#1708)
+
+
+### [3.6.13-v21](https://github.com/stashed/mongodb/releases/tag/3.6.13-v21)
+
+- [8b5e5f26](https://github.com/stashed/mongodb/commit/8b5e5f26) Prepare for release 3.6.13-v21 (#1707)
+
+
+### [4.0.3-v21](https://github.com/stashed/mongodb/releases/tag/4.0.3-v21)
+
+- [ede5e29c](https://github.com/stashed/mongodb/commit/ede5e29c) Prepare for release 4.0.3-v21 (#1710)
+
+
+### [4.0.5-v21](https://github.com/stashed/mongodb/releases/tag/4.0.5-v21)
+
+- [5caeaeda](https://github.com/stashed/mongodb/commit/5caeaeda) Prepare for release 4.0.5-v21 (#1711)
+
+
+### [4.0.11-v21](https://github.com/stashed/mongodb/releases/tag/4.0.11-v21)
+
+- [deba26e1](https://github.com/stashed/mongodb/commit/deba26e1) Prepare for release 4.0.11-v21 (#1709)
+
+
+### [4.1.4-v21](https://github.com/stashed/mongodb/releases/tag/4.1.4-v21)
+
+- [4b2ad2ab](https://github.com/stashed/mongodb/commit/4b2ad2ab) Prepare for release 4.1.4-v21 (#1713)
+
+
+### [4.1.7-v21](https://github.com/stashed/mongodb/releases/tag/4.1.7-v21)
+
+- [a7b8fe3b](https://github.com/stashed/mongodb/commit/a7b8fe3b) Prepare for release 4.1.7-v21 (#1714)
+
+
+### [4.1.13-v21](https://github.com/stashed/mongodb/releases/tag/4.1.13-v21)
+
+- [dc6ef634](https://github.com/stashed/mongodb/commit/dc6ef634) Prepare for release 4.1.13-v21 (#1712)
+
+
+### [4.2.3-v21](https://github.com/stashed/mongodb/releases/tag/4.2.3-v21)
+
+- [358bfa5c](https://github.com/stashed/mongodb/commit/358bfa5c) Prepare for release 4.2.3-v21 (#1715)
+
+
+### [4.4.6-v12](https://github.com/stashed/mongodb/releases/tag/4.4.6-v12)
+
+- [7b684f62](https://github.com/stashed/mongodb/commit/7b684f62) Prepare for release 4.4.6-v12 (#1716)
+- [e7414415](https://github.com/stashed/mongodb/commit/e7414415) Prepare for release 4.4.6-v11 (#1702)
+
+
+### [5.0.3-v9](https://github.com/stashed/mongodb/releases/tag/5.0.3-v9)
+
+- [b63fcd29](https://github.com/stashed/mongodb/commit/b63fcd29) Prepare for release 5.0.3-v9 (#1717)
+- [963cb8ef](https://github.com/stashed/mongodb/commit/963cb8ef) Prepare for release 5.0.3-v8 (#1703)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v21](https://github.com/stashed/mysql/releases/tag/5.7.25-v21)
+
+- [cdd2b0f9](https://github.com/stashed/mysql/commit/cdd2b0f9) Prepare for release 5.7.25-v21 (#671)
+
+
+### [8.0.3-v21](https://github.com/stashed/mysql/releases/tag/8.0.3-v21)
+
+- [74efb1f1](https://github.com/stashed/mysql/commit/74efb1f1) Prepare for release 8.0.3-v21 (#674)
+
+
+### [8.0.14-v21](https://github.com/stashed/mysql/releases/tag/8.0.14-v21)
+
+- [6c643791](https://github.com/stashed/mysql/commit/6c643791) Prepare for release 8.0.14-v21 (#672)
+
+
+### [8.0.21-v15](https://github.com/stashed/mysql/releases/tag/8.0.21-v15)
+
+- [63f6fdc1](https://github.com/stashed/mysql/commit/63f6fdc1) Prepare for release 8.0.21-v15 (#673)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v9](https://github.com/stashed/nats/releases/tag/2.6.1-v9)
+
+- [b07278f](https://github.com/stashed/nats/commit/b07278f) Prepare for release 2.6.1-v9 (#81)
+
+
+### [2.8.2-v4](https://github.com/stashed/nats/releases/tag/2.8.2-v4)
+
+- [d374ae2](https://github.com/stashed/nats/commit/d374ae2) Prepare for release 2.8.2-v4 (#82)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v16](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v16)
+
+- [dceb6fd5](https://github.com/stashed/percona-xtradb/commit/dceb6fd5) Prepare for release 5.7-v16 (#278)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v20](https://github.com/stashed/postgres/releases/tag/9.6.19-v20)
+
+- [c5a91002](https://github.com/stashed/postgres/commit/c5a91002) Prepare for release 9.6.19-v20 (#1142)
+
+
+### [10.14-v20](https://github.com/stashed/postgres/releases/tag/10.14-v20)
+
+- [6a71a45a](https://github.com/stashed/postgres/commit/6a71a45a) Prepare for release 10.14-v20 (#1136)
+
+
+### [11.9-v20](https://github.com/stashed/postgres/releases/tag/11.9-v20)
+
+- [a52a1e1e](https://github.com/stashed/postgres/commit/a52a1e1e) Prepare for release 11.9-v20 (#1137)
+
+
+### [12.4-v20](https://github.com/stashed/postgres/releases/tag/12.4-v20)
+
+- [012c0bc1](https://github.com/stashed/postgres/commit/012c0bc1) Prepare for release 12.4-v20 (#1138)
+
+
+### [13.1-v17](https://github.com/stashed/postgres/releases/tag/13.1-v17)
+
+- [929f348e](https://github.com/stashed/postgres/commit/929f348e) Prepare for release 13.1-v17 (#1139)
+
+
+### [14.0-v9](https://github.com/stashed/postgres/releases/tag/14.0-v9)
+
+- [bbd9e54c](https://github.com/stashed/postgres/commit/bbd9e54c) Prepare for release 14.0-v9 (#1140)
+
+
+### [15.1-v1](https://github.com/stashed/postgres/releases/tag/15.1-v1)
+
+- [c1411460](https://github.com/stashed/postgres/commit/c1411460) Prepare for release 15.1-v1 (#1141)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v9](https://github.com/stashed/redis/releases/tag/5.0.13-v9)
+
+- [307f9a7](https://github.com/stashed/redis/commit/307f9a7) Prepare for release 5.0.13-v9 (#140)
+
+
+### [6.2.5-v9](https://github.com/stashed/redis/releases/tag/6.2.5-v9)
+
+- [fea59b5](https://github.com/stashed/redis/commit/fea59b5) Prepare for release 6.2.5-v9 (#141)
+
+
+### [7.0.5-v2](https://github.com/stashed/redis/releases/tag/7.0.5-v2)
+
+- [92ab44b](https://github.com/stashed/redis/commit/92ab44b) Prepare for release 7.0.5-v2 (#142)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.25.0](https://github.com/stashed/stash/releases/tag/v0.25.0)
+
+- [06faa1fa](https://github.com/stashed/stash/commit/06faa1fae) Prepare for release v0.25.0 (#1499)
+- [b7ed85bf](https://github.com/stashed/stash/commit/b7ed85bfe) Fix Upserting temporary volume (#1498)
+- [371fefee](https://github.com/stashed/stash/commit/371fefeee) Fix NPE using license-proxyserver (#1497)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.7.0](https://github.com/stashed/ui-server/releases/tag/v0.7.0)
+
+- [40819d4](https://github.com/stashed/ui-server/commit/40819d4) Prepare for release v0.7.0 (#20)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v1](https://github.com/stashed/vault/releases/tag/1.10.3-v1)
+
+- [39030875](https://github.com/stashed/vault/commit/39030875) Prepare for release 1.10.3-v1 (#3)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.01.05
Release-tracker: https://github.com/stashed/CHANGELOG/pull/60
Signed-off-by: 1gtm <1gtm@appscode.com>