### PR TITLE
Prepare for release v2023.03.13

### DIFF
--- a/docs/CHANGELOG-v2023.03.13.md
+++ b/docs/CHANGELOG-v2023.03.13.md
@@ -1,0 +1,376 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.03.13
+    name: Changelog-v2023.03.13
+    parent: welcome
+    weight: 20230313
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.03.13/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.03.13/
+---
+
+# Stash v2023.03.13 (2023-03-13)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.27.0](https://github.com/stashed/apimachinery/releases/tag/v0.27.0)
+
+- [4fef7bc2](https://github.com/stashed/apimachinery/commit/4fef7bc2) Allow ci and update-crds workflows cocurrently
+- [83908c99](https://github.com/stashed/apimachinery/commit/83908c99) Fix unlock error message in prune command
+- [f47c89ef](https://github.com/stashed/apimachinery/commit/f47c89ef) Unlock if prune fails for locked repo (#198)
+- [1f431032](https://github.com/stashed/apimachinery/commit/1f431032) Update workflows (Go 1.20, k8s 1.26) (#197)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.27.0](https://github.com/stashed/cli/releases/tag/v0.27.0)
+
+- [db608b5f](https://github.com/stashed/cli/commit/db608b5f) Prepare for release v0.27.0 (#178)
+- [ee66407a](https://github.com/stashed/cli/commit/ee66407a) Fix unlock command for local repository (#177)
+- [ba3e3b07](https://github.com/stashed/cli/commit/ba3e3b07) Update workflows (Go 1.20, k8s 1.26) (#176)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v23](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v23)
+
+- [25cf7cac](https://github.com/stashed/elasticsearch/commit/25cf7cac) Prepare for release 5.6.4-v23 (#1332)
+- [e2549ec7](https://github.com/stashed/elasticsearch/commit/e2549ec7) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1322)
+
+
+### [6.2.4-v23](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v23)
+
+- [965fdba5](https://github.com/stashed/elasticsearch/commit/965fdba5) Prepare for release 6.2.4-v23 (#1333)
+- [027714c6](https://github.com/stashed/elasticsearch/commit/027714c6) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1323)
+
+
+### [6.3.0-v23](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v23)
+
+- [ef7ffd30](https://github.com/stashed/elasticsearch/commit/ef7ffd30) Prepare for release 6.3.0-v23 (#1334)
+- [e3f63e8e](https://github.com/stashed/elasticsearch/commit/e3f63e8e) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1324)
+
+
+### [6.4.0-v23](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v23)
+
+- [6580b4a3](https://github.com/stashed/elasticsearch/commit/6580b4a3) Prepare for release 6.4.0-v23 (#1335)
+- [2f5d2491](https://github.com/stashed/elasticsearch/commit/2f5d2491) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1325)
+
+
+### [6.5.3-v23](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v23)
+
+- [408e0c76](https://github.com/stashed/elasticsearch/commit/408e0c76) Prepare for release 6.5.3-v23 (#1336)
+- [0d231f63](https://github.com/stashed/elasticsearch/commit/0d231f63) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1326)
+
+
+### [6.8.0-v23](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v23)
+
+- [2de1fd44](https://github.com/stashed/elasticsearch/commit/2de1fd44) Prepare for release 6.8.0-v23 (#1337)
+- [7d004667](https://github.com/stashed/elasticsearch/commit/7d004667) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1327)
+
+
+### [7.2.0-v23](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v23)
+
+- [97143e82](https://github.com/stashed/elasticsearch/commit/97143e82) Prepare for release 7.2.0-v23 (#1339)
+- [3d172262](https://github.com/stashed/elasticsearch/commit/3d172262) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1329)
+
+
+### [7.3.2-v23](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v23)
+
+- [fdadc2fc](https://github.com/stashed/elasticsearch/commit/fdadc2fc) Prepare for release 7.3.2-v23 (#1340)
+- [0a26217c](https://github.com/stashed/elasticsearch/commit/0a26217c) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1330)
+
+
+### [7.14.0-v9](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v9)
+
+- [f707e6a9](https://github.com/stashed/elasticsearch/commit/f707e6a9) Prepare for release 7.14.0-v9 (#1338)
+- [c3017395](https://github.com/stashed/elasticsearch/commit/c3017395) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1328)
+
+
+### [8.2.0-v6](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v6)
+
+- [a06cd438](https://github.com/stashed/elasticsearch/commit/a06cd438) Prepare for release 8.2.0-v6 (#1341)
+- [a31a3fc4](https://github.com/stashed/elasticsearch/commit/a31a3fc4) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1321) (#1331)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.27.0](https://github.com/stashed/enterprise/releases/tag/v0.27.0)
+
+- [089b0070](https://github.com/stashed/enterprise/commit/089b00703) Prepare for release v0.27.0 (#223)
+- [4bfef40b](https://github.com/stashed/enterprise/commit/4bfef40bf) Use valid labels for AutoBackup resources (#221)
+- [053392e9](https://github.com/stashed/enterprise/commit/053392e98) Update workflows (Go 1.20, k8s 1.26) (#220)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v10](https://github.com/stashed/etcd/releases/tag/3.5.0-v10)
+
+- [ba337f8](https://github.com/stashed/etcd/commit/ba337f8) Prepare for release 3.5.0-v10 (#71)
+- [9491906](https://github.com/stashed/etcd/commit/9491906) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#69) (#70)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.03.13](https://github.com/stashed/installer/releases/tag/v2023.03.13)
+
+- [63853c7a](https://github.com/stashed/installer/commit/63853c7a) Prepare for release v2023.03.13 (#296)
+- [ab96161a](https://github.com/stashed/installer/commit/ab96161a) Update workflows (Go 1.20, k8s 1.26) (#295)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v6](https://github.com/stashed/kubedump/releases/tag/0.1.0-v6)
+
+- [71e0a72](https://github.com/stashed/kubedump/commit/71e0a72) Prepare for release 0.1.0-v6 (#31)
+- [f3597b9](https://github.com/stashed/kubedump/commit/f3597b9) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#29) (#30)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v16](https://github.com/stashed/mariadb/releases/tag/10.5.8-v16)
+
+- [cd88cee](https://github.com/stashed/mariadb/commit/cd88cee) Prepare for release 10.5.8-v16 (#214)
+- [e6b9f6a](https://github.com/stashed/mariadb/commit/e6b9f6a) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#212) (#213)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v23](https://github.com/stashed/mongodb/releases/tag/3.4.17-v23)
+
+- [5cd80f95](https://github.com/stashed/mongodb/commit/5cd80f95) Prepare for release 3.4.17-v23 (#1746)
+- [5efeda9a](https://github.com/stashed/mongodb/commit/5efeda9a) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1733)
+
+
+### [3.4.22-v23](https://github.com/stashed/mongodb/releases/tag/3.4.22-v23)
+
+- [e6a93a3b](https://github.com/stashed/mongodb/commit/e6a93a3b) Prepare for release 3.4.22-v23 (#1747)
+- [4b0272c7](https://github.com/stashed/mongodb/commit/4b0272c7) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1734)
+
+
+### [3.6.8-v23](https://github.com/stashed/mongodb/releases/tag/3.6.8-v23)
+
+- [ab9e3843](https://github.com/stashed/mongodb/commit/ab9e3843) Prepare for release 3.6.8-v23 (#1749)
+- [892ece69](https://github.com/stashed/mongodb/commit/892ece69) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1736)
+
+
+### [3.6.13-v23](https://github.com/stashed/mongodb/releases/tag/3.6.13-v23)
+
+- [ba9f6e18](https://github.com/stashed/mongodb/commit/ba9f6e18) Prepare for release 3.6.13-v23 (#1748)
+- [2f597645](https://github.com/stashed/mongodb/commit/2f597645) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1735)
+
+
+### [4.0.3-v23](https://github.com/stashed/mongodb/releases/tag/4.0.3-v23)
+
+- [6cade14c](https://github.com/stashed/mongodb/commit/6cade14c) Prepare for release 4.0.3-v23 (#1751)
+- [07f9216c](https://github.com/stashed/mongodb/commit/07f9216c) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1738)
+
+
+### [4.0.5-v23](https://github.com/stashed/mongodb/releases/tag/4.0.5-v23)
+
+- [aa33c9f0](https://github.com/stashed/mongodb/commit/aa33c9f0) Prepare for release 4.0.5-v23 (#1752)
+- [30373c9c](https://github.com/stashed/mongodb/commit/30373c9c) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1739)
+
+
+### [4.0.11-v23](https://github.com/stashed/mongodb/releases/tag/4.0.11-v23)
+
+- [f4ed5644](https://github.com/stashed/mongodb/commit/f4ed5644) Prepare for release 4.0.11-v23 (#1750)
+- [7df3c35f](https://github.com/stashed/mongodb/commit/7df3c35f) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1737)
+
+
+### [4.1.4-v23](https://github.com/stashed/mongodb/releases/tag/4.1.4-v23)
+
+- [68561b23](https://github.com/stashed/mongodb/commit/68561b23) Prepare for release 4.1.4-v23 (#1754)
+- [2ec01364](https://github.com/stashed/mongodb/commit/2ec01364) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1741)
+
+
+### [4.1.7-v23](https://github.com/stashed/mongodb/releases/tag/4.1.7-v23)
+
+- [a2faed5c](https://github.com/stashed/mongodb/commit/a2faed5c) Prepare for release 4.1.7-v23 (#1755)
+- [2ff4480e](https://github.com/stashed/mongodb/commit/2ff4480e) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1742)
+
+
+### [4.1.13-v23](https://github.com/stashed/mongodb/releases/tag/4.1.13-v23)
+
+- [5c3afe06](https://github.com/stashed/mongodb/commit/5c3afe06) Prepare for release 4.1.13-v23 (#1753)
+- [15b0cb45](https://github.com/stashed/mongodb/commit/15b0cb45) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1740)
+
+
+### [4.2.3-v23](https://github.com/stashed/mongodb/releases/tag/4.2.3-v23)
+
+- [8fc50278](https://github.com/stashed/mongodb/commit/8fc50278) Prepare for release 4.2.3-v23 (#1756)
+- [9751cb56](https://github.com/stashed/mongodb/commit/9751cb56) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1743)
+
+
+### [4.4.6-v14](https://github.com/stashed/mongodb/releases/tag/4.4.6-v14)
+
+- [5277b7fa](https://github.com/stashed/mongodb/commit/5277b7fa) Prepare for release 4.4.6-v14 (#1757)
+- [4942cba5](https://github.com/stashed/mongodb/commit/4942cba5) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1744)
+
+
+### [5.0.3-v11](https://github.com/stashed/mongodb/releases/tag/5.0.3-v11)
+
+- [e7262879](https://github.com/stashed/mongodb/commit/e7262879) Prepare for release 5.0.3-v11 (#1758)
+- [71903562](https://github.com/stashed/mongodb/commit/71903562) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1732) (#1745)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v23](https://github.com/stashed/mysql/releases/tag/5.7.25-v23)
+
+- [4d73c4c7](https://github.com/stashed/mysql/commit/4d73c4c7) Prepare for release 5.7.25-v23 (#686)
+- [2a260942](https://github.com/stashed/mysql/commit/2a260942) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#681) (#682)
+
+
+### [8.0.3-v23](https://github.com/stashed/mysql/releases/tag/8.0.3-v23)
+
+- [820c4b34](https://github.com/stashed/mysql/commit/820c4b34) Prepare for release 8.0.3-v23 (#689)
+- [fd404c15](https://github.com/stashed/mysql/commit/fd404c15) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#681) (#685)
+
+
+### [8.0.14-v23](https://github.com/stashed/mysql/releases/tag/8.0.14-v23)
+
+- [2a043152](https://github.com/stashed/mysql/commit/2a043152) Prepare for release 8.0.14-v23 (#687)
+- [93517b8d](https://github.com/stashed/mysql/commit/93517b8d) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#681) (#683)
+
+
+### [8.0.21-v17](https://github.com/stashed/mysql/releases/tag/8.0.21-v17)
+
+- [e1d2a3fd](https://github.com/stashed/mysql/commit/e1d2a3fd) Prepare for release 8.0.21-v17 (#688)
+- [5587ec19](https://github.com/stashed/mysql/commit/5587ec19) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#681) (#684)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v11](https://github.com/stashed/nats/releases/tag/2.6.1-v11)
+
+- [29202da](https://github.com/stashed/nats/commit/29202da) Prepare for release 2.6.1-v11 (#90)
+- [78b4136](https://github.com/stashed/nats/commit/78b4136) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#87) (#88)
+
+
+### [2.8.2-v6](https://github.com/stashed/nats/releases/tag/2.8.2-v6)
+
+- [1d3b90e](https://github.com/stashed/nats/commit/1d3b90e) Prepare for release 2.8.2-v6 (#91)
+- [92a4648](https://github.com/stashed/nats/commit/92a4648) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#87) (#89)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v18](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v18)
+
+- [efc95cd8](https://github.com/stashed/percona-xtradb/commit/efc95cd8) Prepare for release 5.7-v18 (#284)
+- [bb2fd734](https://github.com/stashed/percona-xtradb/commit/bb2fd734) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#282) (#283)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v22](https://github.com/stashed/postgres/releases/tag/9.6.19-v22)
+
+- [776eae29](https://github.com/stashed/postgres/commit/776eae29) Prepare for release 9.6.19-v22 (#1166)
+- [4b01ad51](https://github.com/stashed/postgres/commit/4b01ad51) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1159)
+
+
+### [10.14-v22](https://github.com/stashed/postgres/releases/tag/10.14-v22)
+
+- [74283c70](https://github.com/stashed/postgres/commit/74283c70) Prepare for release 10.14-v22 (#1160)
+- [7d65c166](https://github.com/stashed/postgres/commit/7d65c166) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1153)
+
+
+### [11.9-v22](https://github.com/stashed/postgres/releases/tag/11.9-v22)
+
+- [9f1de1c6](https://github.com/stashed/postgres/commit/9f1de1c6) Prepare for release 11.9-v22 (#1161)
+- [605163a2](https://github.com/stashed/postgres/commit/605163a2) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1154)
+
+
+### [12.4-v22](https://github.com/stashed/postgres/releases/tag/12.4-v22)
+
+- [788806a2](https://github.com/stashed/postgres/commit/788806a2) Prepare for release 12.4-v22 (#1162)
+- [db464ab0](https://github.com/stashed/postgres/commit/db464ab0) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1155)
+
+
+### [13.1-v19](https://github.com/stashed/postgres/releases/tag/13.1-v19)
+
+- [7fb61d96](https://github.com/stashed/postgres/commit/7fb61d96) Prepare for release 13.1-v19 (#1163)
+- [8c935e00](https://github.com/stashed/postgres/commit/8c935e00) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1156)
+
+
+### [14.0-v11](https://github.com/stashed/postgres/releases/tag/14.0-v11)
+
+- [93212ea6](https://github.com/stashed/postgres/commit/93212ea6) Prepare for release 14.0-v11 (#1164)
+- [1ac9edd5](https://github.com/stashed/postgres/commit/1ac9edd5) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1157)
+
+
+### [15.1-v3](https://github.com/stashed/postgres/releases/tag/15.1-v3)
+
+- [31f3dd33](https://github.com/stashed/postgres/commit/31f3dd33) Prepare for release 15.1-v3 (#1165)
+- [9c6d9590](https://github.com/stashed/postgres/commit/9c6d9590) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#1152) (#1158)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v11](https://github.com/stashed/redis/releases/tag/5.0.13-v11)
+
+- [73da1c1](https://github.com/stashed/redis/commit/73da1c1) Prepare for release 5.0.13-v11 (#152)
+- [9f7e222](https://github.com/stashed/redis/commit/9f7e222) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#148) (#149)
+
+
+### [6.2.5-v11](https://github.com/stashed/redis/releases/tag/6.2.5-v11)
+
+- [dc8e853](https://github.com/stashed/redis/commit/dc8e853) Prepare for release 6.2.5-v11 (#153)
+- [e865167](https://github.com/stashed/redis/commit/e865167) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#148) (#150)
+
+
+### [7.0.5-v4](https://github.com/stashed/redis/releases/tag/7.0.5-v4)
+
+- [dd4da56](https://github.com/stashed/redis/commit/dd4da56) Prepare for release 7.0.5-v4 (#154)
+- [ae71390](https://github.com/stashed/redis/commit/ae71390) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#148) (#151)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.27.0](https://github.com/stashed/stash/releases/tag/v0.27.0)
+
+- [d3428094](https://github.com/stashed/stash/commit/d3428094a) Prepare for release v0.27.0 (#1508)
+- [87bf7e8e](https://github.com/stashed/stash/commit/87bf7e8e5) Update workflows (Go 1.20, k8s 1.26) (#1502)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.9.0](https://github.com/stashed/ui-server/releases/tag/v0.9.0)
+
+- [0c31efb](https://github.com/stashed/ui-server/commit/0c31efb) Prepare for release v0.9.0 (#23)
+- [01975fa](https://github.com/stashed/ui-server/commit/01975fa) Update workflows (Go 1.20, k8s 1.26) (#22)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v3](https://github.com/stashed/vault/releases/tag/1.10.3-v3)
+
+- [52bbbf05](https://github.com/stashed/vault/commit/52bbbf05) Prepare for release 1.10.3-v3 (#9)
+- [4dac4a85](https://github.com/stashed/vault/commit/4dac4a85) [cherry-pick] Update workflows (Go 1.20, k8s 1.26) (#7) (#8)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.03.13
Release-tracker: https://github.com/stashed/CHANGELOG/pull/63
Signed-off-by: 1gtm <1gtm@appscode.com>