### PR TITLE
Prepare for release v2024.8.27

### DIFF
--- a/docs/CHANGELOG-v2024.8.27.md
+++ b/docs/CHANGELOG-v2024.8.27.md
@@ -1,0 +1,391 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2024.8.27
+    name: Changelog-v2024.8.27
+    parent: welcome
+    weight: 20240827
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.8.27/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.8.27/
+---
+
+# Stash v2024.8.27 (2024-08-28)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.35.0](https://github.com/stashed/apimachinery/releases/tag/v0.35.0)
+
+- [865b404c](https://github.com/stashed/apimachinery/commit/865b404c) Update deps
+- [9f543113](https://github.com/stashed/apimachinery/commit/9f543113) Add condition for backup disruption (#223)
+- [36516c28](https://github.com/stashed/apimachinery/commit/36516c28) Use Go 1.23 (#222)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.35.0](https://github.com/stashed/cli/releases/tag/v0.35.0)
+
+- [a4dd874e](https://github.com/stashed/cli/commit/a4dd874e) Prepare for release v0.35.0 (#204)
+- [7fac7e02](https://github.com/stashed/cli/commit/7fac7e02) Add restic `check` and `rebuild-index` cmd for better repository debugging (#203)
+- [6b48bb80](https://github.com/stashed/cli/commit/6b48bb80) Print output for download cmd (#201)
+- [cf294209](https://github.com/stashed/cli/commit/cf294209) Use Go 1.23 (#202)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v32](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v32)
+
+- [022bfe28](https://github.com/stashed/elasticsearch/commit/022bfe28) Prepare for release 5.6.4-v32 (#1547)
+
+
+### [6.2.4-v32](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v32)
+
+- [a1e71bca](https://github.com/stashed/elasticsearch/commit/a1e71bca) Prepare for release 6.2.4-v32 (#1548)
+
+
+### [6.3.0-v32](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v32)
+
+- [590c4411](https://github.com/stashed/elasticsearch/commit/590c4411) Prepare for release 6.3.0-v32 (#1549)
+
+
+### [6.4.0-v32](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v32)
+
+- [7da7110e](https://github.com/stashed/elasticsearch/commit/7da7110e) Prepare for release 6.4.0-v32 (#1550)
+
+
+### [6.5.3-v32](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v32)
+
+- [0e879140](https://github.com/stashed/elasticsearch/commit/0e879140) Prepare for release 6.5.3-v32 (#1551)
+
+
+### [6.8.0-v32](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v32)
+
+- [65c68556](https://github.com/stashed/elasticsearch/commit/65c68556) Prepare for release 6.8.0-v32 (#1552)
+
+
+### [7.2.0-v32](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v32)
+
+- [83fbb80a](https://github.com/stashed/elasticsearch/commit/83fbb80a) Prepare for release 7.2.0-v32 (#1554)
+
+
+### [7.3.2-v32](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v32)
+
+- [5659abd7](https://github.com/stashed/elasticsearch/commit/5659abd7) Prepare for release 7.3.2-v32 (#1555)
+- [ac4829c5](https://github.com/stashed/elasticsearch/commit/ac4829c5) Add support for creating space during dashboard restore (#1544)
+
+
+### [7.14.0-v18](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v18)
+
+- [43d959e5](https://github.com/stashed/elasticsearch/commit/43d959e5) Prepare for release 7.14.0-v18 (#1553)
+- [45964df8](https://github.com/stashed/elasticsearch/commit/45964df8) Add support for creating space during dashboard restore (#1545)
+
+
+### [8.2.0-v15](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v15)
+
+- [def1a44b](https://github.com/stashed/elasticsearch/commit/def1a44b) Prepare for release 8.2.0-v15 (#1556)
+- [f565882f](https://github.com/stashed/elasticsearch/commit/f565882f) Add support for creating space during dashboard restore (#1543)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.35.0](https://github.com/stashed/enterprise/releases/tag/v0.35.0)
+
+- [4f64305b](https://github.com/stashed/enterprise/commit/4f64305b6) Prepare for release v0.35.0 (#255)
+- [52835160](https://github.com/stashed/enterprise/commit/52835160d) Fix backupsession running issue after deadline exceed (#253)
+- [fa5833a7](https://github.com/stashed/enterprise/commit/fa5833a75) Use Go 1.23 (#254)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v19](https://github.com/stashed/etcd/releases/tag/3.5.0-v19)
+
+- [901d0a4](https://github.com/stashed/etcd/commit/901d0a4) Prepare for release 3.5.0-v19 (#98)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2024.8.27](https://github.com/stashed/installer/releases/tag/v2024.8.27)
+
+- [7f7b18f1](https://github.com/stashed/installer/commit/7f7b18f1) Prepare for release v2024.8.27 (#343)
+- [ae2d4f99](https://github.com/stashed/installer/commit/ae2d4f99) Use Go 1.23 (#342)
+- [604ef4f3](https://github.com/stashed/installer/commit/604ef4f3) Test against k8s 1.31 (#341)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v15](https://github.com/stashed/kubedump/releases/tag/0.1.0-v15)
+
+- [f2c07a3](https://github.com/stashed/kubedump/commit/f2c07a3) Prepare for release 0.1.0-v15 (#67)
+- [92e5c91](https://github.com/stashed/kubedump/commit/92e5c91) Use Go 1.23 (#66) (#69)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v26](https://github.com/stashed/mariadb/releases/tag/10.5.8-v26)
+
+- [b674f8ec](https://github.com/stashed/mariadb/commit/b674f8ec) Prepare for release 10.5.8-v26 (#249)
+- [a020b223](https://github.com/stashed/mariadb/commit/a020b223) Use Go 1.23 (#248) (#251)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v32](https://github.com/stashed/mongodb/releases/tag/3.4.17-v32)
+
+- [855e9eb6](https://github.com/stashed/mongodb/commit/855e9eb6) Prepare for release 3.4.17-v32 (#2154)
+- [671e6536](https://github.com/stashed/mongodb/commit/671e6536) [cherry-pick] Fix MongoDB url connection str for external databases (#2138) (#2139)
+
+
+### [3.4.22-v32](https://github.com/stashed/mongodb/releases/tag/3.4.22-v32)
+
+- [852d1338](https://github.com/stashed/mongodb/commit/852d1338) Prepare for release 3.4.22-v32 (#2155)
+- [e3a34ce3](https://github.com/stashed/mongodb/commit/e3a34ce3) Fix MongoDB url connection str for external databases (#2138) (#2140)
+
+
+### [3.6.8-v32](https://github.com/stashed/mongodb/releases/tag/3.6.8-v32)
+
+- [de6e934e](https://github.com/stashed/mongodb/commit/de6e934e) Prepare for release 3.6.8-v32 (#2157)
+- [d440be0d](https://github.com/stashed/mongodb/commit/d440be0d) Fix MongoDB url connection str for external databases (#2138) (#2142)
+
+
+### [3.6.13-v32](https://github.com/stashed/mongodb/releases/tag/3.6.13-v32)
+
+- [8098d72f](https://github.com/stashed/mongodb/commit/8098d72f) Prepare for release 3.6.13-v32 (#2156)
+- [90b99bb7](https://github.com/stashed/mongodb/commit/90b99bb7) Fix MongoDB url connection str for external databases (#2138) (#2141)
+
+
+### [4.0.3-v32](https://github.com/stashed/mongodb/releases/tag/4.0.3-v32)
+
+- [864e0893](https://github.com/stashed/mongodb/commit/864e0893) Prepare for release 4.0.3-v32 (#2159)
+- [25de1602](https://github.com/stashed/mongodb/commit/25de1602) Fix MongoDB url connection str for external databases (#2138) (#2144)
+
+
+### [4.0.5-v32](https://github.com/stashed/mongodb/releases/tag/4.0.5-v32)
+
+- [ca4a260f](https://github.com/stashed/mongodb/commit/ca4a260f) Prepare for release 4.0.5-v32 (#2160)
+- [f056b393](https://github.com/stashed/mongodb/commit/f056b393) Fix MongoDB url connection str for external databases (#2138) (#2145)
+
+
+### [4.0.11-v32](https://github.com/stashed/mongodb/releases/tag/4.0.11-v32)
+
+- [cefa6f1f](https://github.com/stashed/mongodb/commit/cefa6f1f) Prepare for release 4.0.11-v32 (#2158)
+- [71014a6a](https://github.com/stashed/mongodb/commit/71014a6a) Fix MongoDB url connection str for external databases (#2138) (#2143)
+
+
+### [4.1.4-v32](https://github.com/stashed/mongodb/releases/tag/4.1.4-v32)
+
+- [02f6b9fe](https://github.com/stashed/mongodb/commit/02f6b9fe) Prepare for release 4.1.4-v32 (#2162)
+- [03dc6c0b](https://github.com/stashed/mongodb/commit/03dc6c0b) Fix MongoDB url connection str for external databases (#2138) (#2147)
+
+
+### [4.1.7-v32](https://github.com/stashed/mongodb/releases/tag/4.1.7-v32)
+
+- [04b231f7](https://github.com/stashed/mongodb/commit/04b231f7) Prepare for release 4.1.7-v32 (#2163)
+- [4fba2286](https://github.com/stashed/mongodb/commit/4fba2286) Fix MongoDB url connection str for external databases (#2138) (#2148)
+
+
+### [4.1.13-v32](https://github.com/stashed/mongodb/releases/tag/4.1.13-v32)
+
+- [e872ccab](https://github.com/stashed/mongodb/commit/e872ccab) Prepare for release 4.1.13-v32 (#2161)
+- [db585560](https://github.com/stashed/mongodb/commit/db585560) Fix MongoDB url connection str for external databases (#2138) (#2146)
+
+
+### [4.2.3-v32](https://github.com/stashed/mongodb/releases/tag/4.2.3-v32)
+
+- [5ce8589a](https://github.com/stashed/mongodb/commit/5ce8589a) Prepare for release 4.2.3-v32 (#2164)
+- [b1cba825](https://github.com/stashed/mongodb/commit/b1cba825) Fix MongoDB url connection str for external databases (#2138) (#2149)
+
+
+### [4.4.6-v23](https://github.com/stashed/mongodb/releases/tag/4.4.6-v23)
+
+- [4e0a833c](https://github.com/stashed/mongodb/commit/4e0a833c) Prepare for release 4.4.6-v23 (#2165)
+- [58665885](https://github.com/stashed/mongodb/commit/58665885) [cherry-pick] Fix MongoDB url connection str for external databases (#2138) (#2150)
+
+
+### [5.0.3-v20](https://github.com/stashed/mongodb/releases/tag/5.0.3-v20)
+
+- [d3add779](https://github.com/stashed/mongodb/commit/d3add779) Prepare for release 5.0.3-v20 (#2167)
+- [1cd5902d](https://github.com/stashed/mongodb/commit/1cd5902d) [cherry-pick] Fix MongoDB url connection str for external databases (#2138) (#2152)
+
+
+### [5.0.15-v5](https://github.com/stashed/mongodb/releases/tag/5.0.15-v5)
+
+- [e075d41a](https://github.com/stashed/mongodb/commit/e075d41a) Prepare for release 5.0.15-v5 (#2166)
+- [f604ef85](https://github.com/stashed/mongodb/commit/f604ef85) [cherry-pick] Fix MongoDB url connection str for external databases (#2138) (#2151)
+
+
+### [6.0.5-v8](https://github.com/stashed/mongodb/releases/tag/6.0.5-v8)
+
+- [c5810d8d](https://github.com/stashed/mongodb/commit/c5810d8d) Prepare for release 6.0.5-v8 (#2168)
+- [10476599](https://github.com/stashed/mongodb/commit/10476599) [cherry-pick] Fix MongoDB url connection str for external databases (#2138) (#2153)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v32](https://github.com/stashed/mysql/releases/tag/5.7.25-v32)
+
+- [dc20d8fa](https://github.com/stashed/mysql/commit/dc20d8fa) Prepare for release 5.7.25-v32 (#783)
+- [bb4b75c0](https://github.com/stashed/mysql/commit/bb4b75c0) Use Go 1.23 (#782) (#791)
+
+
+### [8.0.3-v32](https://github.com/stashed/mysql/releases/tag/8.0.3-v32)
+
+- [3e2f7a10](https://github.com/stashed/mysql/commit/3e2f7a10) Prepare for release 8.0.3-v32 (#786)
+- [f5b4e4ad](https://github.com/stashed/mysql/commit/f5b4e4ad) Use Go 1.23 (#782) (#788)
+
+
+### [8.0.14-v32](https://github.com/stashed/mysql/releases/tag/8.0.14-v32)
+
+- [9af04bf3](https://github.com/stashed/mysql/commit/9af04bf3) Prepare for release 8.0.14-v32 (#784)
+- [a669d830](https://github.com/stashed/mysql/commit/a669d830) Use Go 1.23 (#782) (#790)
+
+
+### [8.0.21-v26](https://github.com/stashed/mysql/releases/tag/8.0.21-v26)
+
+- [05d3f4a3](https://github.com/stashed/mysql/commit/05d3f4a3) Prepare for release 8.0.21-v26 (#785)
+- [47d1209f](https://github.com/stashed/mysql/commit/47d1209f) Use Go 1.23 (#782) (#789)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v20](https://github.com/stashed/nats/releases/tag/2.6.1-v20)
+
+- [58b60c8](https://github.com/stashed/nats/commit/58b60c8) Prepare for release 2.6.1-v20 (#145)
+- [2dcb9d1](https://github.com/stashed/nats/commit/2dcb9d1) Remove docker registry support (#150)
+- [94005b3](https://github.com/stashed/nats/commit/94005b3) Use Go 1.23 (#144) (#149)
+
+
+### [2.8.2-v15](https://github.com/stashed/nats/releases/tag/2.8.2-v15)
+
+- [a903d63](https://github.com/stashed/nats/commit/a903d63) Prepare for release 2.8.2-v15 (#146)
+- [d6444b9](https://github.com/stashed/nats/commit/d6444b9) Remove docker registry support (#151)
+- [5742b06](https://github.com/stashed/nats/commit/5742b06) Use Go 1.23 (#144) (#148)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v27](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v27)
+
+- [fd5e2104](https://github.com/stashed/percona-xtradb/commit/fd5e2104) Prepare for release 5.7-v27 (#322)
+- [4dedfa78](https://github.com/stashed/percona-xtradb/commit/4dedfa78) Use Go 1.23 (#321) (#324)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v31](https://github.com/stashed/postgres/releases/tag/9.6.19-v31)
+
+- [8ef9f3d5](https://github.com/stashed/postgres/commit/8ef9f3d5) Prepare for release 9.6.19-v31 (#1338)
+- [c4ace0d3](https://github.com/stashed/postgres/commit/c4ace0d3) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1330)
+
+
+### [10.14-v31](https://github.com/stashed/postgres/releases/tag/10.14-v31)
+
+- [48a9b619](https://github.com/stashed/postgres/commit/48a9b619) Prepare for release 10.14-v31 (#1331)
+- [55607a3e](https://github.com/stashed/postgres/commit/55607a3e) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1323)
+
+
+### [11.9-v31](https://github.com/stashed/postgres/releases/tag/11.9-v31)
+
+- [61302a08](https://github.com/stashed/postgres/commit/61302a08) Prepare for release 11.9-v31 (#1332)
+- [1ffec1f8](https://github.com/stashed/postgres/commit/1ffec1f8) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1324)
+
+
+### [12.4-v31](https://github.com/stashed/postgres/releases/tag/12.4-v31)
+
+- [e159aa8e](https://github.com/stashed/postgres/commit/e159aa8e) Prepare for release 12.4-v31 (#1333)
+- [3af46c2d](https://github.com/stashed/postgres/commit/3af46c2d) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1325)
+
+
+### [13.1-v28](https://github.com/stashed/postgres/releases/tag/13.1-v28)
+
+- [468a1f45](https://github.com/stashed/postgres/commit/468a1f45) Prepare for release 13.1-v28 (#1334)
+- [87232642](https://github.com/stashed/postgres/commit/87232642) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1326)
+
+
+### [14.0-v20](https://github.com/stashed/postgres/releases/tag/14.0-v20)
+
+- [f6202ce4](https://github.com/stashed/postgres/commit/f6202ce4) Prepare for release 14.0-v20 (#1335)
+- [1d419325](https://github.com/stashed/postgres/commit/1d419325) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1327)
+
+
+### [15.1-v12](https://github.com/stashed/postgres/releases/tag/15.1-v12)
+
+- [0937f528](https://github.com/stashed/postgres/commit/0937f528) Prepare for release 15.1-v12 (#1336)
+- [00d54c52](https://github.com/stashed/postgres/commit/00d54c52) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1328)
+
+
+### [16.1-v1](https://github.com/stashed/postgres/releases/tag/16.1-v1)
+
+- [b936987e](https://github.com/stashed/postgres/commit/b936987e) Prepare for release 16.1-v1 (#1337)
+- [7a9f6f98](https://github.com/stashed/postgres/commit/7a9f6f98) Get postgresw sslmode from appbinding clientconfig url (#1322) (#1329)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v20](https://github.com/stashed/redis/releases/tag/5.0.13-v20)
+
+- [8a1d962](https://github.com/stashed/redis/commit/8a1d962) Prepare for release 5.0.13-v20 (#229)
+- [2af01a1](https://github.com/stashed/redis/commit/2af01a1) Use Go 1.23 (#228) (#235)
+
+
+### [6.2.5-v20](https://github.com/stashed/redis/releases/tag/6.2.5-v20)
+
+- [5b9b074](https://github.com/stashed/redis/commit/5b9b074) Prepare for release 6.2.5-v20 (#230)
+- [00a261f](https://github.com/stashed/redis/commit/00a261f) Use Go 1.23 (#228) (#234)
+
+
+### [7.0.5-v13](https://github.com/stashed/redis/releases/tag/7.0.5-v13)
+
+- [e690a70](https://github.com/stashed/redis/commit/e690a70) Prepare for release 7.0.5-v13 (#231)
+- [10f53a9](https://github.com/stashed/redis/commit/10f53a9) Use Go 1.23 (#228) (#233)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.35.0](https://github.com/stashed/stash/releases/tag/v0.35.0)
+
+- [74a2c770](https://github.com/stashed/stash/commit/74a2c770d) Prepare for release v0.35.0 (#1577)
+- [c1f2acfd](https://github.com/stashed/stash/commit/c1f2acfd9) Use Go 1.23 (#1574)
+- [6747863e](https://github.com/stashed/stash/commit/6747863e8) Test against k8s 1.31 (#1573)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.16.0](https://github.com/stashed/ui-server/releases/tag/v0.16.0)
+
+- [12b8cc87](https://github.com/stashed/ui-server/commit/12b8cc87) Prepare for release v0.16.0 (#41)
+- [a3c2e27b](https://github.com/stashed/ui-server/commit/a3c2e27b) Use Go 1.23 (#40)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v12](https://github.com/stashed/vault/releases/tag/1.10.3-v12)
+
+- [21d5420a](https://github.com/stashed/vault/commit/21d5420a) Prepare for release 1.10.3-v12 (#42)
+- [f16ae4a0](https://github.com/stashed/vault/commit/f16ae4a0) Use Go 1.23 (#41) (#46)
+- [9247d6bb](https://github.com/stashed/vault/commit/9247d6bb) Remove docker registry support (#44)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.8.27
Release-tracker: https://github.com/stashed/CHANGELOG/pull/75
Signed-off-by: 1gtm <1gtm@appscode.com>