### PR TITLE
Prepare for release v2023.05.31

### DIFF
--- a/docs/CHANGELOG-v2023.05.31.md
+++ b/docs/CHANGELOG-v2023.05.31.md
@@ -1,0 +1,380 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.05.31
+    name: Changelog-v2023.05.31
+    parent: welcome
+    weight: 20230531
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.05.31/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.05.31/
+---
+
+# Stash v2023.05.31 (2023-05-30)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.30.0](https://github.com/stashed/apimachinery/releases/tag/v0.30.0)
+
+- [45c1d9e0](https://github.com/stashed/apimachinery/commit/45c1d9e0) Update deps (#205)
+- [1e979c48](https://github.com/stashed/apimachinery/commit/1e979c48) Store error in restic stats for parallel backup and dump (#204)
+- [ba0e4342](https://github.com/stashed/apimachinery/commit/ba0e4342) Fix backup initiation check + Add constants for ES restoration (#203)
+- [f06d7a0e](https://github.com/stashed/apimachinery/commit/f06d7a0e) Fix build (#202)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.30.0](https://github.com/stashed/cli/releases/tag/v0.30.0)
+
+- [21f75035](https://github.com/stashed/cli/commit/21f75035) Prepare for release v0.30.0 (#183)
+- [2e0ea3ce](https://github.com/stashed/cli/commit/2e0ea3ce) Add repository name as prefix to mount path of NFS volume accessor (#182)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v26](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v26)
+
+- [f09bc4d8](https://github.com/stashed/elasticsearch/commit/f09bc4d8) Prepare for release 5.6.4-v26 (#1390)
+- [80dad168](https://github.com/stashed/elasticsearch/commit/80dad168) [cherry-pick] Dump PVC storage information (#1379) (#1380)
+
+
+### [6.2.4-v26](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v26)
+
+- [225c35b6](https://github.com/stashed/elasticsearch/commit/225c35b6) Prepare for release 6.2.4-v26 (#1391)
+- [162692bf](https://github.com/stashed/elasticsearch/commit/162692bf) [cherry-pick] Dump PVC storage information (#1379) (#1381)
+
+
+### [6.3.0-v26](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v26)
+
+- [cc95e4e8](https://github.com/stashed/elasticsearch/commit/cc95e4e8) Prepare for release 6.3.0-v26 (#1392)
+- [1e1d0f67](https://github.com/stashed/elasticsearch/commit/1e1d0f67) [cherry-pick] Dump PVC storage information (#1379) (#1382)
+
+
+### [6.4.0-v26](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v26)
+
+- [2a0e72ea](https://github.com/stashed/elasticsearch/commit/2a0e72ea) Prepare for release 6.4.0-v26 (#1393)
+- [5ee51cb1](https://github.com/stashed/elasticsearch/commit/5ee51cb1) [cherry-pick] Dump PVC storage information (#1379) (#1383)
+
+
+### [6.5.3-v26](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v26)
+
+- [ffeafd96](https://github.com/stashed/elasticsearch/commit/ffeafd96) Prepare for release 6.5.3-v26 (#1394)
+- [193ef15f](https://github.com/stashed/elasticsearch/commit/193ef15f) [cherry-pick] Dump PVC storage information (#1379) (#1384)
+
+
+### [6.8.0-v26](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v26)
+
+- [a90506a8](https://github.com/stashed/elasticsearch/commit/a90506a8) Prepare for release 6.8.0-v26 (#1395)
+- [54525e6d](https://github.com/stashed/elasticsearch/commit/54525e6d) [cherry-pick] Dump PVC storage information (#1379) (#1385)
+
+
+### [7.2.0-v26](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v26)
+
+- [0d6226f6](https://github.com/stashed/elasticsearch/commit/0d6226f6) Prepare for release 7.2.0-v26 (#1397)
+- [5b25a987](https://github.com/stashed/elasticsearch/commit/5b25a987) [cherry-pick] Dump PVC storage information (#1379) (#1387)
+
+
+### [7.3.2-v26](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v26)
+
+- [00f4531c](https://github.com/stashed/elasticsearch/commit/00f4531c) Prepare for release 7.3.2-v26 (#1398)
+- [0fe78ca7](https://github.com/stashed/elasticsearch/commit/0fe78ca7) [cherry-pick] Dump PVC storage information (#1379) (#1388)
+
+
+### [7.14.0-v12](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v12)
+
+- [ef0141a2](https://github.com/stashed/elasticsearch/commit/ef0141a2) Prepare for release 7.14.0-v12 (#1396)
+- [690cda8e](https://github.com/stashed/elasticsearch/commit/690cda8e) [cherry-pick] Dump PVC storage information (#1379) (#1386)
+
+
+### [8.2.0-v9](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v9)
+
+- [7a3ae1ac](https://github.com/stashed/elasticsearch/commit/7a3ae1ac) Prepare for release 8.2.0-v9 (#1399)
+- [0d2956d2](https://github.com/stashed/elasticsearch/commit/0d2956d2) [cherry-pick] Dump PVC storage information (#1379) (#1389)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.30.0](https://github.com/stashed/enterprise/releases/tag/v0.30.0)
+
+- [6cd51d79](https://github.com/stashed/enterprise/commit/6cd51d79d) Prepare for release v0.30.0 (#234)
+- [8f260c6e](https://github.com/stashed/enterprise/commit/8f260c6ea) Add InterimVolume storage request calculator for Elasticsearch Backup (#230)
+- [e5e2d9a2](https://github.com/stashed/enterprise/commit/e5e2d9a2e) Add repository name as prefix to mount path of NFS volume accessor (#232)
+- [4ec5bc18](https://github.com/stashed/enterprise/commit/4ec5bc18d) Fix Cronjob name generation + Cleanup skipped BackupSessions (#233)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v13](https://github.com/stashed/etcd/releases/tag/3.5.0-v13)
+
+- [568299a](https://github.com/stashed/etcd/commit/568299a) Prepare for release 3.5.0-v13 (#79)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.05.31](https://github.com/stashed/installer/releases/tag/v2023.05.31)
+
+- [09d9471d](https://github.com/stashed/installer/commit/09d9471d) Prepare for release v2023.05.31 (#304)
+- [9c733919](https://github.com/stashed/installer/commit/9c733919) Add Cluster role permissions for elasticsearch (#303)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v9](https://github.com/stashed/kubedump/releases/tag/0.1.0-v9)
+
+- [ef8f697](https://github.com/stashed/kubedump/commit/ef8f697) Prepare for release 0.1.0-v9 (#39)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v19](https://github.com/stashed/mariadb/releases/tag/10.5.8-v19)
+
+- [2fcc724](https://github.com/stashed/mariadb/commit/2fcc724) Prepare for release 10.5.8-v19 (#222)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v26](https://github.com/stashed/mongodb/releases/tag/3.4.17-v26)
+
+- [77efc24c](https://github.com/stashed/mongodb/commit/77efc24c) Prepare for release 3.4.17-v26 (#1835)
+- [335f1787](https://github.com/stashed/mongodb/commit/335f1787) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1821)
+- [e0ea3df6](https://github.com/stashed/mongodb/commit/e0ea3df6) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1807)
+
+
+### [3.4.22-v26](https://github.com/stashed/mongodb/releases/tag/3.4.22-v26)
+
+- [0ee2f542](https://github.com/stashed/mongodb/commit/0ee2f542) Prepare for release 3.4.22-v26 (#1836)
+- [5a1b61b7](https://github.com/stashed/mongodb/commit/5a1b61b7) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1822)
+- [47b66a8b](https://github.com/stashed/mongodb/commit/47b66a8b) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1808)
+
+
+### [3.6.8-v26](https://github.com/stashed/mongodb/releases/tag/3.6.8-v26)
+
+- [93b25a8a](https://github.com/stashed/mongodb/commit/93b25a8a) Prepare for release 3.6.8-v26 (#1838)
+- [f4cc733b](https://github.com/stashed/mongodb/commit/f4cc733b) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1824)
+- [7ac0f9e6](https://github.com/stashed/mongodb/commit/7ac0f9e6) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1810)
+
+
+### [3.6.13-v26](https://github.com/stashed/mongodb/releases/tag/3.6.13-v26)
+
+- [865035f5](https://github.com/stashed/mongodb/commit/865035f5) Prepare for release 3.6.13-v26 (#1837)
+- [cfd53930](https://github.com/stashed/mongodb/commit/cfd53930) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1823)
+- [4fba330b](https://github.com/stashed/mongodb/commit/4fba330b) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1809)
+
+
+### [4.0.3-v26](https://github.com/stashed/mongodb/releases/tag/4.0.3-v26)
+
+- [0b50a887](https://github.com/stashed/mongodb/commit/0b50a887) Prepare for release 4.0.3-v26 (#1840)
+- [ce72f08f](https://github.com/stashed/mongodb/commit/ce72f08f) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1826)
+- [33e82e40](https://github.com/stashed/mongodb/commit/33e82e40) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1812)
+
+
+### [4.0.5-v26](https://github.com/stashed/mongodb/releases/tag/4.0.5-v26)
+
+- [72beb293](https://github.com/stashed/mongodb/commit/72beb293) Prepare for release 4.0.5-v26 (#1841)
+- [a5d36c8b](https://github.com/stashed/mongodb/commit/a5d36c8b) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1827)
+- [71a355d8](https://github.com/stashed/mongodb/commit/71a355d8) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1813)
+
+
+### [4.0.11-v26](https://github.com/stashed/mongodb/releases/tag/4.0.11-v26)
+
+- [0e2d6ab8](https://github.com/stashed/mongodb/commit/0e2d6ab8) Prepare for release 4.0.11-v26 (#1839)
+- [865f8e31](https://github.com/stashed/mongodb/commit/865f8e31) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1825)
+- [d2b19dc9](https://github.com/stashed/mongodb/commit/d2b19dc9) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1811)
+
+
+### [4.1.4-v26](https://github.com/stashed/mongodb/releases/tag/4.1.4-v26)
+
+- [c9214b93](https://github.com/stashed/mongodb/commit/c9214b93) Prepare for release 4.1.4-v26 (#1843)
+- [9122435f](https://github.com/stashed/mongodb/commit/9122435f) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1829)
+- [8a9b3dc1](https://github.com/stashed/mongodb/commit/8a9b3dc1) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1815)
+- [6d1afa77](https://github.com/stashed/mongodb/commit/6d1afa77) Prepare for release 4.1.4-v25 (#1804)
+
+
+### [4.1.7-v26](https://github.com/stashed/mongodb/releases/tag/4.1.7-v26)
+
+- [d123975b](https://github.com/stashed/mongodb/commit/d123975b) Prepare for release 4.1.7-v26 (#1844)
+- [e5ac3e0d](https://github.com/stashed/mongodb/commit/e5ac3e0d) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1830)
+- [bc5c567f](https://github.com/stashed/mongodb/commit/bc5c567f) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1816)
+
+
+### [4.1.13-v26](https://github.com/stashed/mongodb/releases/tag/4.1.13-v26)
+
+- [26420e41](https://github.com/stashed/mongodb/commit/26420e41) Prepare for release 4.1.13-v26 (#1842)
+- [230e572d](https://github.com/stashed/mongodb/commit/230e572d) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1828)
+- [b9ca59ca](https://github.com/stashed/mongodb/commit/b9ca59ca) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1814)
+
+
+### [4.2.3-v26](https://github.com/stashed/mongodb/releases/tag/4.2.3-v26)
+
+- [df7ae46f](https://github.com/stashed/mongodb/commit/df7ae46f) Prepare for release 4.2.3-v26 (#1845)
+- [fe6d98d3](https://github.com/stashed/mongodb/commit/fe6d98d3) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1831)
+- [eb2bf583](https://github.com/stashed/mongodb/commit/eb2bf583) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1817)
+
+
+### [4.4.6-v17](https://github.com/stashed/mongodb/releases/tag/4.4.6-v17)
+
+- [3c0aa2fe](https://github.com/stashed/mongodb/commit/3c0aa2fe) Prepare for release 4.4.6-v17 (#1846)
+- [c58fa36e](https://github.com/stashed/mongodb/commit/c58fa36e) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1832)
+- [a2c61f59](https://github.com/stashed/mongodb/commit/a2c61f59) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1818)
+
+
+### [5.0.3-v14](https://github.com/stashed/mongodb/releases/tag/5.0.3-v14)
+
+- [d4c4a484](https://github.com/stashed/mongodb/commit/d4c4a484) Prepare for release 5.0.3-v14 (#1847)
+- [525adda1](https://github.com/stashed/mongodb/commit/525adda1) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1833)
+- [ec116a61](https://github.com/stashed/mongodb/commit/ec116a61) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1819)
+- [6e6859ad](https://github.com/stashed/mongodb/commit/6e6859ad) Fix backup for mongodb 5.0.x
+
+
+### [6.0.5-v2](https://github.com/stashed/mongodb/releases/tag/6.0.5-v2)
+
+- [8286bbb8](https://github.com/stashed/mongodb/commit/8286bbb8) Prepare for release 6.0.5-v2 (#1848)
+- [fc9befad](https://github.com/stashed/mongodb/commit/fc9befad) [cherry-pick] Fix component status updating for shard backup and restore (#1806) (#1834)
+- [82e162a7](https://github.com/stashed/mongodb/commit/82e162a7) [cherry-pick] Fix Backup and Restore for TLS enabled mongo (#1805) (#1820)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v26](https://github.com/stashed/mysql/releases/tag/5.7.25-v26)
+
+- [f4e24f08](https://github.com/stashed/mysql/commit/f4e24f08) Prepare for release 5.7.25-v26 (#706)
+
+
+### [8.0.3-v26](https://github.com/stashed/mysql/releases/tag/8.0.3-v26)
+
+- [c57db948](https://github.com/stashed/mysql/commit/c57db948) Prepare for release 8.0.3-v26 (#709)
+
+
+### [8.0.14-v26](https://github.com/stashed/mysql/releases/tag/8.0.14-v26)
+
+- [713feadb](https://github.com/stashed/mysql/commit/713feadb) Prepare for release 8.0.14-v26 (#707)
+
+
+### [8.0.21-v20](https://github.com/stashed/mysql/releases/tag/8.0.21-v20)
+
+- [23c7c8b8](https://github.com/stashed/mysql/commit/23c7c8b8) Prepare for release 8.0.21-v20 (#708)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v14](https://github.com/stashed/nats/releases/tag/2.6.1-v14)
+
+- [1c05a39](https://github.com/stashed/nats/commit/1c05a39) Prepare for release 2.6.1-v14 (#103)
+
+
+### [2.8.2-v9](https://github.com/stashed/nats/releases/tag/2.8.2-v9)
+
+- [167a172](https://github.com/stashed/nats/commit/167a172) Prepare for release 2.8.2-v9 (#104)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v21](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v21)
+
+- [c3b32c76](https://github.com/stashed/percona-xtradb/commit/c3b32c76) Prepare for release 5.7-v21 (#292)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v25](https://github.com/stashed/postgres/releases/tag/9.6.19-v25)
+
+- [95fbec26](https://github.com/stashed/postgres/commit/95fbec26) Prepare for release 9.6.19-v25 (#1198)
+
+
+### [10.14-v25](https://github.com/stashed/postgres/releases/tag/10.14-v25)
+
+- [0c104a8b](https://github.com/stashed/postgres/commit/0c104a8b) Prepare for release 10.14-v25 (#1192)
+
+
+### [11.9-v25](https://github.com/stashed/postgres/releases/tag/11.9-v25)
+
+- [dc1ea0d4](https://github.com/stashed/postgres/commit/dc1ea0d4) Prepare for release 11.9-v25 (#1193)
+
+
+### [12.4-v25](https://github.com/stashed/postgres/releases/tag/12.4-v25)
+
+- [b45471ce](https://github.com/stashed/postgres/commit/b45471ce) Prepare for release 12.4-v25 (#1194)
+
+
+### [13.1-v22](https://github.com/stashed/postgres/releases/tag/13.1-v22)
+
+- [b89e2d73](https://github.com/stashed/postgres/commit/b89e2d73) Prepare for release 13.1-v22 (#1195)
+
+
+### [14.0-v14](https://github.com/stashed/postgres/releases/tag/14.0-v14)
+
+- [57782aec](https://github.com/stashed/postgres/commit/57782aec) Prepare for release 14.0-v14 (#1196)
+
+
+### [15.1-v6](https://github.com/stashed/postgres/releases/tag/15.1-v6)
+
+- [4f3ecc41](https://github.com/stashed/postgres/commit/4f3ecc41) Prepare for release 15.1-v6 (#1197)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v14](https://github.com/stashed/redis/releases/tag/5.0.13-v14)
+
+- [0a38067](https://github.com/stashed/redis/commit/0a38067) Prepare for release 5.0.13-v14 (#176)
+- [f40f32c](https://github.com/stashed/redis/commit/f40f32c) [cherry-pick] Add Insecure TLS verify (#172) (#173)
+
+
+### [6.2.5-v14](https://github.com/stashed/redis/releases/tag/6.2.5-v14)
+
+- [704e687](https://github.com/stashed/redis/commit/704e687) Prepare for release 6.2.5-v14 (#177)
+- [f708927](https://github.com/stashed/redis/commit/f708927) [cherry-pick] Add Insecure TLS verify (#172) (#174)
+
+
+### [7.0.5-v7](https://github.com/stashed/redis/releases/tag/7.0.5-v7)
+
+- [20c3604](https://github.com/stashed/redis/commit/20c3604) Prepare for release 7.0.5-v7 (#178)
+- [b4f6d5f](https://github.com/stashed/redis/commit/b4f6d5f) [cherry-pick] Add Insecure TLS verify (#172) (#175)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.30.0](https://github.com/stashed/stash/releases/tag/v0.30.0)
+
+- [e465af2f](https://github.com/stashed/stash/commit/e465af2fc) Prepare for release v0.30.0 (#1527)
+- [3aa466cb](https://github.com/stashed/stash/commit/3aa466cb7) Update deps
+- [929d1f53](https://github.com/stashed/stash/commit/929d1f535) Fix Cronjob name generation + Cleanup skipped BackupSession (#1525)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.12.0](https://github.com/stashed/ui-server/releases/tag/v0.12.0)
+
+- [785f737](https://github.com/stashed/ui-server/commit/785f737) Prepare for release v0.12.0 (#27)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v6](https://github.com/stashed/vault/releases/tag/1.10.3-v6)
+
+- [336f14a2](https://github.com/stashed/vault/commit/336f14a2) Prepare for release 1.10.3-v6 (#17)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.05.31
Release-tracker: https://github.com/stashed/CHANGELOG/pull/66
Signed-off-by: 1gtm <1gtm@appscode.com>