### PR TITLE
Prepare for release v2023.04.30

### DIFF
--- a/docs/CHANGELOG-v2023.04.30.md
+++ b/docs/CHANGELOG-v2023.04.30.md
@@ -1,0 +1,388 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.04.30
+    name: Changelog-v2023.04.30
+    parent: welcome
+    weight: 20230430
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.04.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.04.30/
+---
+
+# Stash v2023.04.30 (2023-05-01)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.29.0](https://github.com/stashed/apimachinery/releases/tag/v0.29.0)
+
+- [cf255d28](https://github.com/stashed/apimachinery/commit/cf255d28) Make dump public as DumpOnce (#201)
+- [d75b9663](https://github.com/stashed/apimachinery/commit/d75b9663) Use ghcr.io (#200)
+- [8a1c90af](https://github.com/stashed/apimachinery/commit/8a1c90af) make gen fmt
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.29.0](https://github.com/stashed/cli/releases/tag/v0.29.0)
+
+- [58ff504f](https://github.com/stashed/cli/commit/58ff504f) Prepare for release v0.29.0 (#181)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v25](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v25)
+
+- [0ee516bf](https://github.com/stashed/elasticsearch/commit/0ee516bf) Prepare for release 5.6.4-v25 (#1368)
+- [e9f9b93c](https://github.com/stashed/elasticsearch/commit/e9f9b93c) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1358)
+
+
+### [6.2.4-v25](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v25)
+
+- [9d7318d0](https://github.com/stashed/elasticsearch/commit/9d7318d0) Prepare for release 6.2.4-v25 (#1369)
+- [0aef89d3](https://github.com/stashed/elasticsearch/commit/0aef89d3) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1359)
+
+
+### [6.3.0-v25](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v25)
+
+- [74d20240](https://github.com/stashed/elasticsearch/commit/74d20240) Prepare for release 6.3.0-v25 (#1370)
+- [c0f6ec9b](https://github.com/stashed/elasticsearch/commit/c0f6ec9b) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1360)
+
+
+### [6.4.0-v25](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v25)
+
+- [d54966fa](https://github.com/stashed/elasticsearch/commit/d54966fa) Prepare for release 6.4.0-v25 (#1371)
+- [55e8573a](https://github.com/stashed/elasticsearch/commit/55e8573a) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1361)
+
+
+### [6.5.3-v25](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v25)
+
+- [15d08d71](https://github.com/stashed/elasticsearch/commit/15d08d71) Prepare for release 6.5.3-v25 (#1372)
+- [5b4c2eac](https://github.com/stashed/elasticsearch/commit/5b4c2eac) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1362)
+
+
+### [6.8.0-v25](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v25)
+
+- [1a05c3a8](https://github.com/stashed/elasticsearch/commit/1a05c3a8) Prepare for release 6.8.0-v25 (#1373)
+- [84dcd7f3](https://github.com/stashed/elasticsearch/commit/84dcd7f3) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1363)
+
+
+### [7.2.0-v25](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v25)
+
+- [1c547594](https://github.com/stashed/elasticsearch/commit/1c547594) Prepare for release 7.2.0-v25 (#1375)
+- [fbf47b6b](https://github.com/stashed/elasticsearch/commit/fbf47b6b) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1365)
+
+
+### [7.3.2-v25](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v25)
+
+- [a27dbe82](https://github.com/stashed/elasticsearch/commit/a27dbe82) Prepare for release 7.3.2-v25 (#1376)
+- [d4ae0196](https://github.com/stashed/elasticsearch/commit/d4ae0196) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1366)
+
+
+### [7.14.0-v11](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v11)
+
+- [94794608](https://github.com/stashed/elasticsearch/commit/94794608) Prepare for release 7.14.0-v11 (#1374)
+- [7c70adf7](https://github.com/stashed/elasticsearch/commit/7c70adf7) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1364)
+
+
+### [8.2.0-v8](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v8)
+
+- [6e557492](https://github.com/stashed/elasticsearch/commit/6e557492) Prepare for release 8.2.0-v8 (#1377)
+- [4bac3d22](https://github.com/stashed/elasticsearch/commit/4bac3d22) [cherry-pick] Use numeric uid in Dockerfile (#1357) (#1367)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.29.0](https://github.com/stashed/enterprise/releases/tag/v0.29.0)
+
+- [1a51e875](https://github.com/stashed/enterprise/commit/1a51e875f) Prepare for release v0.29.0 (#229)
+- [a67955d0](https://github.com/stashed/enterprise/commit/a67955d0a) Use numeric uid in Dockerfile (#228)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v12](https://github.com/stashed/etcd/releases/tag/3.5.0-v12)
+
+- [ef26a24](https://github.com/stashed/etcd/commit/ef26a24) Prepare for release 3.5.0-v12 (#77)
+- [07c7c30](https://github.com/stashed/etcd/commit/07c7c30) [cherry-pick] Use numeric uid in Dockerfile (#75) (#76)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.04.30](https://github.com/stashed/installer/releases/tag/v2023.04.30)
+
+- [f69ead12](https://github.com/stashed/installer/commit/f69ead12) Prepare for release v2023.04.30 (#302)
+- [729afc21](https://github.com/stashed/installer/commit/729afc21) Test against k8s 1.27.1 (#301)
+- [8ecafa65](https://github.com/stashed/installer/commit/8ecafa65) Use ghcr.io (#300)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v8](https://github.com/stashed/kubedump/releases/tag/0.1.0-v8)
+
+- [b454d58](https://github.com/stashed/kubedump/commit/b454d58) Prepare for release 0.1.0-v8 (#37)
+- [70f0d3c](https://github.com/stashed/kubedump/commit/70f0d3c) [cherry-pick] Use numeric uid in Dockerfile (#35) (#36)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v18](https://github.com/stashed/mariadb/releases/tag/10.5.8-v18)
+
+- [40471eb](https://github.com/stashed/mariadb/commit/40471eb) Prepare for release 10.5.8-v18 (#220)
+- [7e8d8d1](https://github.com/stashed/mariadb/commit/7e8d8d1) [cherry-pick] Use numeric uid in Dockerfile (#218) (#219)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v25](https://github.com/stashed/mongodb/releases/tag/3.4.17-v25)
+
+- [ee474ffb](https://github.com/stashed/mongodb/commit/ee474ffb) Prepare for release 3.4.17-v25 (#1789)
+- [6aa4d7be](https://github.com/stashed/mongodb/commit/6aa4d7be) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1775)
+
+
+### [3.4.22-v25](https://github.com/stashed/mongodb/releases/tag/3.4.22-v25)
+
+- [58db6548](https://github.com/stashed/mongodb/commit/58db6548) Prepare for release 3.4.22-v25 (#1790)
+- [cf380322](https://github.com/stashed/mongodb/commit/cf380322) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1776)
+
+
+### [3.6.8-v25](https://github.com/stashed/mongodb/releases/tag/3.6.8-v25)
+
+- [05f2b457](https://github.com/stashed/mongodb/commit/05f2b457) Prepare for release 3.6.8-v25 (#1792)
+- [8a973cc7](https://github.com/stashed/mongodb/commit/8a973cc7) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1778)
+
+
+### [3.6.13-v25](https://github.com/stashed/mongodb/releases/tag/3.6.13-v25)
+
+- [4c76961f](https://github.com/stashed/mongodb/commit/4c76961f) Prepare for release 3.6.13-v25 (#1791)
+- [7b4f5756](https://github.com/stashed/mongodb/commit/7b4f5756) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1777)
+
+
+### [4.0.3-v25](https://github.com/stashed/mongodb/releases/tag/4.0.3-v25)
+
+- [55f20859](https://github.com/stashed/mongodb/commit/55f20859) Prepare for release 4.0.3-v25 (#1794)
+- [9c56288a](https://github.com/stashed/mongodb/commit/9c56288a) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1780)
+
+
+### [4.0.5-v25](https://github.com/stashed/mongodb/releases/tag/4.0.5-v25)
+
+- [14ed2e50](https://github.com/stashed/mongodb/commit/14ed2e50) Prepare for release 4.0.5-v25 (#1795)
+- [7a92e2d8](https://github.com/stashed/mongodb/commit/7a92e2d8) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1781)
+
+
+### [4.0.11-v25](https://github.com/stashed/mongodb/releases/tag/4.0.11-v25)
+
+- [f27bea0a](https://github.com/stashed/mongodb/commit/f27bea0a) Prepare for release 4.0.11-v25 (#1793)
+- [e421ed2f](https://github.com/stashed/mongodb/commit/e421ed2f) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1779)
+
+
+### [4.1.4-v25](https://github.com/stashed/mongodb/releases/tag/4.1.4-v25)
+
+- [73c9bc38](https://github.com/stashed/mongodb/commit/73c9bc38) Prepare for release 4.1.4-v25 (#1797)
+- [aabe17c4](https://github.com/stashed/mongodb/commit/aabe17c4) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1783)
+
+
+### [4.1.7-v25](https://github.com/stashed/mongodb/releases/tag/4.1.7-v25)
+
+- [d39c4f50](https://github.com/stashed/mongodb/commit/d39c4f50) Prepare for release 4.1.7-v25 (#1798)
+- [28c67f0c](https://github.com/stashed/mongodb/commit/28c67f0c) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1784)
+
+
+### [4.1.13-v25](https://github.com/stashed/mongodb/releases/tag/4.1.13-v25)
+
+- [ba045e54](https://github.com/stashed/mongodb/commit/ba045e54) Prepare for release 4.1.13-v25 (#1796)
+- [f81ee4da](https://github.com/stashed/mongodb/commit/f81ee4da) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1782)
+
+
+### [4.2.3-v25](https://github.com/stashed/mongodb/releases/tag/4.2.3-v25)
+
+- [9bf064bb](https://github.com/stashed/mongodb/commit/9bf064bb) Prepare for release 4.2.3-v25 (#1799)
+- [b1a08dba](https://github.com/stashed/mongodb/commit/b1a08dba) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1785)
+
+
+### [4.4.6-v16](https://github.com/stashed/mongodb/releases/tag/4.4.6-v16)
+
+- [14e1d296](https://github.com/stashed/mongodb/commit/14e1d296) Prepare for release 4.4.6-v16 (#1800)
+- [640b1544](https://github.com/stashed/mongodb/commit/640b1544) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1786)
+
+
+### [5.0.3-v13](https://github.com/stashed/mongodb/releases/tag/5.0.3-v13)
+
+- [3affc0f9](https://github.com/stashed/mongodb/commit/3affc0f9) Prepare for release 5.0.3-v13 (#1801)
+- [3c32151a](https://github.com/stashed/mongodb/commit/3c32151a) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1787)
+
+
+### [6.0.5-v1](https://github.com/stashed/mongodb/releases/tag/6.0.5-v1)
+
+- [9960c95c](https://github.com/stashed/mongodb/commit/9960c95c) Prepare for release 6.0.5-v1 (#1802)
+- [983b59c6](https://github.com/stashed/mongodb/commit/983b59c6) [cherry-pick] Use numeric uid in Dockerfile (#1774) (#1788)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v25](https://github.com/stashed/mysql/releases/tag/5.7.25-v25)
+
+- [5eae9b8b](https://github.com/stashed/mysql/commit/5eae9b8b) Prepare for release 5.7.25-v25 (#701)
+- [dbfc2143](https://github.com/stashed/mysql/commit/dbfc2143) Use numeric uid in Dockerfile (#696) (#697)
+
+
+### [8.0.3-v25](https://github.com/stashed/mysql/releases/tag/8.0.3-v25)
+
+- [c2a30c87](https://github.com/stashed/mysql/commit/c2a30c87) Prepare for release 8.0.3-v25 (#704)
+- [bd69d6ad](https://github.com/stashed/mysql/commit/bd69d6ad) Use numeric uid in Dockerfile (#696) (#700)
+
+
+### [8.0.14-v25](https://github.com/stashed/mysql/releases/tag/8.0.14-v25)
+
+- [a9385be7](https://github.com/stashed/mysql/commit/a9385be7) Prepare for release 8.0.14-v25 (#702)
+- [05a04a56](https://github.com/stashed/mysql/commit/05a04a56) Use numeric uid in Dockerfile (#696) (#698)
+
+
+### [8.0.21-v19](https://github.com/stashed/mysql/releases/tag/8.0.21-v19)
+
+- [7f68cb08](https://github.com/stashed/mysql/commit/7f68cb08) Prepare for release 8.0.21-v19 (#703)
+- [6beb1eed](https://github.com/stashed/mysql/commit/6beb1eed) [cherry-pick] Use numeric uid in Dockerfile (#696) (#699)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v13](https://github.com/stashed/nats/releases/tag/2.6.1-v13)
+
+- [2cfd5b8](https://github.com/stashed/nats/commit/2cfd5b8) Prepare for release 2.6.1-v13 (#100)
+- [02f2e3c](https://github.com/stashed/nats/commit/02f2e3c) [cherry-pick] Use numeric uid in Dockerfile (#97) (#98)
+
+
+### [2.8.2-v8](https://github.com/stashed/nats/releases/tag/2.8.2-v8)
+
+- [bd1c3b9](https://github.com/stashed/nats/commit/bd1c3b9) Prepare for release 2.8.2-v8 (#101)
+- [9977ac2](https://github.com/stashed/nats/commit/9977ac2) [cherry-pick] Use numeric uid in Dockerfile (#97) (#99)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v20](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v20)
+
+- [9e5a1789](https://github.com/stashed/percona-xtradb/commit/9e5a1789) Prepare for release 5.7-v20 (#290)
+- [dce46839](https://github.com/stashed/percona-xtradb/commit/dce46839) [cherry-pick] Use numeric uid in Dockerfile (#288) (#289)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v24](https://github.com/stashed/postgres/releases/tag/9.6.19-v24)
+
+- [5fd149a6](https://github.com/stashed/postgres/commit/5fd149a6) Prepare for release 9.6.19-v24 (#1190)
+- [e09a4972](https://github.com/stashed/postgres/commit/e09a4972) Use numeric uid in Dockerfile (#1176) (#1183)
+
+
+### [10.14-v24](https://github.com/stashed/postgres/releases/tag/10.14-v24)
+
+- [77fb4d62](https://github.com/stashed/postgres/commit/77fb4d62) Prepare for release 10.14-v24 (#1184)
+- [e229b03c](https://github.com/stashed/postgres/commit/e229b03c) Use numeric uid in Dockerfile (#1176) (#1177)
+
+
+### [11.9-v24](https://github.com/stashed/postgres/releases/tag/11.9-v24)
+
+- [f4e574c9](https://github.com/stashed/postgres/commit/f4e574c9) Prepare for release 11.9-v24 (#1185)
+- [435c1e58](https://github.com/stashed/postgres/commit/435c1e58) Use numeric uid in Dockerfile (#1176) (#1178)
+
+
+### [12.4-v24](https://github.com/stashed/postgres/releases/tag/12.4-v24)
+
+- [f2854938](https://github.com/stashed/postgres/commit/f2854938) Prepare for release 12.4-v24 (#1186)
+- [15249a55](https://github.com/stashed/postgres/commit/15249a55) [cherry-pick] Use numeric uid in Dockerfile (#1176) (#1179)
+
+
+### [13.1-v21](https://github.com/stashed/postgres/releases/tag/13.1-v21)
+
+- [677de51c](https://github.com/stashed/postgres/commit/677de51c) Prepare for release 13.1-v21 (#1187)
+- [0a2426e2](https://github.com/stashed/postgres/commit/0a2426e2) [cherry-pick] Use numeric uid in Dockerfile (#1176) (#1180)
+
+
+### [14.0-v13](https://github.com/stashed/postgres/releases/tag/14.0-v13)
+
+- [1a97a10c](https://github.com/stashed/postgres/commit/1a97a10c) Prepare for release 14.0-v13 (#1188)
+- [06b6ad43](https://github.com/stashed/postgres/commit/06b6ad43) [cherry-pick] Use numeric uid in Dockerfile (#1176) (#1181)
+
+
+### [15.1-v5](https://github.com/stashed/postgres/releases/tag/15.1-v5)
+
+- [aa21b8e8](https://github.com/stashed/postgres/commit/aa21b8e8) Prepare for release 15.1-v5 (#1189)
+- [4fddfae3](https://github.com/stashed/postgres/commit/4fddfae3) [cherry-pick] Use numeric uid in Dockerfile (#1176) (#1182)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v13](https://github.com/stashed/redis/releases/tag/5.0.13-v13)
+
+- [f5cfc4b](https://github.com/stashed/redis/commit/f5cfc4b) Prepare for release 5.0.13-v13 (#168)
+- [35b6cd5](https://github.com/stashed/redis/commit/35b6cd5) [cherry-pick] Support backup and restore for redis clusters (#164) (#165)
+- [5dbc12b](https://github.com/stashed/redis/commit/5dbc12b) Use ghcr.io for appscode/golang-dev
+- [b67eb58](https://github.com/stashed/redis/commit/b67eb58) Add Support for Redis when Auth is Disabled in Kubedb (#77)
+- [8372b08](https://github.com/stashed/redis/commit/8372b08) [cherry-pick] Use numeric uid in Dockerfile (#160) (#161)
+
+
+### [6.2.5-v13](https://github.com/stashed/redis/releases/tag/6.2.5-v13)
+
+- [468c1bd](https://github.com/stashed/redis/commit/468c1bd) Prepare for release 6.2.5-v13 (#169)
+- [d549e24](https://github.com/stashed/redis/commit/d549e24) [cherry-pick] Support backup and restore for redis clusters (#164) (#166)
+- [7803cc9](https://github.com/stashed/redis/commit/7803cc9) Use ghcr.io for appscode/golang-dev
+- [eb9af10](https://github.com/stashed/redis/commit/eb9af10) Add Support for Redis when Auth is Disabled in Kubedb (#77)
+- [bec48a2](https://github.com/stashed/redis/commit/bec48a2) [cherry-pick] Use numeric uid in Dockerfile (#160) (#162)
+
+
+### [7.0.5-v6](https://github.com/stashed/redis/releases/tag/7.0.5-v6)
+
+- [a2088a4](https://github.com/stashed/redis/commit/a2088a4) Prepare for release 7.0.5-v6 (#170)
+- [b7b327a](https://github.com/stashed/redis/commit/b7b327a) [cherry-pick] Support backup and restore for redis clusters (#164) (#167)
+- [be87eed](https://github.com/stashed/redis/commit/be87eed) Use ghcr.io for appscode/golang-dev
+- [7c48c51](https://github.com/stashed/redis/commit/7c48c51) Add Support for Redis when Auth is Disabled in Kubedb (#77)
+- [7d8d9b4](https://github.com/stashed/redis/commit/7d8d9b4) [cherry-pick] Use numeric uid in Dockerfile (#160) (#163)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.29.0](https://github.com/stashed/stash/releases/tag/v0.29.0)
+
+- [a80cbf90](https://github.com/stashed/stash/commit/a80cbf905) Prepare for release v0.29.0 (#1514)
+- [3625b857](https://github.com/stashed/stash/commit/3625b8579) Use numeric uid in Dockerfile (#1513)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.11.0](https://github.com/stashed/ui-server/releases/tag/v0.11.0)
+
+- [633cf86](https://github.com/stashed/ui-server/commit/633cf86) Prepare for release v0.11.0 (#26)
+- [0a6ce3a](https://github.com/stashed/ui-server/commit/0a6ce3a) Use numeric uid in Dockerfile (#25)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v5](https://github.com/stashed/vault/releases/tag/1.10.3-v5)
+
+- [6b7fd704](https://github.com/stashed/vault/commit/6b7fd704) Prepare for release 1.10.3-v5 (#15)
+- [389cd328](https://github.com/stashed/vault/commit/389cd328) [cherry-pick] Use numeric uid in Dockerfile (#13) (#14)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.04.30
Release-tracker: https://github.com/stashed/CHANGELOG/pull/65
Signed-off-by: 1gtm <1gtm@appscode.com>