### PR TITLE
Prepare for release v2023.02.28

### DIFF
--- a/docs/CHANGELOG-v2023.02.28.md
+++ b/docs/CHANGELOG-v2023.02.28.md
@@ -1,0 +1,326 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.02.28
+    name: Changelog-v2023.02.28
+    parent: welcome
+    weight: 20230228
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.02.28/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.02.28/
+---
+
+# Stash v2023.02.28 (2023-03-01)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.26.0](https://github.com/stashed/apimachinery/releases/tag/v0.26.0)
+
+- [38cb356b](https://github.com/stashed/apimachinery/commit/38cb356b) Update deps
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.26.0](https://github.com/stashed/cli/releases/tag/v0.26.0)
+
+- [39be7edf](https://github.com/stashed/cli/commit/39be7edf) Prepare for release v0.26.0 (#175)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v22](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v22)
+
+- [9b77bc33](https://github.com/stashed/elasticsearch/commit/9b77bc33) Prepare for release 5.6.4-v22 (#1310)
+
+
+### [6.2.4-v22](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v22)
+
+- [ac06258d](https://github.com/stashed/elasticsearch/commit/ac06258d) Prepare for release 6.2.4-v22 (#1311)
+
+
+### [6.3.0-v22](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v22)
+
+- [bcd376ec](https://github.com/stashed/elasticsearch/commit/bcd376ec) Prepare for release 6.3.0-v22 (#1312)
+
+
+### [6.4.0-v22](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v22)
+
+- [b2799053](https://github.com/stashed/elasticsearch/commit/b2799053) Prepare for release 6.4.0-v22 (#1313)
+
+
+### [6.5.3-v22](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v22)
+
+- [9a25cb57](https://github.com/stashed/elasticsearch/commit/9a25cb57) Prepare for release 6.5.3-v22 (#1314)
+
+
+### [6.8.0-v22](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v22)
+
+- [b5d9aeca](https://github.com/stashed/elasticsearch/commit/b5d9aeca) Prepare for release 6.8.0-v22 (#1315)
+
+
+### [7.2.0-v22](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v22)
+
+- [01144db2](https://github.com/stashed/elasticsearch/commit/01144db2) Prepare for release 7.2.0-v22 (#1317)
+
+
+### [7.3.2-v22](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v22)
+
+- [011b8b4d](https://github.com/stashed/elasticsearch/commit/011b8b4d) Prepare for release 7.3.2-v22 (#1318)
+
+
+### [7.14.0-v8](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v8)
+
+- [0fe02f51](https://github.com/stashed/elasticsearch/commit/0fe02f51) Prepare for release 7.14.0-v8 (#1316)
+
+
+### [8.2.0-v5](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v5)
+
+- [5e2c1f2b](https://github.com/stashed/elasticsearch/commit/5e2c1f2b) Prepare for release 8.2.0-v5 (#1319)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.26.0](https://github.com/stashed/enterprise/releases/tag/v0.26.0)
+
+- [df406b77](https://github.com/stashed/enterprise/commit/df406b770) Prepare for release v0.26.0 (#219)
+- [86f5d92c](https://github.com/stashed/enterprise/commit/86f5d92cb) Fix BackupBlueprint resolver (#218)
+- [4e539c88](https://github.com/stashed/enterprise/commit/4e539c881) Update Backup Target Conditions for VolumeSnapshotter (#217)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v9](https://github.com/stashed/etcd/releases/tag/3.5.0-v9)
+
+- [1d33849](https://github.com/stashed/etcd/commit/1d33849) Prepare for release 3.5.0-v9 (#67)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.02.28](https://github.com/stashed/installer/releases/tag/v2023.02.28)
+
+- [20e21083](https://github.com/stashed/installer/commit/20e21083) Prepare for release v2023.02.28 (#294)
+- [ebf193a8](https://github.com/stashed/installer/commit/ebf193a8) Run GH actions on ubuntu-20.04 (#291)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v5](https://github.com/stashed/kubedump/releases/tag/0.1.0-v5)
+
+- [472c892](https://github.com/stashed/kubedump/commit/472c892) Prepare for release 0.1.0-v5 (#27)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v15](https://github.com/stashed/mariadb/releases/tag/10.5.8-v15)
+
+- [4591bd5](https://github.com/stashed/mariadb/commit/4591bd5) Prepare for release 10.5.8-v15 (#210)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v22](https://github.com/stashed/mongodb/releases/tag/3.4.17-v22)
+
+- [830dcd31](https://github.com/stashed/mongodb/commit/830dcd31) Prepare for release 3.4.17-v22 (#1718)
+
+
+### [3.4.22-v22](https://github.com/stashed/mongodb/releases/tag/3.4.22-v22)
+
+- [1bd76847](https://github.com/stashed/mongodb/commit/1bd76847) Prepare for release 3.4.22-v22 (#1719)
+
+
+### [3.6.8-v22](https://github.com/stashed/mongodb/releases/tag/3.6.8-v22)
+
+- [e52ccd58](https://github.com/stashed/mongodb/commit/e52ccd58) Prepare for release 3.6.8-v22 (#1721)
+
+
+### [3.6.13-v22](https://github.com/stashed/mongodb/releases/tag/3.6.13-v22)
+
+- [2d8fa2aa](https://github.com/stashed/mongodb/commit/2d8fa2aa) Prepare for release 3.6.13-v22 (#1720)
+
+
+### [4.0.3-v22](https://github.com/stashed/mongodb/releases/tag/4.0.3-v22)
+
+- [ef458a74](https://github.com/stashed/mongodb/commit/ef458a74) Prepare for release 4.0.3-v22 (#1723)
+
+
+### [4.0.5-v22](https://github.com/stashed/mongodb/releases/tag/4.0.5-v22)
+
+- [497da3b7](https://github.com/stashed/mongodb/commit/497da3b7) Prepare for release 4.0.5-v22 (#1724)
+
+
+### [4.0.11-v22](https://github.com/stashed/mongodb/releases/tag/4.0.11-v22)
+
+- [aa9c6f32](https://github.com/stashed/mongodb/commit/aa9c6f32) Prepare for release 4.0.11-v22 (#1722)
+
+
+### [4.1.4-v22](https://github.com/stashed/mongodb/releases/tag/4.1.4-v22)
+
+- [a2fff17c](https://github.com/stashed/mongodb/commit/a2fff17c) Prepare for release 4.1.4-v22 (#1726)
+
+
+### [4.1.7-v22](https://github.com/stashed/mongodb/releases/tag/4.1.7-v22)
+
+- [16dd4a13](https://github.com/stashed/mongodb/commit/16dd4a13) Prepare for release 4.1.7-v22 (#1727)
+
+
+### [4.1.13-v22](https://github.com/stashed/mongodb/releases/tag/4.1.13-v22)
+
+- [118255a9](https://github.com/stashed/mongodb/commit/118255a9) Prepare for release 4.1.13-v22 (#1725)
+
+
+### [4.2.3-v22](https://github.com/stashed/mongodb/releases/tag/4.2.3-v22)
+
+- [1a6305af](https://github.com/stashed/mongodb/commit/1a6305af) Prepare for release 4.2.3-v22 (#1728)
+
+
+### [4.4.6-v13](https://github.com/stashed/mongodb/releases/tag/4.4.6-v13)
+
+- [a6d88593](https://github.com/stashed/mongodb/commit/a6d88593) Prepare for release 4.4.6-v13 (#1729)
+
+
+### [5.0.3-v10](https://github.com/stashed/mongodb/releases/tag/5.0.3-v10)
+
+- [d896df47](https://github.com/stashed/mongodb/commit/d896df47) Prepare for release 5.0.3-v10 (#1731)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v22](https://github.com/stashed/mysql/releases/tag/5.7.25-v22)
+
+- [9da4bdcb](https://github.com/stashed/mysql/commit/9da4bdcb) Prepare for release 5.7.25-v22 (#676)
+
+
+### [8.0.3-v22](https://github.com/stashed/mysql/releases/tag/8.0.3-v22)
+
+- [5becd133](https://github.com/stashed/mysql/commit/5becd133) Prepare for release 8.0.3-v22 (#679)
+
+
+### [8.0.14-v22](https://github.com/stashed/mysql/releases/tag/8.0.14-v22)
+
+- [55634236](https://github.com/stashed/mysql/commit/55634236) Prepare for release 8.0.14-v22 (#677)
+
+
+### [8.0.21-v16](https://github.com/stashed/mysql/releases/tag/8.0.21-v16)
+
+- [853ef87c](https://github.com/stashed/mysql/commit/853ef87c) Prepare for release 8.0.21-v16 (#678)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v10](https://github.com/stashed/nats/releases/tag/2.6.1-v10)
+
+- [e0ba713](https://github.com/stashed/nats/commit/e0ba713) Prepare for release 2.6.1-v10 (#84)
+
+
+### [2.8.2-v5](https://github.com/stashed/nats/releases/tag/2.8.2-v5)
+
+- [668989d](https://github.com/stashed/nats/commit/668989d) Prepare for release 2.8.2-v5 (#85)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v17](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v17)
+
+- [f6d1b63b](https://github.com/stashed/percona-xtradb/commit/f6d1b63b) Prepare for release 5.7-v17 (#280)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v21](https://github.com/stashed/postgres/releases/tag/9.6.19-v21)
+
+- [5a34673c](https://github.com/stashed/postgres/commit/5a34673c) Prepare for release 9.6.19-v21 (#1150)
+
+
+### [10.14-v21](https://github.com/stashed/postgres/releases/tag/10.14-v21)
+
+- [9fd0b5a3](https://github.com/stashed/postgres/commit/9fd0b5a3) Prepare for release 10.14-v21 (#1144)
+
+
+### [11.9-v21](https://github.com/stashed/postgres/releases/tag/11.9-v21)
+
+- [1d8c983e](https://github.com/stashed/postgres/commit/1d8c983e) Prepare for release 11.9-v21 (#1145)
+
+
+### [12.4-v21](https://github.com/stashed/postgres/releases/tag/12.4-v21)
+
+- [3c2d69cd](https://github.com/stashed/postgres/commit/3c2d69cd) Prepare for release 12.4-v21 (#1146)
+
+
+### [13.1-v18](https://github.com/stashed/postgres/releases/tag/13.1-v18)
+
+- [18e00555](https://github.com/stashed/postgres/commit/18e00555) Prepare for release 13.1-v18 (#1147)
+
+
+### [14.0-v10](https://github.com/stashed/postgres/releases/tag/14.0-v10)
+
+- [9c7d6efa](https://github.com/stashed/postgres/commit/9c7d6efa) Prepare for release 14.0-v10 (#1148)
+
+
+### [15.1-v2](https://github.com/stashed/postgres/releases/tag/15.1-v2)
+
+- [9ec57c96](https://github.com/stashed/postgres/commit/9ec57c96) Prepare for release 15.1-v2 (#1149)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v10](https://github.com/stashed/redis/releases/tag/5.0.13-v10)
+
+- [602099c](https://github.com/stashed/redis/commit/602099c) Prepare for release 5.0.13-v10 (#144)
+
+
+### [6.2.5-v10](https://github.com/stashed/redis/releases/tag/6.2.5-v10)
+
+- [8fb361c](https://github.com/stashed/redis/commit/8fb361c) Prepare for release 6.2.5-v10 (#145)
+
+
+### [7.0.5-v3](https://github.com/stashed/redis/releases/tag/7.0.5-v3)
+
+- [2c2e6f1](https://github.com/stashed/redis/commit/2c2e6f1) Prepare for release 7.0.5-v3 (#146)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.26.0](https://github.com/stashed/stash/releases/tag/v0.26.0)
+
+- [0ee682b5](https://github.com/stashed/stash/commit/0ee682b59) Prepare for release v0.26.0 (#1501)
+- [23bc702a](https://github.com/stashed/stash/commit/23bc702ae) Fix status updating of volumesnapshotter command. (#1500)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.8.0](https://github.com/stashed/ui-server/releases/tag/v0.8.0)
+
+- [d3b13ce](https://github.com/stashed/ui-server/commit/d3b13ce) Prepare for release v0.8.0 (#21)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v2](https://github.com/stashed/vault/releases/tag/1.10.3-v2)
+
+- [e47e82e9](https://github.com/stashed/vault/commit/e47e82e9) Prepare for release 1.10.3-v2 (#5)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.02.28
Release-tracker: https://github.com/stashed/CHANGELOG/pull/61
Signed-off-by: 1gtm <1gtm@appscode.com>