### PR TITLE
Prepare for release v2024.2.13

### DIFF
--- a/docs/CHANGELOG-v2024.2.13.md
+++ b/docs/CHANGELOG-v2024.2.13.md
@@ -1,0 +1,376 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2024.2.13
+    name: Changelog-v2024.2.13
+    parent: welcome
+    weight: 20240213
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.2.13/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.2.13/
+---
+
+# Stash v2024.2.13 (2024-02-14)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.33.0](https://github.com/stashed/apimachinery/releases/tag/v0.33.0)
+
+- [8624cbcb](https://github.com/stashed/apimachinery/commit/8624cbcb) Update deps
+- [999853f0](https://github.com/stashed/apimachinery/commit/999853f0) Fix flags
+- [a7373104](https://github.com/stashed/apimachinery/commit/a7373104) Update deps
+- [152e1d41](https://github.com/stashed/apimachinery/commit/152e1d41) Add support Disabling TLS Certificate Verification for Secure S3 Storage (#219)
+- [c604da62](https://github.com/stashed/apimachinery/commit/c604da62) Upsert task params (#218)
+- [a91ab94b](https://github.com/stashed/apimachinery/commit/a91ab94b) Update lint command (#217)
+- [ef308633](https://github.com/stashed/apimachinery/commit/ef308633) Fix linter
+- [6f5a8df2](https://github.com/stashed/apimachinery/commit/6f5a8df2) Use k8s 1.29 client libs (#215)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.33.0](https://github.com/stashed/cli/releases/tag/v0.33.0)
+
+- [2330558e](https://github.com/stashed/cli/commit/2330558e) Prepare for release v0.33.0 (#195)
+- [e9ef1060](https://github.com/stashed/cli/commit/e9ef1060) Prepare for release v0.33.0-rc.0 (#194)
+- [6bfaa69b](https://github.com/stashed/cli/commit/6bfaa69b) Update deps (#193)
+- [2fa9872b](https://github.com/stashed/cli/commit/2fa9872b) Use k8s 1.29 client libs (#192)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v30](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v30)
+
+- [0f3a558d](https://github.com/stashed/elasticsearch/commit/0f3a558d) Prepare for release 5.6.4-v30 (#1498)
+
+
+### [6.2.4-v30](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v30)
+
+- [0380f47c](https://github.com/stashed/elasticsearch/commit/0380f47c) Prepare for release 6.2.4-v30 (#1499)
+
+
+### [6.3.0-v30](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v30)
+
+- [92104224](https://github.com/stashed/elasticsearch/commit/92104224) Prepare for release 6.3.0-v30 (#1500)
+
+
+### [6.4.0-v30](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v30)
+
+- [6d8db1c3](https://github.com/stashed/elasticsearch/commit/6d8db1c3) Prepare for release 6.4.0-v30 (#1501)
+
+
+### [6.5.3-v30](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v30)
+
+- [967b0d5d](https://github.com/stashed/elasticsearch/commit/967b0d5d) Prepare for release 6.5.3-v30 (#1502)
+
+
+### [6.8.0-v30](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v30)
+
+- [b888ee9a](https://github.com/stashed/elasticsearch/commit/b888ee9a) Prepare for release 6.8.0-v30 (#1503)
+
+
+### [7.2.0-v30](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v30)
+
+- [b341edf1](https://github.com/stashed/elasticsearch/commit/b341edf1) Prepare for release 7.2.0-v30 (#1505)
+
+
+### [7.3.2-v30](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v30)
+
+- [fe59875e](https://github.com/stashed/elasticsearch/commit/fe59875e) Prepare for release 7.3.2-v30 (#1506)
+
+
+### [7.14.0-v16](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v16)
+
+- [f1b23a52](https://github.com/stashed/elasticsearch/commit/f1b23a52) Prepare for release 7.14.0-v16 (#1504)
+
+
+### [8.2.0-v13](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v13)
+
+- [99781148](https://github.com/stashed/elasticsearch/commit/99781148) Prepare for release 8.2.0-v13 (#1507)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.33.0](https://github.com/stashed/enterprise/releases/tag/v0.33.0)
+
+- [056fe40e](https://github.com/stashed/enterprise/commit/056fe40ea) Prepare for release v0.33.0 (#249)
+- [d00e48c4](https://github.com/stashed/enterprise/commit/d00e48c4c) Resolve Empty String Bug Across Different Storage Providers Excluding S3 (#248)
+- [926b5487](https://github.com/stashed/enterprise/commit/926b54873) Prepare for release v0.33.0-rc.0 (#247)
+- [728318a7](https://github.com/stashed/enterprise/commit/728318a76) Use external-snapshotter v7
+- [e187755d](https://github.com/stashed/enterprise/commit/e187755d7) Update deps (#246)
+- [b0ca48ec](https://github.com/stashed/enterprise/commit/b0ca48ecc) Add disabling TLS Certificate Verification support for Secure `S3` Storage (#245)
+- [8a257274](https://github.com/stashed/enterprise/commit/8a2572742) Add kibana dashboard backup and restore support (#244)
+- [0d77a340](https://github.com/stashed/enterprise/commit/0d77a3401) Fix eas
+- [af352f7e](https://github.com/stashed/enterprise/commit/af352f7e2) Update gendocs script
+- [cc95c59e](https://github.com/stashed/enterprise/commit/cc95c59ed) Configure openapi v3
+- [4fbde18f](https://github.com/stashed/enterprise/commit/4fbde18f1) Use k8s 1.29 client libs (#242)
+- [cd3342c0](https://github.com/stashed/enterprise/commit/cd3342c04) Send audit events hourly
+- [272590c6](https://github.com/stashed/enterprise/commit/272590c64) Update InterimVolume storage request calculator function name (#241)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v17](https://github.com/stashed/etcd/releases/tag/3.5.0-v17)
+
+- [e1609a4](https://github.com/stashed/etcd/commit/e1609a4) Prepare for release 3.5.0-v17 (#89)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2024.2.13](https://github.com/stashed/installer/releases/tag/v2024.2.13)
+
+- [2b363d9f](https://github.com/stashed/installer/commit/2b363d9f) Prepare for release v2024.2.13 (#329)
+- [56bd5380](https://github.com/stashed/installer/commit/56bd5380) Prepare for release v2024.2.9-rc.0 (#328)
+- [20c7b9a2](https://github.com/stashed/installer/commit/20c7b9a2) Add support Disabling TLS Certificate Verification for Secure S3 Storage (#326)
+- [c66f9803](https://github.com/stashed/installer/commit/c66f9803) Add dashboard backup and restore support (#325)
+- [f6f31321](https://github.com/stashed/installer/commit/f6f31321) Use k8s 1.29 client libs (#324)
+- [722af4d3](https://github.com/stashed/installer/commit/722af4d3) Check for image existence (#323)
+- [4ed53d44](https://github.com/stashed/installer/commit/4ed53d44) Update deps
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v13](https://github.com/stashed/kubedump/releases/tag/0.1.0-v13)
+
+- [f60b817](https://github.com/stashed/kubedump/commit/f60b817) Prepare for release 0.1.0-v13 (#57)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v24](https://github.com/stashed/mariadb/releases/tag/10.5.8-v24)
+
+- [caae4d31](https://github.com/stashed/mariadb/commit/caae4d31) Prepare for release 10.5.8-v24 (#240)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v30](https://github.com/stashed/mongodb/releases/tag/3.4.17-v30)
+
+- [5081c341](https://github.com/stashed/mongodb/commit/5081c341) Prepare for release 3.4.17-v30 (#2080)
+
+
+### [3.4.22-v30](https://github.com/stashed/mongodb/releases/tag/3.4.22-v30)
+
+- [f6207dac](https://github.com/stashed/mongodb/commit/f6207dac) Prepare for release 3.4.22-v30 (#2081)
+
+
+### [3.6.8-v30](https://github.com/stashed/mongodb/releases/tag/3.6.8-v30)
+
+- [2387f378](https://github.com/stashed/mongodb/commit/2387f378) Prepare for release 3.6.8-v30 (#2083)
+
+
+### [3.6.13-v30](https://github.com/stashed/mongodb/releases/tag/3.6.13-v30)
+
+- [61271bff](https://github.com/stashed/mongodb/commit/61271bff) Prepare for release 3.6.13-v30 (#2082)
+
+
+### [4.0.3-v30](https://github.com/stashed/mongodb/releases/tag/4.0.3-v30)
+
+- [f326d30a](https://github.com/stashed/mongodb/commit/f326d30a) Prepare for release 4.0.3-v30 (#2085)
+
+
+### [4.0.5-v30](https://github.com/stashed/mongodb/releases/tag/4.0.5-v30)
+
+- [7e96bbf7](https://github.com/stashed/mongodb/commit/7e96bbf7) Prepare for release 4.0.5-v30 (#2086)
+
+
+### [4.0.11-v30](https://github.com/stashed/mongodb/releases/tag/4.0.11-v30)
+
+- [44da1d6f](https://github.com/stashed/mongodb/commit/44da1d6f) Prepare for release 4.0.11-v30 (#2084)
+
+
+### [4.1.4-v30](https://github.com/stashed/mongodb/releases/tag/4.1.4-v30)
+
+- [2356a00a](https://github.com/stashed/mongodb/commit/2356a00a) Prepare for release 4.1.4-v30 (#2088)
+
+
+### [4.1.7-v30](https://github.com/stashed/mongodb/releases/tag/4.1.7-v30)
+
+- [bdaaef1d](https://github.com/stashed/mongodb/commit/bdaaef1d) Prepare for release 4.1.7-v30 (#2089)
+
+
+### [4.1.13-v30](https://github.com/stashed/mongodb/releases/tag/4.1.13-v30)
+
+- [5469bb49](https://github.com/stashed/mongodb/commit/5469bb49) Prepare for release 4.1.13-v30 (#2087)
+
+
+### [4.2.3-v30](https://github.com/stashed/mongodb/releases/tag/4.2.3-v30)
+
+- [2bc8be8a](https://github.com/stashed/mongodb/commit/2bc8be8a) Prepare for release 4.2.3-v30 (#2090)
+
+
+### [4.4.6-v21](https://github.com/stashed/mongodb/releases/tag/4.4.6-v21)
+
+- [809c73d8](https://github.com/stashed/mongodb/commit/809c73d8) Prepare for release 4.4.6-v21 (#2091)
+
+
+### [5.0.3-v18](https://github.com/stashed/mongodb/releases/tag/5.0.3-v18)
+
+- [8de25714](https://github.com/stashed/mongodb/commit/8de25714) Prepare for release 5.0.3-v18 (#2093)
+
+
+### [5.0.15-v3](https://github.com/stashed/mongodb/releases/tag/5.0.15-v3)
+
+- [bee01d90](https://github.com/stashed/mongodb/commit/bee01d90) Prepare for release 5.0.15-v3 (#2092)
+
+
+### [6.0.5-v6](https://github.com/stashed/mongodb/releases/tag/6.0.5-v6)
+
+- [fae938ce](https://github.com/stashed/mongodb/commit/fae938ce) Prepare for release 6.0.5-v6 (#2094)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v30](https://github.com/stashed/mysql/releases/tag/5.7.25-v30)
+
+- [b3aa034b](https://github.com/stashed/mysql/commit/b3aa034b) Prepare for release 5.7.25-v30 (#756)
+
+
+### [8.0.3-v30](https://github.com/stashed/mysql/releases/tag/8.0.3-v30)
+
+- [81c6d225](https://github.com/stashed/mysql/commit/81c6d225) Prepare for release 8.0.3-v30 (#759)
+
+
+### [8.0.14-v30](https://github.com/stashed/mysql/releases/tag/8.0.14-v30)
+
+- [d63e3687](https://github.com/stashed/mysql/commit/d63e3687) Prepare for release 8.0.14-v30 (#757)
+
+
+### [8.0.21-v24](https://github.com/stashed/mysql/releases/tag/8.0.21-v24)
+
+- [e3cf2123](https://github.com/stashed/mysql/commit/e3cf2123) Prepare for release 8.0.21-v24 (#758)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v18](https://github.com/stashed/nats/releases/tag/2.6.1-v18)
+
+- [f0bc785](https://github.com/stashed/nats/commit/f0bc785) Prepare for release 2.6.1-v18 (#132)
+
+
+### [2.8.2-v13](https://github.com/stashed/nats/releases/tag/2.8.2-v13)
+
+- [9e86ae7](https://github.com/stashed/nats/commit/9e86ae7) Prepare for release 2.8.2-v13 (#133)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v25](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v25)
+
+- [2890ead5](https://github.com/stashed/percona-xtradb/commit/2890ead5) Prepare for release 5.7-v25 (#312)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v29](https://github.com/stashed/postgres/releases/tag/9.6.19-v29)
+
+- [c52291e5](https://github.com/stashed/postgres/commit/c52291e5) Prepare for release 9.6.19-v29 (#1272)
+
+
+### [10.14-v29](https://github.com/stashed/postgres/releases/tag/10.14-v29)
+
+- [80a3c18f](https://github.com/stashed/postgres/commit/80a3c18f) Prepare for release 10.14-v29 (#1266)
+
+
+### [11.9-v29](https://github.com/stashed/postgres/releases/tag/11.9-v29)
+
+- [8df3672a](https://github.com/stashed/postgres/commit/8df3672a) Prepare for release 11.9-v29 (#1267)
+
+
+### [12.4-v29](https://github.com/stashed/postgres/releases/tag/12.4-v29)
+
+- [67373668](https://github.com/stashed/postgres/commit/67373668) Prepare for release 12.4-v29 (#1268)
+
+
+### [13.1-v26](https://github.com/stashed/postgres/releases/tag/13.1-v26)
+
+- [b058e4fc](https://github.com/stashed/postgres/commit/b058e4fc) Prepare for release 13.1-v26 (#1269)
+
+
+### [14.0-v18](https://github.com/stashed/postgres/releases/tag/14.0-v18)
+
+- [e4d8de36](https://github.com/stashed/postgres/commit/e4d8de36) Prepare for release 14.0-v18 (#1270)
+
+
+### [15.1-v10](https://github.com/stashed/postgres/releases/tag/15.1-v10)
+
+- [e1f30a46](https://github.com/stashed/postgres/commit/e1f30a46) Prepare for release 15.1-v10 (#1271)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v18](https://github.com/stashed/redis/releases/tag/5.0.13-v18)
+
+- [aa46891](https://github.com/stashed/redis/commit/aa46891) Prepare for release 5.0.13-v18 (#212)
+
+
+### [6.2.5-v18](https://github.com/stashed/redis/releases/tag/6.2.5-v18)
+
+- [96a6d0f](https://github.com/stashed/redis/commit/96a6d0f) Prepare for release 6.2.5-v18 (#213)
+
+
+### [7.0.5-v11](https://github.com/stashed/redis/releases/tag/7.0.5-v11)
+
+- [9902062](https://github.com/stashed/redis/commit/9902062) Prepare for release 7.0.5-v11 (#214)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.33.0](https://github.com/stashed/stash/releases/tag/v0.33.0)
+
+- [8f76d737](https://github.com/stashed/stash/commit/8f76d7376) Prepare for release v0.33.0 (#1558)
+- [b0ecb486](https://github.com/stashed/stash/commit/b0ecb486c) Resolve Empty String Bug Across Different Storage Providers Excluding `S3` (#1557)
+- [8cb8f6f6](https://github.com/stashed/stash/commit/8cb8f6f6d) Fix webhook server
+- [4bd38bd4](https://github.com/stashed/stash/commit/4bd38bd45) Prepare for release v0.33.0-rc.0 (#1556)
+- [2d785965](https://github.com/stashed/stash/commit/2d7859658) Use external-snapshotter/v7
+- [c221c378](https://github.com/stashed/stash/commit/c221c3789) Update deps (#1555)
+- [8fa0835d](https://github.com/stashed/stash/commit/8fa0835de) Add disabling TLS Certificate Verification support for Secure S3 Storage (#1554)
+- [6d5ad36a](https://github.com/stashed/stash/commit/6d5ad36a8) Fix eas
+- [dc70cedd](https://github.com/stashed/stash/commit/dc70cedd9) Update gendocs script
+- [86fb04f8](https://github.com/stashed/stash/commit/86fb04f87) Configure openapi v3 (#1551)
+- [2b252fac](https://github.com/stashed/stash/commit/2b252fac5) Use k8s 1.29 client libs (#1550)
+- [620a6236](https://github.com/stashed/stash/commit/620a6236b) Use k8s 1.29 client libs (#1547)
+- [01bdb47d](https://github.com/stashed/stash/commit/01bdb47d4) Send audit events hourly
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.14.0](https://github.com/stashed/ui-server/releases/tag/v0.14.0)
+
+- [9e9d2512](https://github.com/stashed/ui-server/commit/9e9d2512) Prepare for release v0.14.0 (#36)
+- [2473d4b9](https://github.com/stashed/ui-server/commit/2473d4b9) Configure openapi v3 (#35)
+- [4622b7bd](https://github.com/stashed/ui-server/commit/4622b7bd) Prepare for release v0.14.0-rc.0 (#34)
+- [0ad06c75](https://github.com/stashed/ui-server/commit/0ad06c75) Update deps (#33)
+- [e44a14af](https://github.com/stashed/ui-server/commit/e44a14af) Use k8s 1.29 client libs (#32)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v10](https://github.com/stashed/vault/releases/tag/1.10.3-v10)
+
+- [53f85d89](https://github.com/stashed/vault/commit/53f85d89) Prepare for release 1.10.3-v10 (#33)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.2.13
Release-tracker: https://github.com/stashed/CHANGELOG/pull/71
Signed-off-by: 1gtm <1gtm@appscode.com>