### PR TITLE
Prepare for release v2023.10.9

### DIFF
--- a/docs/CHANGELOG-v2023.10.9.md
+++ b/docs/CHANGELOG-v2023.10.9.md
@@ -1,0 +1,374 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2023.10.9
+    name: Changelog-v2023.10.9
+    parent: welcome
+    weight: 20231009
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.10.9/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.10.9/
+---
+
+# Stash v2023.10.9 (2023-10-04)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.32.0](https://github.com/stashed/apimachinery/releases/tag/v0.32.0)
+
+- [47e563c6](https://github.com/stashed/apimachinery/commit/47e563c6) Update deps
+- [741d0149](https://github.com/stashed/apimachinery/commit/741d0149) Add restic methods for managing restic keys (#211)
+- [3eb3dc0d](https://github.com/stashed/apimachinery/commit/3eb3dc0d) Add  new hookExecutionPolicy `OnFinalRetryFailure` (#210)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.32.0](https://github.com/stashed/cli/releases/tag/v0.32.0)
+
+- [575a83da](https://github.com/stashed/cli/commit/575a83da) Prepare for release v0.32.0 (#190)
+- [a5706148](https://github.com/stashed/cli/commit/a5706148) Add commands for generating restore rules and managing restic keys (#189)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v28](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v28)
+
+- [a8d57072](https://github.com/stashed/elasticsearch/commit/a8d57072) Prepare for release 5.6.4-v28 (#1434)
+
+
+### [6.2.4-v28](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v28)
+
+- [7dbca84a](https://github.com/stashed/elasticsearch/commit/7dbca84a) Prepare for release 6.2.4-v28 (#1435)
+
+
+### [6.3.0-v28](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v28)
+
+- [a9ece1ec](https://github.com/stashed/elasticsearch/commit/a9ece1ec) Prepare for release 6.3.0-v28 (#1436)
+
+
+### [6.4.0-v28](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v28)
+
+- [8b4ab388](https://github.com/stashed/elasticsearch/commit/8b4ab388) Prepare for release 6.4.0-v28 (#1437)
+
+
+### [6.5.3-v28](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v28)
+
+- [082ca286](https://github.com/stashed/elasticsearch/commit/082ca286) Prepare for release 6.5.3-v28 (#1438)
+
+
+### [6.8.0-v28](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v28)
+
+- [84e1ee57](https://github.com/stashed/elasticsearch/commit/84e1ee57) Prepare for release 6.8.0-v28 (#1439)
+
+
+### [7.2.0-v28](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v28)
+
+- [3e6a708f](https://github.com/stashed/elasticsearch/commit/3e6a708f) Prepare for release 7.2.0-v28 (#1441)
+
+
+### [7.3.2-v28](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v28)
+
+- [9249eefe](https://github.com/stashed/elasticsearch/commit/9249eefe) Prepare for release 7.3.2-v28 (#1442)
+
+
+### [7.14.0-v14](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v14)
+
+- [91ad7fe5](https://github.com/stashed/elasticsearch/commit/91ad7fe5) Prepare for release 7.14.0-v14 (#1440)
+
+
+### [8.2.0-v11](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v11)
+
+- [8142ea6d](https://github.com/stashed/elasticsearch/commit/8142ea6d) Prepare for release 8.2.0-v11 (#1443)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.32.0](https://github.com/stashed/enterprise/releases/tag/v0.32.0)
+
+- [433789a4](https://github.com/stashed/enterprise/commit/433789a4c) Prepare for release v0.32.0 (#240)
+- [149f81cc](https://github.com/stashed/enterprise/commit/149f81cc2) Add commands for managing restic passwords + Update snapshot download directory  (#239)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v15](https://github.com/stashed/etcd/releases/tag/3.5.0-v15)
+
+- [47078d2](https://github.com/stashed/etcd/commit/47078d2) Prepare for release 3.5.0-v15 (#83)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2023.10.9](https://github.com/stashed/installer/releases/tag/v2023.10.9)
+
+- [7bd4fbf5](https://github.com/stashed/installer/commit/7bd4fbf5) Prepare for release v2023.10.9 (#321)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v11](https://github.com/stashed/kubedump/releases/tag/0.1.0-v11)
+
+- [f4af197](https://github.com/stashed/kubedump/commit/f4af197) Prepare for release 0.1.0-v11 (#47)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v21](https://github.com/stashed/mariadb/releases/tag/10.5.8-v21)
+
+- [8a94399](https://github.com/stashed/mariadb/commit/8a94399) Prepare for release 10.5.8-v21 (#230)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v28](https://github.com/stashed/mongodb/releases/tag/3.4.17-v28)
+
+- [bcf4a647](https://github.com/stashed/mongodb/commit/bcf4a647) Prepare for release 3.4.17-v28 (#1976)
+- [66d02849](https://github.com/stashed/mongodb/commit/66d02849) Unlock and sync secondary (#1973)
+- [8d14efa5](https://github.com/stashed/mongodb/commit/8d14efa5) Add support for restoring specific snapshot (#1927) (#1947)
+- [cb8f9ff8](https://github.com/stashed/mongodb/commit/cb8f9ff8) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1930)
+
+
+### [3.4.22-v28](https://github.com/stashed/mongodb/releases/tag/3.4.22-v28)
+
+- [65bf1bd4](https://github.com/stashed/mongodb/commit/65bf1bd4) Prepare for release 3.4.22-v28 (#1977)
+- [7f588f23](https://github.com/stashed/mongodb/commit/7f588f23) Unlock and sync secondary (#1972)
+- [704053fb](https://github.com/stashed/mongodb/commit/704053fb) Add support for restoring specific snapshot (#1927) (#1948)
+- [fad11e0b](https://github.com/stashed/mongodb/commit/fad11e0b) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1931)
+
+
+### [3.6.8-v28](https://github.com/stashed/mongodb/releases/tag/3.6.8-v28)
+
+- [64352461](https://github.com/stashed/mongodb/commit/64352461) Prepare for release 3.6.8-v28 (#1979)
+- [f28e5990](https://github.com/stashed/mongodb/commit/f28e5990) Unlock and sync secondary (#1969)
+- [58e82130](https://github.com/stashed/mongodb/commit/58e82130) Add support for restoring specific snapshot (#1927) (#1950)
+- [e594e6ef](https://github.com/stashed/mongodb/commit/e594e6ef) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1933)
+
+
+### [3.6.13-v28](https://github.com/stashed/mongodb/releases/tag/3.6.13-v28)
+
+- [3da732da](https://github.com/stashed/mongodb/commit/3da732da) Prepare for release 3.6.13-v28 (#1978)
+- [3e032a81](https://github.com/stashed/mongodb/commit/3e032a81) Unlock and sync secondary (#1970)
+- [4cca80c3](https://github.com/stashed/mongodb/commit/4cca80c3) Add support for restoring specific snapshot (#1927) (#1949)
+- [18c43f7e](https://github.com/stashed/mongodb/commit/18c43f7e) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1932)
+
+
+### [4.0.3-v28](https://github.com/stashed/mongodb/releases/tag/4.0.3-v28)
+
+- [ed7e2a5f](https://github.com/stashed/mongodb/commit/ed7e2a5f) Prepare for release 4.0.3-v28 (#1981)
+- [3340ae34](https://github.com/stashed/mongodb/commit/3340ae34) Unlock and sync secondary (#1971)
+- [26f42032](https://github.com/stashed/mongodb/commit/26f42032) Add support for restoring specific snapshot (#1927) (#1952)
+- [f16cbfba](https://github.com/stashed/mongodb/commit/f16cbfba) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1935)
+
+
+### [4.0.5-v28](https://github.com/stashed/mongodb/releases/tag/4.0.5-v28)
+
+- [7d29cfa8](https://github.com/stashed/mongodb/commit/7d29cfa8) Prepare for release 4.0.5-v28 (#1982)
+- [d0461920](https://github.com/stashed/mongodb/commit/d0461920) Unlock and sync secondary (#1974)
+- [2eeec3ba](https://github.com/stashed/mongodb/commit/2eeec3ba) Add support for restoring specific snapshot (#1927) (#1953)
+- [4efc8bff](https://github.com/stashed/mongodb/commit/4efc8bff) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1936)
+
+
+### [4.0.11-v28](https://github.com/stashed/mongodb/releases/tag/4.0.11-v28)
+
+- [9891070f](https://github.com/stashed/mongodb/commit/9891070f) Prepare for release 4.0.11-v28 (#1980)
+- [37bfb091](https://github.com/stashed/mongodb/commit/37bfb091) unlock and sync secondary (#1975)
+- [53244213](https://github.com/stashed/mongodb/commit/53244213) Add support for restoring specific snapshot (#1927) (#1951)
+- [c61568dd](https://github.com/stashed/mongodb/commit/c61568dd) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1934)
+
+
+### [4.1.4-v28](https://github.com/stashed/mongodb/releases/tag/4.1.4-v28)
+
+- [90543078](https://github.com/stashed/mongodb/commit/90543078) Prepare for release 4.1.4-v28 (#1984)
+- [62d36ac9](https://github.com/stashed/mongodb/commit/62d36ac9) Unlock and sync secondary (#1965)
+- [11c75f06](https://github.com/stashed/mongodb/commit/11c75f06) Add support for restoring specific snapshot (#1927) (#1955)
+- [16475896](https://github.com/stashed/mongodb/commit/16475896) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1938)
+
+
+### [4.1.7-v28](https://github.com/stashed/mongodb/releases/tag/4.1.7-v28)
+
+- [ad96467e](https://github.com/stashed/mongodb/commit/ad96467e) Prepare for release 4.1.7-v28 (#1985)
+- [fe5de7da](https://github.com/stashed/mongodb/commit/fe5de7da) Unlock and sync secondary (#1966)
+- [d2810a49](https://github.com/stashed/mongodb/commit/d2810a49) Add support for restoring specific snapshot (#1927) (#1956)
+- [209aaa40](https://github.com/stashed/mongodb/commit/209aaa40) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1939)
+
+
+### [4.1.13-v28](https://github.com/stashed/mongodb/releases/tag/4.1.13-v28)
+
+- [26289363](https://github.com/stashed/mongodb/commit/26289363) Prepare for release 4.1.13-v28 (#1983)
+- [a529618c](https://github.com/stashed/mongodb/commit/a529618c) Unlock and sync secondary (#1967)
+- [c2de7995](https://github.com/stashed/mongodb/commit/c2de7995) Add support for restoring specific snapshot (#1927) (#1954)
+- [c3118596](https://github.com/stashed/mongodb/commit/c3118596) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1937)
+
+
+### [4.2.3-v28](https://github.com/stashed/mongodb/releases/tag/4.2.3-v28)
+
+- [d716d870](https://github.com/stashed/mongodb/commit/d716d870) Prepare for release 4.2.3-v28 (#1987)
+- [5b708249](https://github.com/stashed/mongodb/commit/5b708249) Unlock and sync secondary (#1968)
+- [89798c12](https://github.com/stashed/mongodb/commit/89798c12) Add support for restoring specific snapshot (#1927) (#1957)
+- [3e23f106](https://github.com/stashed/mongodb/commit/3e23f106) [cherry-pick] Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1940)
+
+
+### [4.4.6-v19](https://github.com/stashed/mongodb/releases/tag/4.4.6-v19)
+
+- [aba61b85](https://github.com/stashed/mongodb/commit/aba61b85) Prepare for release 4.4.6-v19 (#1988)
+- [34ab90b8](https://github.com/stashed/mongodb/commit/34ab90b8) Unlock and sync secondary hosts (#1945)
+- [68c8b8c8](https://github.com/stashed/mongodb/commit/68c8b8c8) Add support for restoring specific snapshot (#1927) (#1958)
+- [476c6063](https://github.com/stashed/mongodb/commit/476c6063) Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1941)
+- [a8474619](https://github.com/stashed/mongodb/commit/a8474619) Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1928)
+
+
+### [5.0.3-v16](https://github.com/stashed/mongodb/releases/tag/5.0.3-v16)
+
+- [8f480622](https://github.com/stashed/mongodb/commit/8f480622) Prepare for release 5.0.3-v16 (#1990)
+- [70f9d538](https://github.com/stashed/mongodb/commit/70f9d538) Unlock and sync secondary (#1964)
+- [be10f0b2](https://github.com/stashed/mongodb/commit/be10f0b2) Add support for restoring specific snapshot (#1927) (#1960)
+- [147be12d](https://github.com/stashed/mongodb/commit/147be12d) Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1943)
+
+
+### [5.0.15-v1](https://github.com/stashed/mongodb/releases/tag/5.0.15-v1)
+
+- [070dc6c6](https://github.com/stashed/mongodb/commit/070dc6c6) Prepare for release 5.0.15-v1 (#1989)
+- [95f520db](https://github.com/stashed/mongodb/commit/95f520db) Unlock and sync secondary (#1963)
+- [ff442bc0](https://github.com/stashed/mongodb/commit/ff442bc0) Add support for restoring specific snapshot (#1927) (#1959)
+- [f4bed984](https://github.com/stashed/mongodb/commit/f4bed984) Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1942)
+
+
+### [6.0.5-v4](https://github.com/stashed/mongodb/releases/tag/6.0.5-v4)
+
+- [093dcce3](https://github.com/stashed/mongodb/commit/093dcce3) Prepare for release 6.0.5-v4 (#1991)
+- [b20054bc](https://github.com/stashed/mongodb/commit/b20054bc) Unlock and sync secondary (#1962)
+- [f9357173](https://github.com/stashed/mongodb/commit/f9357173) Add support for restoring specific snapshot (#1927) (#1961)
+- [5f2f88ea](https://github.com/stashed/mongodb/commit/5f2f88ea) Add stopBalancer timeout; Retry setBalancerState; Improve logging (#1929) (#1944)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v28](https://github.com/stashed/mysql/releases/tag/5.7.25-v28)
+
+- [e8925996](https://github.com/stashed/mysql/commit/e8925996) Prepare for release 5.7.25-v28 (#727)
+
+
+### [8.0.3-v28](https://github.com/stashed/mysql/releases/tag/8.0.3-v28)
+
+- [00672e31](https://github.com/stashed/mysql/commit/00672e31) Prepare for release 8.0.3-v28 (#730)
+
+
+### [8.0.14-v28](https://github.com/stashed/mysql/releases/tag/8.0.14-v28)
+
+- [a7c4579f](https://github.com/stashed/mysql/commit/a7c4579f) Prepare for release 8.0.14-v28 (#728)
+
+
+### [8.0.21-v22](https://github.com/stashed/mysql/releases/tag/8.0.21-v22)
+
+- [2c21d225](https://github.com/stashed/mysql/commit/2c21d225) Prepare for release 8.0.21-v22 (#729)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v16](https://github.com/stashed/nats/releases/tag/2.6.1-v16)
+
+- [fb04742](https://github.com/stashed/nats/commit/fb04742) Prepare for release 2.6.1-v16 (#117)
+
+
+### [2.8.2-v11](https://github.com/stashed/nats/releases/tag/2.8.2-v11)
+
+- [535e051](https://github.com/stashed/nats/commit/535e051) Prepare for release 2.8.2-v11 (#118)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v23](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v23)
+
+- [54009c23](https://github.com/stashed/percona-xtradb/commit/54009c23) Prepare for release 5.7-v23 (#300)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v27](https://github.com/stashed/postgres/releases/tag/9.6.19-v27)
+
+- [c8aa8598](https://github.com/stashed/postgres/commit/c8aa8598) Prepare for release 9.6.19-v27 (#1230)
+
+
+### [10.14-v27](https://github.com/stashed/postgres/releases/tag/10.14-v27)
+
+- [3a7ba3fa](https://github.com/stashed/postgres/commit/3a7ba3fa) Prepare for release 10.14-v27 (#1224)
+
+
+### [11.9-v27](https://github.com/stashed/postgres/releases/tag/11.9-v27)
+
+- [b8bb39e3](https://github.com/stashed/postgres/commit/b8bb39e3) Prepare for release 11.9-v27 (#1225)
+
+
+### [12.4-v27](https://github.com/stashed/postgres/releases/tag/12.4-v27)
+
+- [fb6b2835](https://github.com/stashed/postgres/commit/fb6b2835) Prepare for release 12.4-v27 (#1226)
+
+
+### [13.1-v24](https://github.com/stashed/postgres/releases/tag/13.1-v24)
+
+- [3e815eba](https://github.com/stashed/postgres/commit/3e815eba) Prepare for release 13.1-v24 (#1227)
+
+
+### [14.0-v16](https://github.com/stashed/postgres/releases/tag/14.0-v16)
+
+- [7183205b](https://github.com/stashed/postgres/commit/7183205b) Prepare for release 14.0-v16 (#1228)
+
+
+### [15.1-v8](https://github.com/stashed/postgres/releases/tag/15.1-v8)
+
+- [00deb5be](https://github.com/stashed/postgres/commit/00deb5be) Prepare for release 15.1-v8 (#1229)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v16](https://github.com/stashed/redis/releases/tag/5.0.13-v16)
+
+- [e267408](https://github.com/stashed/redis/commit/e267408) Prepare for release 5.0.13-v16 (#192)
+
+
+### [6.2.5-v16](https://github.com/stashed/redis/releases/tag/6.2.5-v16)
+
+- [f1e5414](https://github.com/stashed/redis/commit/f1e5414) Prepare for release 6.2.5-v16 (#193)
+
+
+### [7.0.5-v9](https://github.com/stashed/redis/releases/tag/7.0.5-v9)
+
+- [4e11289](https://github.com/stashed/redis/commit/4e11289) Prepare for release 7.0.5-v9 (#194)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.32.0](https://github.com/stashed/stash/releases/tag/v0.32.0)
+
+- [993671e7](https://github.com/stashed/stash/commit/993671e74) Prepare for release v0.32.0 (#1539)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v8](https://github.com/stashed/vault/releases/tag/1.10.3-v8)
+
+- [4b96de6a](https://github.com/stashed/vault/commit/4b96de6a) Prepare for release 1.10.3-v8 (#25)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.10.9
Release-tracker: https://github.com/stashed/CHANGELOG/pull/69
Signed-off-by: 1gtm <1gtm@appscode.com>