### PR TITLE
Prepare for release v2024.4.8

### DIFF
--- a/docs/CHANGELOG-v2024.4.8.md
+++ b/docs/CHANGELOG-v2024.4.8.md
@@ -1,0 +1,434 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2024.4.8
+    name: Changelog-v2024.4.8
+    parent: welcome
+    weight: 20240408
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.4.8/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.4.8/
+---
+
+# Stash v2024.4.8 (2024-04-09)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.34.0](https://github.com/stashed/apimachinery/releases/tag/v0.34.0)
+
+- [be710277](https://github.com/stashed/apimachinery/commit/be710277) Use Go 1.22 (#221)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.34.0](https://github.com/stashed/cli/releases/tag/v0.34.0)
+
+- [3a2104b6](https://github.com/stashed/cli/commit/3a2104b6) Prepare for release v0.34.0 (#200)
+- [97c3c9dc](https://github.com/stashed/cli/commit/97c3c9dc) Use Go 1.22 (#199)
+- [57359de6](https://github.com/stashed/cli/commit/57359de6) Use Go 1.22 (#198)
+- [cc9996a7](https://github.com/stashed/cli/commit/cc9996a7) Update external snapshotter deps v4 to v7 (#197)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v31](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v31)
+
+- [9b4eb820](https://github.com/stashed/elasticsearch/commit/9b4eb820) Prepare for release 5.6.4-v31 (#1532)
+- [64d18cf3](https://github.com/stashed/elasticsearch/commit/64d18cf3) [cherry-pick] Use Go 1.22 (#1521) (#1522)
+- [d1ea4dc7](https://github.com/stashed/elasticsearch/commit/d1ea4dc7) [cherry-pick] Use Go 1.22 (#1510) (#1511)
+
+
+### [6.2.4-v31](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v31)
+
+- [7c84bbc1](https://github.com/stashed/elasticsearch/commit/7c84bbc1) Prepare for release 6.2.4-v31 (#1533)
+- [fed5d9e2](https://github.com/stashed/elasticsearch/commit/fed5d9e2) [cherry-pick] Use Go 1.22 (#1521) (#1523)
+- [1f63d8ec](https://github.com/stashed/elasticsearch/commit/1f63d8ec) [cherry-pick] Use Go 1.22 (#1510) (#1512)
+
+
+### [6.3.0-v31](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v31)
+
+- [c9cdfcd6](https://github.com/stashed/elasticsearch/commit/c9cdfcd6) Prepare for release 6.3.0-v31 (#1534)
+- [735faaf2](https://github.com/stashed/elasticsearch/commit/735faaf2) [cherry-pick] Use Go 1.22 (#1521) (#1524)
+- [1f3097e6](https://github.com/stashed/elasticsearch/commit/1f3097e6) [cherry-pick] Use Go 1.22 (#1510) (#1513)
+
+
+### [6.4.0-v31](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v31)
+
+- [6fdc0ea7](https://github.com/stashed/elasticsearch/commit/6fdc0ea7) Prepare for release 6.4.0-v31 (#1535)
+- [d4c96d76](https://github.com/stashed/elasticsearch/commit/d4c96d76) [cherry-pick] Use Go 1.22 (#1521) (#1525)
+- [2314563b](https://github.com/stashed/elasticsearch/commit/2314563b) [cherry-pick] Use Go 1.22 (#1510) (#1514)
+
+
+### [6.5.3-v31](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v31)
+
+- [0dc8cd3d](https://github.com/stashed/elasticsearch/commit/0dc8cd3d) Prepare for release 6.5.3-v31 (#1536)
+- [9dd6338f](https://github.com/stashed/elasticsearch/commit/9dd6338f) [cherry-pick] Use Go 1.22 (#1521) (#1526)
+- [3f9bce22](https://github.com/stashed/elasticsearch/commit/3f9bce22) [cherry-pick] Use Go 1.22 (#1510) (#1515)
+
+
+### [6.8.0-v31](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v31)
+
+- [1f7abda9](https://github.com/stashed/elasticsearch/commit/1f7abda9) Prepare for release 6.8.0-v31 (#1537)
+- [237ace67](https://github.com/stashed/elasticsearch/commit/237ace67) [cherry-pick] Use Go 1.22 (#1521) (#1527)
+- [670a073a](https://github.com/stashed/elasticsearch/commit/670a073a) [cherry-pick] Use Go 1.22 (#1510) (#1516)
+
+
+### [7.2.0-v31](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v31)
+
+- [7a4aeeaa](https://github.com/stashed/elasticsearch/commit/7a4aeeaa) Prepare for release 7.2.0-v31 (#1539)
+- [2bcea750](https://github.com/stashed/elasticsearch/commit/2bcea750) [cherry-pick] Use Go 1.22 (#1521) (#1529)
+- [ad6db703](https://github.com/stashed/elasticsearch/commit/ad6db703) [cherry-pick] Use Go 1.22 (#1510) (#1518)
+
+
+### [7.3.2-v31](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v31)
+
+- [e79d7c36](https://github.com/stashed/elasticsearch/commit/e79d7c36) Prepare for release 7.3.2-v31 (#1540)
+- [19a2baee](https://github.com/stashed/elasticsearch/commit/19a2baee) Use Go 1.22 (#1510) (#1519)
+- [fccdd7ae](https://github.com/stashed/elasticsearch/commit/fccdd7ae) Use Go 1.22 (#1521) (#1530)
+
+
+### [7.14.0-v17](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v17)
+
+- [07732198](https://github.com/stashed/elasticsearch/commit/07732198) Prepare for release 7.14.0-v17 (#1538)
+- [84560940](https://github.com/stashed/elasticsearch/commit/84560940) Use Go 1.22 (#1510) (#1517)
+- [a7e835e0](https://github.com/stashed/elasticsearch/commit/a7e835e0) Use Go 1.22 (#1521) (#1528)
+
+
+### [8.2.0-v14](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v14)
+
+- [5c652e9b](https://github.com/stashed/elasticsearch/commit/5c652e9b) Prepare for release 8.2.0-v14 (#1541)
+- [5816087b](https://github.com/stashed/elasticsearch/commit/5816087b) Use Go 1.22 (#1510) (#1520)
+- [6fda5520](https://github.com/stashed/elasticsearch/commit/6fda5520) Use Go 1.22 (#1521) (#1531)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.34.0](https://github.com/stashed/enterprise/releases/tag/v0.34.0)
+
+- [abdda99c](https://github.com/stashed/enterprise/commit/abdda99c1) Prepare for release v0.34.0 (#252)
+- [ac0a94b1](https://github.com/stashed/enterprise/commit/ac0a94b12) Use Go 1.22 (#251)
+- [21941602](https://github.com/stashed/enterprise/commit/219416023) Use Go 1.22 (#250)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v18](https://github.com/stashed/etcd/releases/tag/3.5.0-v18)
+
+- [7831686](https://github.com/stashed/etcd/commit/7831686) Prepare for release 3.5.0-v18 (#95)
+- [1615a10](https://github.com/stashed/etcd/commit/1615a10) [cherry-pick] Use Go 1.22 (#93) (#94)
+- [4a6c248](https://github.com/stashed/etcd/commit/4a6c248) [cherry-pick] Use Go 1.22 (#91) (#92)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2024.4.8](https://github.com/stashed/installer/releases/tag/v2024.4.8)
+
+- [a5779c26](https://github.com/stashed/installer/commit/a5779c26) Prepare for release v2024.4.8 (#336)
+- [85724696](https://github.com/stashed/installer/commit/85724696) Use Go 1.22 (#335)
+- [78d05dfa](https://github.com/stashed/installer/commit/78d05dfa) Use Go 1.22 (#334)
+- [462dae9e](https://github.com/stashed/installer/commit/462dae9e) Add pg version 16 support (#331)
+- [14ca5b0a](https://github.com/stashed/installer/commit/14ca5b0a) Add node selector, toleration and affinity rules for jobs (#333)
+- [6675e10f](https://github.com/stashed/installer/commit/6675e10f) Add `--ignore-groupkinds` flag in kubedump function (#332)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v14](https://github.com/stashed/kubedump/releases/tag/0.1.0-v14)
+
+- [6774b71](https://github.com/stashed/kubedump/commit/6774b71) Prepare for release 0.1.0-v14 (#64)
+- [756520f](https://github.com/stashed/kubedump/commit/756520f) Use Go 1.22 (#60) (#61)
+- [30bb01b](https://github.com/stashed/kubedump/commit/30bb01b) Use Go 1.22 (#62) (#63)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v25](https://github.com/stashed/mariadb/releases/tag/10.5.8-v25)
+
+- [77c27b4d](https://github.com/stashed/mariadb/commit/77c27b4d) Prepare for release 10.5.8-v25 (#246)
+- [b8cfb2c2](https://github.com/stashed/mariadb/commit/b8cfb2c2) [cherry-pick] Use Go 1.22 (#244) (#245)
+- [9c86fee6](https://github.com/stashed/mariadb/commit/9c86fee6) [cherry-pick] Use Go 1.22 (#242) (#243)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v31](https://github.com/stashed/mongodb/releases/tag/3.4.17-v31)
+
+- [58b55d55](https://github.com/stashed/mongodb/commit/58b55d55) Prepare for release 3.4.17-v31 (#2119)
+- [15f8513c](https://github.com/stashed/mongodb/commit/15f8513c) Use Go 1.22 (#2098) (#2104)
+
+
+### [3.4.22-v31](https://github.com/stashed/mongodb/releases/tag/3.4.22-v31)
+
+- [15bc4a8e](https://github.com/stashed/mongodb/commit/15bc4a8e) Prepare for release 3.4.22-v31 (#2120)
+- [a70cbdfc](https://github.com/stashed/mongodb/commit/a70cbdfc) Use Go 1.22 (#2098) (#2105)
+
+
+### [3.6.8-v31](https://github.com/stashed/mongodb/releases/tag/3.6.8-v31)
+
+- [1d63b61c](https://github.com/stashed/mongodb/commit/1d63b61c) Prepare for release 3.6.8-v31 (#2122)
+- [27c70e3e](https://github.com/stashed/mongodb/commit/27c70e3e) Use Go 1.22 (#2098) (#2107)
+
+
+### [3.6.13-v31](https://github.com/stashed/mongodb/releases/tag/3.6.13-v31)
+
+- [f5a988bd](https://github.com/stashed/mongodb/commit/f5a988bd) Prepare for release 3.6.13-v31 (#2121)
+- [e4fbdca1](https://github.com/stashed/mongodb/commit/e4fbdca1) Use Go 1.22 (#2098) (#2106)
+
+
+### [4.0.3-v31](https://github.com/stashed/mongodb/releases/tag/4.0.3-v31)
+
+- [c8a40f84](https://github.com/stashed/mongodb/commit/c8a40f84) Prepare for release 4.0.3-v31 (#2124)
+- [c320e2e3](https://github.com/stashed/mongodb/commit/c320e2e3) Use Go 1.22 (#2098) (#2109)
+
+
+### [4.0.5-v31](https://github.com/stashed/mongodb/releases/tag/4.0.5-v31)
+
+- [4f1dd2ea](https://github.com/stashed/mongodb/commit/4f1dd2ea) Prepare for release 4.0.5-v31 (#2125)
+- [8dbf0b26](https://github.com/stashed/mongodb/commit/8dbf0b26) Use Go 1.22 (#2098) (#2110)
+
+
+### [4.0.11-v31](https://github.com/stashed/mongodb/releases/tag/4.0.11-v31)
+
+- [4a1ca435](https://github.com/stashed/mongodb/commit/4a1ca435) Prepare for release 4.0.11-v31 (#2123)
+- [71013236](https://github.com/stashed/mongodb/commit/71013236) Use Go 1.22 (#2098) (#2108)
+
+
+### [4.1.4-v31](https://github.com/stashed/mongodb/releases/tag/4.1.4-v31)
+
+- [0987370a](https://github.com/stashed/mongodb/commit/0987370a) Prepare for release 4.1.4-v31 (#2127)
+- [d611f612](https://github.com/stashed/mongodb/commit/d611f612) Use Go 1.22 (#2098) (#2112)
+
+
+### [4.1.7-v31](https://github.com/stashed/mongodb/releases/tag/4.1.7-v31)
+
+- [4bc37444](https://github.com/stashed/mongodb/commit/4bc37444) Prepare for release 4.1.7-v31 (#2128)
+- [f1b8cbbb](https://github.com/stashed/mongodb/commit/f1b8cbbb) Use Go 1.22 (#2098) (#2113)
+
+
+### [4.1.13-v31](https://github.com/stashed/mongodb/releases/tag/4.1.13-v31)
+
+- [0a3b3fcd](https://github.com/stashed/mongodb/commit/0a3b3fcd) Prepare for release 4.1.13-v31 (#2126)
+- [114ffe42](https://github.com/stashed/mongodb/commit/114ffe42) Use Go 1.22 (#2098) (#2111)
+
+
+### [4.2.3-v31](https://github.com/stashed/mongodb/releases/tag/4.2.3-v31)
+
+- [a4399e27](https://github.com/stashed/mongodb/commit/a4399e27) Prepare for release 4.2.3-v31 (#2129)
+- [0d7bc575](https://github.com/stashed/mongodb/commit/0d7bc575) Use Go 1.22 (#2098) (#2114)
+
+
+### [4.4.6-v22](https://github.com/stashed/mongodb/releases/tag/4.4.6-v22)
+
+- [c0a13d5a](https://github.com/stashed/mongodb/commit/c0a13d5a) Prepare for release 4.4.6-v22 (#2130)
+- [e89fb707](https://github.com/stashed/mongodb/commit/e89fb707) Use Go 1.22 (#2098) (#2115)
+
+
+### [5.0.3-v19](https://github.com/stashed/mongodb/releases/tag/5.0.3-v19)
+
+- [e3f0395d](https://github.com/stashed/mongodb/commit/e3f0395d) Prepare for release 5.0.3-v19 (#2132)
+- [af619bb9](https://github.com/stashed/mongodb/commit/af619bb9) Use Go 1.22 (#2098) (#2117)
+
+
+### [5.0.15-v4](https://github.com/stashed/mongodb/releases/tag/5.0.15-v4)
+
+- [cd1774de](https://github.com/stashed/mongodb/commit/cd1774de) Prepare for release 5.0.15-v4 (#2131)
+- [b97c1fd6](https://github.com/stashed/mongodb/commit/b97c1fd6) Use Go 1.22 (#2098) (#2116)
+
+
+### [6.0.5-v7](https://github.com/stashed/mongodb/releases/tag/6.0.5-v7)
+
+- [f54a09de](https://github.com/stashed/mongodb/commit/f54a09de) Prepare for release 6.0.5-v7 (#2133)
+- [65963e0b](https://github.com/stashed/mongodb/commit/65963e0b) Use Go 1.22 (#2098) (#2118)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v31](https://github.com/stashed/mysql/releases/tag/5.7.25-v31)
+
+- [b05bf372](https://github.com/stashed/mysql/commit/b05bf372) Prepare for release 5.7.25-v31 (#772)
+- [9bc2d64b](https://github.com/stashed/mysql/commit/9bc2d64b) [cherry-pick] Use Go 1.22 (#767) (#768)
+- [d12b9957](https://github.com/stashed/mysql/commit/d12b9957) [cherry-pick] Use Go 1.22 (#762) (#763)
+
+
+### [8.0.3-v31](https://github.com/stashed/mysql/releases/tag/8.0.3-v31)
+
+- [12351196](https://github.com/stashed/mysql/commit/12351196) Prepare for release 8.0.3-v31 (#775)
+- [572d4433](https://github.com/stashed/mysql/commit/572d4433) [cherry-pick] Use Go 1.22 (#767) (#771)
+- [003dd782](https://github.com/stashed/mysql/commit/003dd782) [cherry-pick] Use Go 1.22 (#762) (#766)
+
+
+### [8.0.14-v31](https://github.com/stashed/mysql/releases/tag/8.0.14-v31)
+
+- [bddcbc5e](https://github.com/stashed/mysql/commit/bddcbc5e) Prepare for release 8.0.14-v31 (#773)
+- [fb6655db](https://github.com/stashed/mysql/commit/fb6655db) [cherry-pick] Use Go 1.22 (#767) (#769)
+- [9168a96f](https://github.com/stashed/mysql/commit/9168a96f) [cherry-pick] Use Go 1.22 (#762) (#764)
+
+
+### [8.0.21-v25](https://github.com/stashed/mysql/releases/tag/8.0.21-v25)
+
+- [7ccbafa0](https://github.com/stashed/mysql/commit/7ccbafa0) Prepare for release 8.0.21-v25 (#774)
+- [65d51861](https://github.com/stashed/mysql/commit/65d51861) [cherry-pick] Use Go 1.22 (#767) (#770)
+- [fa68ec10](https://github.com/stashed/mysql/commit/fa68ec10) [cherry-pick] Use Go 1.22 (#762) (#765)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v19](https://github.com/stashed/nats/releases/tag/2.6.1-v19)
+
+- [3b03387](https://github.com/stashed/nats/commit/3b03387) Prepare for release 2.6.1-v19 (#141)
+- [b82f62f](https://github.com/stashed/nats/commit/b82f62f) [cherry-pick] Use Go 1.22 (#138) (#139)
+- [a1daf1a](https://github.com/stashed/nats/commit/a1daf1a) [cherry-pick] Use Go 1.22 (#135) (#136)
+
+
+### [2.8.2-v14](https://github.com/stashed/nats/releases/tag/2.8.2-v14)
+
+- [dd6c32c](https://github.com/stashed/nats/commit/dd6c32c) Prepare for release 2.8.2-v14 (#142)
+- [f3f64d8](https://github.com/stashed/nats/commit/f3f64d8) [cherry-pick] Use Go 1.22 (#138) (#140)
+- [4bf6909](https://github.com/stashed/nats/commit/4bf6909) [cherry-pick] Use Go 1.22 (#135) (#137)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v26](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v26)
+
+- [3e476cf1](https://github.com/stashed/percona-xtradb/commit/3e476cf1) Prepare for release 5.7-v26 (#319)
+- [4792bc77](https://github.com/stashed/percona-xtradb/commit/4792bc77) [cherry-pick] Use Go 1.22 (#317) (#318)
+- [4092d00f](https://github.com/stashed/percona-xtradb/commit/4092d00f) [cherry-pick] Use Go 1.22 (#315) (#316)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v30](https://github.com/stashed/postgres/releases/tag/9.6.19-v30)
+
+- [fbd16044](https://github.com/stashed/postgres/commit/fbd16044) Prepare for release 9.6.19-v30 (#1310)
+- [ccc209f2](https://github.com/stashed/postgres/commit/ccc209f2) [cherry-pick] Use Go 1.22 (#1294) (#1302)
+- [6e158932](https://github.com/stashed/postgres/commit/6e158932) [cherry-pick] Use Go 1.22 (#1285) (#1293)
+- [8ad02897](https://github.com/stashed/postgres/commit/8ad02897) TLS fix for Postgres (#1276) (#1284)
+
+
+### [10.14-v30](https://github.com/stashed/postgres/releases/tag/10.14-v30)
+
+- [96117cdb](https://github.com/stashed/postgres/commit/96117cdb) Prepare for release 10.14-v30 (#1303)
+- [14485d33](https://github.com/stashed/postgres/commit/14485d33) [cherry-pick] Use Go 1.22 (#1294) (#1295)
+- [50933257](https://github.com/stashed/postgres/commit/50933257) [cherry-pick] Use Go 1.22 (#1285) (#1286)
+- [6a572310](https://github.com/stashed/postgres/commit/6a572310) TLS fix for Postgres (#1276) (#1277)
+
+
+### [11.9-v30](https://github.com/stashed/postgres/releases/tag/11.9-v30)
+
+- [f0dce3ab](https://github.com/stashed/postgres/commit/f0dce3ab) Prepare for release 11.9-v30 (#1304)
+- [ae71d48f](https://github.com/stashed/postgres/commit/ae71d48f) [cherry-pick] Use Go 1.22 (#1294) (#1296)
+- [42d88fa3](https://github.com/stashed/postgres/commit/42d88fa3) [cherry-pick] Use Go 1.22 (#1285) (#1287)
+- [71b29f42](https://github.com/stashed/postgres/commit/71b29f42) TLS fix for Postgres (#1276) (#1278)
+
+
+### [12.4-v30](https://github.com/stashed/postgres/releases/tag/12.4-v30)
+
+- [0fbdd5ca](https://github.com/stashed/postgres/commit/0fbdd5ca) Prepare for release 12.4-v30 (#1305)
+- [60928e72](https://github.com/stashed/postgres/commit/60928e72) [cherry-pick] Use Go 1.22 (#1294) (#1297)
+- [bba3655d](https://github.com/stashed/postgres/commit/bba3655d) [cherry-pick] Use Go 1.22 (#1285) (#1288)
+- [29abe734](https://github.com/stashed/postgres/commit/29abe734) TLS fix for Postgres (#1276) (#1279)
+
+
+### [13.1-v27](https://github.com/stashed/postgres/releases/tag/13.1-v27)
+
+- [5a0180f3](https://github.com/stashed/postgres/commit/5a0180f3) Prepare for release 13.1-v27 (#1306)
+- [9bd70f79](https://github.com/stashed/postgres/commit/9bd70f79) [cherry-pick] Use Go 1.22 (#1294) (#1298)
+- [c5f3f4e7](https://github.com/stashed/postgres/commit/c5f3f4e7) [cherry-pick] Use Go 1.22 (#1285) (#1289)
+- [574e5101](https://github.com/stashed/postgres/commit/574e5101) TLS fix for Postgres (#1276) (#1280)
+
+
+### [14.0-v19](https://github.com/stashed/postgres/releases/tag/14.0-v19)
+
+- [fb410c7d](https://github.com/stashed/postgres/commit/fb410c7d) Prepare for release 14.0-v19 (#1307)
+- [f0ec4a9b](https://github.com/stashed/postgres/commit/f0ec4a9b) [cherry-pick] Use Go 1.22 (#1294) (#1299)
+- [a0d2cb4e](https://github.com/stashed/postgres/commit/a0d2cb4e) [cherry-pick] Use Go 1.22 (#1285) (#1290)
+- [a713b5ce](https://github.com/stashed/postgres/commit/a713b5ce) TLS fix for Postgres (#1276) (#1281)
+
+
+### [15.1-v11](https://github.com/stashed/postgres/releases/tag/15.1-v11)
+
+- [d1f558b5](https://github.com/stashed/postgres/commit/d1f558b5) Prepare for release 15.1-v11 (#1308)
+- [5e31b5e3](https://github.com/stashed/postgres/commit/5e31b5e3) [cherry-pick] Use Go 1.22 (#1294) (#1300)
+- [1ef33931](https://github.com/stashed/postgres/commit/1ef33931) [cherry-pick] Use Go 1.22 (#1285) (#1291)
+- [38de64a2](https://github.com/stashed/postgres/commit/38de64a2) TLS fix for Postgres (#1276) (#1282)
+
+
+### [16.1](https://github.com/stashed/postgres/releases/tag/16.1)
+
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v19](https://github.com/stashed/redis/releases/tag/5.0.13-v19)
+
+- [454812a](https://github.com/stashed/redis/commit/454812a) Prepare for release 5.0.13-v19 (#224)
+- [b0d2bc8](https://github.com/stashed/redis/commit/b0d2bc8) [cherry-pick] Use Go 1.22 (#220) (#221)
+- [91e6c34](https://github.com/stashed/redis/commit/91e6c34) [cherry-pick] Use Go 1.22 (#216) (#217)
+
+
+### [6.2.5-v19](https://github.com/stashed/redis/releases/tag/6.2.5-v19)
+
+- [82df5aa](https://github.com/stashed/redis/commit/82df5aa) Prepare for release 6.2.5-v19 (#225)
+- [c92bc97](https://github.com/stashed/redis/commit/c92bc97) [cherry-pick] Use Go 1.22 (#220) (#222)
+- [7132972](https://github.com/stashed/redis/commit/7132972) [cherry-pick] Use Go 1.22 (#216) (#218)
+
+
+### [7.0.5-v12](https://github.com/stashed/redis/releases/tag/7.0.5-v12)
+
+- [c3d5394](https://github.com/stashed/redis/commit/c3d5394) Prepare for release 7.0.5-v12 (#226)
+- [2a9d78d](https://github.com/stashed/redis/commit/2a9d78d) [cherry-pick] Use Go 1.22 (#220) (#223)
+- [ca351a1](https://github.com/stashed/redis/commit/ca351a1) [cherry-pick] Use Go 1.22 (#216) (#219)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.34.0](https://github.com/stashed/stash/releases/tag/v0.34.0)
+
+- [c0166b9a](https://github.com/stashed/stash/commit/c0166b9ab) Prepare for release v0.34.0 (#1567)
+- [99e49802](https://github.com/stashed/stash/commit/99e49802f) Use Go 1.22 (#1566)
+- [a3177914](https://github.com/stashed/stash/commit/a31779145) Use Go 1.22 (#1564)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.15.0](https://github.com/stashed/ui-server/releases/tag/v0.15.0)
+
+- [53dadbe9](https://github.com/stashed/ui-server/commit/53dadbe9) Prepare for release v0.15.0 (#39)
+- [c708bdd2](https://github.com/stashed/ui-server/commit/c708bdd2) Use Go 1.22 (#38)
+- [e0c26d2a](https://github.com/stashed/ui-server/commit/e0c26d2a) Use Go 1.22 (#37)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v11](https://github.com/stashed/vault/releases/tag/1.10.3-v11)
+
+- [cc9393ba](https://github.com/stashed/vault/commit/cc9393ba) Prepare for release 1.10.3-v11 (#39)
+- [7f427970](https://github.com/stashed/vault/commit/7f427970) [cherry-pick] Use Go 1.22 (#37) (#38)
+- [bb505746](https://github.com/stashed/vault/commit/bb505746) [cherry-pick] Use Go 1.22 (#35) (#36)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.4.8
Release-tracker: https://github.com/stashed/CHANGELOG/pull/72
Signed-off-by: 1gtm <1gtm@appscode.com>