### PR TITLE
Prepare for release v2023.03.20

### DIFF
--- a/docs/CHANGELOG-v2023.03.20.md
+++ b/docs/CHANGELOG-v2023.03.20.md
@@ -1,0 +1,327 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.03.20
+    name: Changelog-v2023.03.20
+    parent: welcome
+    weight: 20230320
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.03.20/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.03.20/
+---
+
+# Stash v2023.03.20 (2023-03-19)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.28.0](https://github.com/stashed/apimachinery/releases/tag/v0.28.0)
+
+- [292f37f4](https://github.com/stashed/apimachinery/commit/292f37f4) Update dependencies
+- [1c5d99c3](https://github.com/stashed/apimachinery/commit/1c5d99c3) Create directory for local repository for restic init (#199)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.28.0](https://github.com/stashed/cli/releases/tag/v0.28.0)
+
+- [fc785021](https://github.com/stashed/cli/commit/fc785021) Prepare for release v0.28.0 (#180)
+- [9cadafcb](https://github.com/stashed/cli/commit/9cadafcb) Enable unlocking of local repository on NFS volume (#179)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v24](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v24)
+
+- [6cd18de9](https://github.com/stashed/elasticsearch/commit/6cd18de9) Prepare for release 5.6.4-v24 (#1344)
+
+
+### [6.2.4-v24](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v24)
+
+- [11f17468](https://github.com/stashed/elasticsearch/commit/11f17468) Prepare for release 6.2.4-v24 (#1345)
+
+
+### [6.3.0-v24](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v24)
+
+- [72441b73](https://github.com/stashed/elasticsearch/commit/72441b73) Prepare for release 6.3.0-v24 (#1346)
+
+
+### [6.4.0-v24](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v24)
+
+- [ebb9119a](https://github.com/stashed/elasticsearch/commit/ebb9119a) Prepare for release 6.4.0-v24 (#1347)
+
+
+### [6.5.3-v24](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v24)
+
+- [2bfe6379](https://github.com/stashed/elasticsearch/commit/2bfe6379) Prepare for release 6.5.3-v24 (#1348)
+
+
+### [6.8.0-v24](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v24)
+
+- [7f221239](https://github.com/stashed/elasticsearch/commit/7f221239) Prepare for release 6.8.0-v24 (#1349)
+
+
+### [7.2.0-v24](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v24)
+
+- [cf23989f](https://github.com/stashed/elasticsearch/commit/cf23989f) Prepare for release 7.2.0-v24 (#1351)
+
+
+### [7.3.2-v24](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v24)
+
+- [eb185e09](https://github.com/stashed/elasticsearch/commit/eb185e09) Prepare for release 7.3.2-v24 (#1352)
+
+
+### [7.14.0-v10](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v10)
+
+- [2fc98a7b](https://github.com/stashed/elasticsearch/commit/2fc98a7b) Prepare for release 7.14.0-v10 (#1350)
+
+
+### [8.2.0-v7](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v7)
+
+- [3c4d977e](https://github.com/stashed/elasticsearch/commit/3c4d977e) Prepare for release 8.2.0-v7 (#1353)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.28.0](https://github.com/stashed/enterprise/releases/tag/v0.28.0)
+
+- [69cc9409](https://github.com/stashed/enterprise/commit/69cc9409f) Prepare for release v0.28.0 (#226)
+- [d882beb1](https://github.com/stashed/enterprise/commit/d882beb1a) Add unlock command for CLI (#224)
+- [25b4ff16](https://github.com/stashed/enterprise/commit/25b4ff160) Append image pull secrets instead of replace (#225)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v11](https://github.com/stashed/etcd/releases/tag/3.5.0-v11)
+
+- [67526a5](https://github.com/stashed/etcd/commit/67526a5) Prepare for release 3.5.0-v11 (#73)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.03.20](https://github.com/stashed/installer/releases/tag/v2023.03.20)
+
+- [1ec11e29](https://github.com/stashed/installer/commit/1ec11e29) Prepare for release v2023.03.20 (#297)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v7](https://github.com/stashed/kubedump/releases/tag/0.1.0-v7)
+
+- [f6961d5](https://github.com/stashed/kubedump/commit/f6961d5) Prepare for release 0.1.0-v7 (#33)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v17](https://github.com/stashed/mariadb/releases/tag/10.5.8-v17)
+
+- [18974b1](https://github.com/stashed/mariadb/commit/18974b1) Prepare for release 10.5.8-v17 (#216)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v24](https://github.com/stashed/mongodb/releases/tag/3.4.17-v24)
+
+- [a35ca221](https://github.com/stashed/mongodb/commit/a35ca221) Prepare for release 3.4.17-v24 (#1760)
+
+
+### [3.4.22-v24](https://github.com/stashed/mongodb/releases/tag/3.4.22-v24)
+
+- [0acd0614](https://github.com/stashed/mongodb/commit/0acd0614) Prepare for release 3.4.22-v24 (#1761)
+
+
+### [3.6.8-v24](https://github.com/stashed/mongodb/releases/tag/3.6.8-v24)
+
+- [90e1ee6f](https://github.com/stashed/mongodb/commit/90e1ee6f) Prepare for release 3.6.8-v24 (#1763)
+
+
+### [3.6.13-v24](https://github.com/stashed/mongodb/releases/tag/3.6.13-v24)
+
+- [3b6758d1](https://github.com/stashed/mongodb/commit/3b6758d1) Prepare for release 3.6.13-v24 (#1762)
+
+
+### [4.0.3-v24](https://github.com/stashed/mongodb/releases/tag/4.0.3-v24)
+
+- [e102289e](https://github.com/stashed/mongodb/commit/e102289e) Prepare for release 4.0.3-v24 (#1765)
+
+
+### [4.0.5-v24](https://github.com/stashed/mongodb/releases/tag/4.0.5-v24)
+
+- [65473863](https://github.com/stashed/mongodb/commit/65473863) Prepare for release 4.0.5-v24 (#1766)
+
+
+### [4.0.11-v24](https://github.com/stashed/mongodb/releases/tag/4.0.11-v24)
+
+- [2d985943](https://github.com/stashed/mongodb/commit/2d985943) Prepare for release 4.0.11-v24 (#1764)
+
+
+### [4.1.4-v24](https://github.com/stashed/mongodb/releases/tag/4.1.4-v24)
+
+- [539a0db1](https://github.com/stashed/mongodb/commit/539a0db1) Prepare for release 4.1.4-v24 (#1768)
+
+
+### [4.1.7-v24](https://github.com/stashed/mongodb/releases/tag/4.1.7-v24)
+
+- [3e8c030d](https://github.com/stashed/mongodb/commit/3e8c030d) Prepare for release 4.1.7-v24 (#1769)
+
+
+### [4.1.13-v24](https://github.com/stashed/mongodb/releases/tag/4.1.13-v24)
+
+- [b501f60f](https://github.com/stashed/mongodb/commit/b501f60f) Prepare for release 4.1.13-v24 (#1767)
+
+
+### [4.2.3-v24](https://github.com/stashed/mongodb/releases/tag/4.2.3-v24)
+
+- [c526024e](https://github.com/stashed/mongodb/commit/c526024e) Prepare for release 4.2.3-v24 (#1770)
+
+
+### [4.4.6-v15](https://github.com/stashed/mongodb/releases/tag/4.4.6-v15)
+
+- [61902b46](https://github.com/stashed/mongodb/commit/61902b46) Prepare for release 4.4.6-v15 (#1771)
+
+
+### [5.0.3-v12](https://github.com/stashed/mongodb/releases/tag/5.0.3-v12)
+
+- [38ad041e](https://github.com/stashed/mongodb/commit/38ad041e) Prepare for release 5.0.3-v12 (#1772)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v24](https://github.com/stashed/mysql/releases/tag/5.7.25-v24)
+
+- [a8dcdc62](https://github.com/stashed/mysql/commit/a8dcdc62) Prepare for release 5.7.25-v24 (#691)
+
+
+### [8.0.3-v24](https://github.com/stashed/mysql/releases/tag/8.0.3-v24)
+
+- [15020258](https://github.com/stashed/mysql/commit/15020258) Prepare for release 8.0.3-v24 (#694)
+
+
+### [8.0.14-v24](https://github.com/stashed/mysql/releases/tag/8.0.14-v24)
+
+- [80fe4fb8](https://github.com/stashed/mysql/commit/80fe4fb8) Prepare for release 8.0.14-v24 (#692)
+
+
+### [8.0.21-v18](https://github.com/stashed/mysql/releases/tag/8.0.21-v18)
+
+- [5fed08e3](https://github.com/stashed/mysql/commit/5fed08e3) Prepare for release 8.0.21-v18 (#693)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v12](https://github.com/stashed/nats/releases/tag/2.6.1-v12)
+
+- [0a385ca](https://github.com/stashed/nats/commit/0a385ca) Prepare for release 2.6.1-v12 (#93)
+
+
+### [2.8.2-v7](https://github.com/stashed/nats/releases/tag/2.8.2-v7)
+
+- [e050da5](https://github.com/stashed/nats/commit/e050da5) Prepare for release 2.8.2-v7 (#94)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v19](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v19)
+
+- [4c93ae53](https://github.com/stashed/percona-xtradb/commit/4c93ae53) Prepare for release 5.7-v19 (#286)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v23](https://github.com/stashed/postgres/releases/tag/9.6.19-v23)
+
+- [ca9ce6bd](https://github.com/stashed/postgres/commit/ca9ce6bd) Prepare for release 9.6.19-v23 (#1174)
+
+
+### [10.14-v23](https://github.com/stashed/postgres/releases/tag/10.14-v23)
+
+- [47b1062f](https://github.com/stashed/postgres/commit/47b1062f) Prepare for release 10.14-v23 (#1168)
+
+
+### [11.9-v23](https://github.com/stashed/postgres/releases/tag/11.9-v23)
+
+- [398f746e](https://github.com/stashed/postgres/commit/398f746e) Prepare for release 11.9-v23 (#1169)
+
+
+### [12.4-v23](https://github.com/stashed/postgres/releases/tag/12.4-v23)
+
+- [0f2c4aa1](https://github.com/stashed/postgres/commit/0f2c4aa1) Prepare for release 12.4-v23 (#1170)
+
+
+### [13.1-v20](https://github.com/stashed/postgres/releases/tag/13.1-v20)
+
+- [646372a2](https://github.com/stashed/postgres/commit/646372a2) Prepare for release 13.1-v20 (#1171)
+
+
+### [14.0-v12](https://github.com/stashed/postgres/releases/tag/14.0-v12)
+
+- [9a83d73b](https://github.com/stashed/postgres/commit/9a83d73b) Prepare for release 14.0-v12 (#1172)
+
+
+### [15.1-v4](https://github.com/stashed/postgres/releases/tag/15.1-v4)
+
+- [4be14a52](https://github.com/stashed/postgres/commit/4be14a52) Prepare for release 15.1-v4 (#1173)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v12](https://github.com/stashed/redis/releases/tag/5.0.13-v12)
+
+- [9b351df](https://github.com/stashed/redis/commit/9b351df) Prepare for release 5.0.13-v12 (#156)
+
+
+### [6.2.5-v12](https://github.com/stashed/redis/releases/tag/6.2.5-v12)
+
+- [1d7e7cf](https://github.com/stashed/redis/commit/1d7e7cf) Prepare for release 6.2.5-v12 (#157)
+
+
+### [7.0.5-v5](https://github.com/stashed/redis/releases/tag/7.0.5-v5)
+
+- [46bddd9](https://github.com/stashed/redis/commit/46bddd9) Prepare for release 7.0.5-v5 (#158)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.28.0](https://github.com/stashed/stash/releases/tag/v0.28.0)
+
+- [7e74e401](https://github.com/stashed/stash/commit/7e74e4014) Prepare for release v0.28.0 (#1510)
+- [5fb5bda3](https://github.com/stashed/stash/commit/5fb5bda34) Append image pull secrets instead of replace (#1509)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.10.0](https://github.com/stashed/ui-server/releases/tag/v0.10.0)
+
+- [6b61475](https://github.com/stashed/ui-server/commit/6b61475) Prepare for release v0.10.0 (#24)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v4](https://github.com/stashed/vault/releases/tag/1.10.3-v4)
+
+- [d70c128f](https://github.com/stashed/vault/commit/d70c128f) Prepare for release 1.10.3-v4 (#11)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.03.20
Release-tracker: https://github.com/stashed/CHANGELOG/pull/64
Signed-off-by: 1gtm <1gtm@appscode.com>