### PR TITLE
Prepare for release v2024.9.30

### DIFF
--- a/docs/CHANGELOG-v2024.9.30.md
+++ b/docs/CHANGELOG-v2024.9.30.md
@@ -1,0 +1,163 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2024.9.30
+    name: Changelog-v2024.9.30
+    parent: welcome
+    weight: 20240930
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.9.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.9.30/
+---
+
+# Stash v2024.9.30 (2024-09-27)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.36.0](https://github.com/stashed/apimachinery/releases/tag/v0.36.0)
+
+- [c6c78d52](https://github.com/stashed/apimachinery/commit/c6c78d52) Update deps
+- [46e84c06](https://github.com/stashed/apimachinery/commit/46e84c06) Use KIND v0.24.0 (#225)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.36.0](https://github.com/stashed/cli/releases/tag/v0.36.0)
+
+- [2eb6b48d](https://github.com/stashed/cli/commit/2eb6b48d) Prepare for release v0.36.0 (#205)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.36.0](https://github.com/stashed/enterprise/releases/tag/v0.36.0)
+
+- [6f330f41](https://github.com/stashed/enterprise/commit/6f330f412) Prepare for release v0.36.0 (#257)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2024.9.30](https://github.com/stashed/installer/releases/tag/v2024.9.30)
+
+- [189f9cf5](https://github.com/stashed/installer/commit/189f9cf5) Prepare for release v2024.9.30 (#347)
+- [a793309d](https://github.com/stashed/installer/commit/a793309d) Use seccompProfile RuntimeDefault (#346)
+- [8356df1e](https://github.com/stashed/installer/commit/8356df1e) Add imagelist
+- [2e0fec68](https://github.com/stashed/installer/commit/2e0fec68) Revise metrics config user roles
+- [a8b4f092](https://github.com/stashed/installer/commit/a8b4f092) Revise appcatalog permissions
+- [07e82e3d](https://github.com/stashed/installer/commit/07e82e3d) Revise user roles (#345)
+- [145494b9](https://github.com/stashed/installer/commit/145494b9) Use KIND v0.24.0 (#344)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v33](https://github.com/stashed/mongodb/releases/tag/3.4.17-v33)
+
+- [72315b9a](https://github.com/stashed/mongodb/commit/72315b9a) Prepare for release 3.4.17-v33 (#2189)
+- [55f83331](https://github.com/stashed/mongodb/commit/55f83331) Fix --oplog and --db arguments error (#2173) (#2174)
+
+
+### [3.4.22-v33](https://github.com/stashed/mongodb/releases/tag/3.4.22-v33)
+
+- [4f7f60a4](https://github.com/stashed/mongodb/commit/4f7f60a4) Prepare for release 3.4.22-v33 (#2190)
+- [2e9cd2c7](https://github.com/stashed/mongodb/commit/2e9cd2c7) Fix --oplog and --db arguments error (#2173) (#2175)
+
+
+### [3.6.8-v33](https://github.com/stashed/mongodb/releases/tag/3.6.8-v33)
+
+- [bec1d5db](https://github.com/stashed/mongodb/commit/bec1d5db) Prepare for release 3.6.8-v33 (#2192)
+- [91ef428b](https://github.com/stashed/mongodb/commit/91ef428b) Fix --oplog and --db arguments error (#2173) (#2177)
+
+
+### [3.6.13-v33](https://github.com/stashed/mongodb/releases/tag/3.6.13-v33)
+
+- [dd822eaa](https://github.com/stashed/mongodb/commit/dd822eaa) Prepare for release 3.6.13-v33 (#2191)
+- [b0f73ddf](https://github.com/stashed/mongodb/commit/b0f73ddf) Fix --oplog and --db arguments error (#2173) (#2176)
+
+
+### [4.0.3-v33](https://github.com/stashed/mongodb/releases/tag/4.0.3-v33)
+
+- [b4921b6f](https://github.com/stashed/mongodb/commit/b4921b6f) Prepare for release 4.0.3-v33 (#2194)
+- [99eee161](https://github.com/stashed/mongodb/commit/99eee161) Fix --oplog and --db arguments error (#2173) (#2179)
+
+
+### [4.0.5-v33](https://github.com/stashed/mongodb/releases/tag/4.0.5-v33)
+
+- [20b4ac2c](https://github.com/stashed/mongodb/commit/20b4ac2c) Prepare for release 4.0.5-v33 (#2195)
+- [a6d22a7a](https://github.com/stashed/mongodb/commit/a6d22a7a) Fix --oplog and --db arguments error (#2173) (#2180)
+
+
+### [4.0.11-v33](https://github.com/stashed/mongodb/releases/tag/4.0.11-v33)
+
+- [7731b0f5](https://github.com/stashed/mongodb/commit/7731b0f5) Prepare for release 4.0.11-v33 (#2193)
+
+
+### [4.1.4-v33](https://github.com/stashed/mongodb/releases/tag/4.1.4-v33)
+
+- [169c4084](https://github.com/stashed/mongodb/commit/169c4084) Prepare for release 4.1.4-v33 (#2197)
+- [3c4d0f4c](https://github.com/stashed/mongodb/commit/3c4d0f4c) Fix --oplog and --db arguments error (#2173) (#2182)
+
+
+### [4.1.7-v33](https://github.com/stashed/mongodb/releases/tag/4.1.7-v33)
+
+- [fa94de5b](https://github.com/stashed/mongodb/commit/fa94de5b) Prepare for release 4.1.7-v33 (#2198)
+- [ffe23f8a](https://github.com/stashed/mongodb/commit/ffe23f8a) Fix --oplog and --db arguments error (#2173) (#2183)
+
+
+### [4.1.13-v33](https://github.com/stashed/mongodb/releases/tag/4.1.13-v33)
+
+- [09f15435](https://github.com/stashed/mongodb/commit/09f15435) Prepare for release 4.1.13-v33 (#2196)
+
+
+### [4.2.3-v33](https://github.com/stashed/mongodb/releases/tag/4.2.3-v33)
+
+- [686da5f7](https://github.com/stashed/mongodb/commit/686da5f7) Prepare for release 4.2.3-v33 (#2199)
+
+
+### [4.4.6-v24](https://github.com/stashed/mongodb/releases/tag/4.4.6-v24)
+
+- [cc246f5f](https://github.com/stashed/mongodb/commit/cc246f5f) Prepare for release 4.4.6-v24 (#2200)
+
+
+### [5.0.3-v21](https://github.com/stashed/mongodb/releases/tag/5.0.3-v21)
+
+- [8fd1e40c](https://github.com/stashed/mongodb/commit/8fd1e40c) Prepare for release 5.0.3-v21 (#2202)
+
+
+### [5.0.15-v6](https://github.com/stashed/mongodb/releases/tag/5.0.15-v6)
+
+- [7b65267a](https://github.com/stashed/mongodb/commit/7b65267a) Prepare for release 5.0.15-v6 (#2201)
+
+
+### [6.0.5-v9](https://github.com/stashed/mongodb/releases/tag/6.0.5-v9)
+
+- [69244680](https://github.com/stashed/mongodb/commit/69244680) Prepare for release 6.0.5-v9 (#2203)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.36.0](https://github.com/stashed/stash/releases/tag/v0.36.0)
+
+- [ef7a17bb](https://github.com/stashed/stash/commit/ef7a17bb4) Prepare for release v0.36.0 (#1581)
+- [f9966814](https://github.com/stashed/stash/commit/f99668149) Use KIND v0.24.0 (#1580)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.17.0](https://github.com/stashed/ui-server/releases/tag/v0.17.0)
+
+- [04e5e6b2](https://github.com/stashed/ui-server/commit/04e5e6b2) Prepare for release v0.17.0 (#42)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.9.30
Release-tracker: https://github.com/stashed/CHANGELOG/pull/76
Signed-off-by: 1gtm <1gtm@appscode.com>