### PR TITLE
Prepare for release v2024.12.18

### DIFF
--- a/docs/CHANGELOG-v2024.12.18.md
+++ b/docs/CHANGELOG-v2024.12.18.md
@@ -1,0 +1,447 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2024.12.18
+    name: Changelog-v2024.12.18
+    parent: welcome
+    weight: 20241218
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.12.18/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.12.18/
+---
+
+# Stash v2024.12.18 (2024-12-18)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.37.0](https://github.com/stashed/apimachinery/releases/tag/v0.37.0)
+
+- [8f07b3c5](https://github.com/stashed/apimachinery/commit/8f07b3c5) Update deps
+- [0cab85aa](https://github.com/stashed/apimachinery/commit/0cab85aa) Run dump command in bash shell (#228)
+- [fb4061fd](https://github.com/stashed/apimachinery/commit/fb4061fd) Add support for templating for exec hook command (#229)
+- [2e1520fd](https://github.com/stashed/apimachinery/commit/2e1520fd) Use kind v0.25.0 (#227)
+- [785bc7ee](https://github.com/stashed/apimachinery/commit/785bc7ee) Use debian:12 base image (#226)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.37.0](https://github.com/stashed/cli/releases/tag/v0.37.0)
+
+- [9e673748](https://github.com/stashed/cli/commit/9e673748) Prepare for release v0.37.0 (#206)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v33](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v33)
+
+- [fa5b7b2f](https://github.com/stashed/elasticsearch/commit/fa5b7b2f) Prepare for release 5.6.4-v33 (#1579)
+- [3b38c8bd](https://github.com/stashed/elasticsearch/commit/3b38c8bd) Use debian:12 base image (#1568) (#1569)
+- [505c24be](https://github.com/stashed/elasticsearch/commit/505c24be) Remove docker registry support (#1558)
+
+
+### [6.2.4-v33](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v33)
+
+- [a88234a3](https://github.com/stashed/elasticsearch/commit/a88234a3) Prepare for release 6.2.4-v33 (#1580)
+- [c2bf0ea4](https://github.com/stashed/elasticsearch/commit/c2bf0ea4) [cherry-pick] Use debian:12 base image (#1568) (#1570)
+- [9fe5b292](https://github.com/stashed/elasticsearch/commit/9fe5b292) Remove docker registry support (#1559)
+
+
+### [6.3.0-v33](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v33)
+
+- [a56523b9](https://github.com/stashed/elasticsearch/commit/a56523b9) Prepare for release 6.3.0-v33 (#1581)
+- [023637f6](https://github.com/stashed/elasticsearch/commit/023637f6) Use debian:12 base image (#1568) (#1571)
+- [01e177ca](https://github.com/stashed/elasticsearch/commit/01e177ca) Remove docker registry support (#1560)
+
+
+### [6.4.0-v33](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v33)
+
+- [542f3af6](https://github.com/stashed/elasticsearch/commit/542f3af6) Prepare for release 6.4.0-v33 (#1582)
+- [9cb0f847](https://github.com/stashed/elasticsearch/commit/9cb0f847) Use debian:12 base image (#1568) (#1572)
+- [fe39fce0](https://github.com/stashed/elasticsearch/commit/fe39fce0) Remove docker registry support (#1561)
+
+
+### [6.5.3-v33](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v33)
+
+- [8432af1e](https://github.com/stashed/elasticsearch/commit/8432af1e) Prepare for release 6.5.3-v33 (#1583)
+- [06c360e0](https://github.com/stashed/elasticsearch/commit/06c360e0) Use debian:12 base image (#1568) (#1573)
+- [d1e0a4cc](https://github.com/stashed/elasticsearch/commit/d1e0a4cc) Remove docker registry support (#1562)
+
+
+### [6.8.0-v33](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v33)
+
+- [65ee63c2](https://github.com/stashed/elasticsearch/commit/65ee63c2) Prepare for release 6.8.0-v33 (#1584)
+- [fcf09b2f](https://github.com/stashed/elasticsearch/commit/fcf09b2f) Use debian:12 base image (#1568) (#1574)
+- [0d6061c6](https://github.com/stashed/elasticsearch/commit/0d6061c6) Remove docker registry support (#1563)
+
+
+### [7.2.0-v33](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v33)
+
+- [f6fc183c](https://github.com/stashed/elasticsearch/commit/f6fc183c) Prepare for release 7.2.0-v33 (#1586)
+- [2c36fd90](https://github.com/stashed/elasticsearch/commit/2c36fd90) Use debian:12 base image (#1568) (#1576)
+- [67539698](https://github.com/stashed/elasticsearch/commit/67539698) Remove docker registry support (#1565)
+
+
+### [7.3.2-v33](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v33)
+
+- [20d1e671](https://github.com/stashed/elasticsearch/commit/20d1e671) Prepare for release 7.3.2-v33 (#1587)
+- [cd431ad2](https://github.com/stashed/elasticsearch/commit/cd431ad2) Use debian:12 base image (#1568) (#1577)
+- [f7f4f242](https://github.com/stashed/elasticsearch/commit/f7f4f242) Remove docker registry support (#1566)
+
+
+### [7.14.0-v19](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v19)
+
+- [123a2ac8](https://github.com/stashed/elasticsearch/commit/123a2ac8) Prepare for release 7.14.0-v19 (#1585)
+- [348a3cbf](https://github.com/stashed/elasticsearch/commit/348a3cbf) Use debian:12 base image (#1568) (#1575)
+- [3275d2b7](https://github.com/stashed/elasticsearch/commit/3275d2b7) Remove docker registry support (#1564)
+
+
+### [8.2.0-v16](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v16)
+
+- [22c08e5e](https://github.com/stashed/elasticsearch/commit/22c08e5e) Prepare for release 8.2.0-v16 (#1588)
+- [a1fa89fb](https://github.com/stashed/elasticsearch/commit/a1fa89fb) Use debian:12 base image (#1568) (#1578)
+- [3953e658](https://github.com/stashed/elasticsearch/commit/3953e658) Remove docker registry support (#1567)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.37.0](https://github.com/stashed/enterprise/releases/tag/v0.37.0)
+
+- [bd5b4582](https://github.com/stashed/enterprise/commit/bd5b45826) Prepare for release v0.37.0 (#260)
+- [ce7dcec5](https://github.com/stashed/enterprise/commit/ce7dcec59) Use debian:12 base image (#259)
+- [2cc2b868](https://github.com/stashed/enterprise/commit/2cc2b8689) Use debian:12 base image (#258)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v20](https://github.com/stashed/etcd/releases/tag/3.5.0-v20)
+
+- [5e4749a](https://github.com/stashed/etcd/commit/5e4749a) Prepare for release 3.5.0-v20 (#106)
+- [75abfaa](https://github.com/stashed/etcd/commit/75abfaa) [cherry-pick] Use debian:12 base image (#104) (#105)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2024.12.18](https://github.com/stashed/installer/releases/tag/v2024.12.18)
+
+- [848c27da](https://github.com/stashed/installer/commit/848c27da) Prepare for release v2024.12.18 (#381)
+- [f3a6becb](https://github.com/stashed/installer/commit/f3a6becb) Check image arch (#377)
+- [96d42726](https://github.com/stashed/installer/commit/96d42726) Add `multi-dump-args` in backup arguments section (#373)
+- [c69f9823](https://github.com/stashed/installer/commit/c69f9823) Update cve report (#379)
+- [3acacc8f](https://github.com/stashed/installer/commit/3acacc8f) Update cve report (#378)
+- [00187530](https://github.com/stashed/installer/commit/00187530) Update cve report (#376)
+- [0ffdef58](https://github.com/stashed/installer/commit/0ffdef58) Update cve report (#375)
+- [1049873b](https://github.com/stashed/installer/commit/1049873b) Update cve report (#374)
+- [cc0e41e3](https://github.com/stashed/installer/commit/cc0e41e3) Update cve report (#372)
+- [fc059f8d](https://github.com/stashed/installer/commit/fc059f8d) Update cve report (#371)
+- [bed81bf8](https://github.com/stashed/installer/commit/bed81bf8) Use kind v0.25.0 (#370)
+- [79852fb8](https://github.com/stashed/installer/commit/79852fb8) Update cve report (#369)
+- [5b58fc1e](https://github.com/stashed/installer/commit/5b58fc1e) Update cve report (#368)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.1.0-v16](https://github.com/stashed/kubedump/releases/tag/0.1.0-v16)
+
+- [7b4ed69](https://github.com/stashed/kubedump/commit/7b4ed69) Prepare for release 0.1.0-v16 (#74)
+- [0e56b50](https://github.com/stashed/kubedump/commit/0e56b50) Use debian:12 base image (#72) (#73)
+- [77f8072](https://github.com/stashed/kubedump/commit/77f8072) [cherry-pick] Use debian:12 base image (#70) (#71)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v27](https://github.com/stashed/mariadb/releases/tag/10.5.8-v27)
+
+- [dbc3a4e6](https://github.com/stashed/mariadb/commit/dbc3a4e6) Prepare for release 10.5.8-v27 (#254)
+- [725695de](https://github.com/stashed/mariadb/commit/725695de) [cherry-pick] Use debian:12 base image (#252) (#253)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v34](https://github.com/stashed/mongodb/releases/tag/3.4.17-v34)
+
+- [b99e6dd1](https://github.com/stashed/mongodb/commit/b99e6dd1) Prepare for release 3.4.17-v34 (#2221)
+- [9554ccd0](https://github.com/stashed/mongodb/commit/9554ccd0) Use debian:12 base image (#2205) (#2206)
+
+
+### [3.4.22-v34](https://github.com/stashed/mongodb/releases/tag/3.4.22-v34)
+
+- [5697da70](https://github.com/stashed/mongodb/commit/5697da70) Prepare for release 3.4.22-v34 (#2222)
+- [070a6a8c](https://github.com/stashed/mongodb/commit/070a6a8c) Use debian:12 base image (#2205) (#2207)
+
+
+### [3.6.8-v34](https://github.com/stashed/mongodb/releases/tag/3.6.8-v34)
+
+- [6337c127](https://github.com/stashed/mongodb/commit/6337c127) Prepare for release 3.6.8-v34 (#2224)
+- [7174720b](https://github.com/stashed/mongodb/commit/7174720b) Use debian:12 base image (#2205) (#2209)
+
+
+### [3.6.13-v34](https://github.com/stashed/mongodb/releases/tag/3.6.13-v34)
+
+- [39b9cd24](https://github.com/stashed/mongodb/commit/39b9cd24) Prepare for release 3.6.13-v34 (#2223)
+- [714113ca](https://github.com/stashed/mongodb/commit/714113ca) Use debian:12 base image (#2205) (#2208)
+
+
+### [4.0.3-v34](https://github.com/stashed/mongodb/releases/tag/4.0.3-v34)
+
+- [3eb3037d](https://github.com/stashed/mongodb/commit/3eb3037d) Prepare for release 4.0.3-v34 (#2226)
+- [2df3bd50](https://github.com/stashed/mongodb/commit/2df3bd50) Use debian:12 base image (#2205) (#2211)
+
+
+### [4.0.5-v34](https://github.com/stashed/mongodb/releases/tag/4.0.5-v34)
+
+- [ecfd742c](https://github.com/stashed/mongodb/commit/ecfd742c) Prepare for release 4.0.5-v34 (#2227)
+- [84e91774](https://github.com/stashed/mongodb/commit/84e91774) Use debian:12 base image (#2205) (#2212)
+
+
+### [4.0.11-v34](https://github.com/stashed/mongodb/releases/tag/4.0.11-v34)
+
+- [152dd128](https://github.com/stashed/mongodb/commit/152dd128) Prepare for release 4.0.11-v34 (#2225)
+- [c717178e](https://github.com/stashed/mongodb/commit/c717178e) Use debian:12 base image (#2205) (#2210)
+
+
+### [4.1.4-v34](https://github.com/stashed/mongodb/releases/tag/4.1.4-v34)
+
+- [415a1cad](https://github.com/stashed/mongodb/commit/415a1cad) Prepare for release 4.1.4-v34 (#2229)
+- [b2862276](https://github.com/stashed/mongodb/commit/b2862276) Use debian:12 base image (#2205) (#2214)
+
+
+### [4.1.7-v34](https://github.com/stashed/mongodb/releases/tag/4.1.7-v34)
+
+- [34588eaa](https://github.com/stashed/mongodb/commit/34588eaa) Prepare for release 4.1.7-v34 (#2230)
+- [0c0e202f](https://github.com/stashed/mongodb/commit/0c0e202f) Use debian:12 base image (#2205) (#2215)
+
+
+### [4.1.13-v34](https://github.com/stashed/mongodb/releases/tag/4.1.13-v34)
+
+- [1f742d4b](https://github.com/stashed/mongodb/commit/1f742d4b) Prepare for release 4.1.13-v34 (#2228)
+- [19c6d407](https://github.com/stashed/mongodb/commit/19c6d407) Use debian:12 base image (#2205) (#2213)
+
+
+### [4.2.3-v34](https://github.com/stashed/mongodb/releases/tag/4.2.3-v34)
+
+- [21242246](https://github.com/stashed/mongodb/commit/21242246) Prepare for release 4.2.3-v34 (#2231)
+- [153a446f](https://github.com/stashed/mongodb/commit/153a446f) Use debian:12 base image (#2205) (#2216)
+
+
+### [4.4.6-v25](https://github.com/stashed/mongodb/releases/tag/4.4.6-v25)
+
+- [5e514650](https://github.com/stashed/mongodb/commit/5e514650) Prepare for release 4.4.6-v25 (#2232)
+- [b37818d5](https://github.com/stashed/mongodb/commit/b37818d5) Use debian:12 base image (#2205) (#2217)
+
+
+### [5.0.3-v22](https://github.com/stashed/mongodb/releases/tag/5.0.3-v22)
+
+- [537a6863](https://github.com/stashed/mongodb/commit/537a6863) Prepare for release 5.0.3-v22 (#2234)
+- [26f41d15](https://github.com/stashed/mongodb/commit/26f41d15) Use debian:12 base image (#2205) (#2219)
+
+
+### [5.0.15-v7](https://github.com/stashed/mongodb/releases/tag/5.0.15-v7)
+
+- [d80984a1](https://github.com/stashed/mongodb/commit/d80984a1) Prepare for release 5.0.15-v7 (#2233)
+- [476f673d](https://github.com/stashed/mongodb/commit/476f673d) Use debian:12 base image (#2205) (#2218)
+
+
+### [6.0.5-v10](https://github.com/stashed/mongodb/releases/tag/6.0.5-v10)
+
+- [bb7a2e10](https://github.com/stashed/mongodb/commit/bb7a2e10) Prepare for release 6.0.5-v10 (#2235)
+- [85edc0ff](https://github.com/stashed/mongodb/commit/85edc0ff) Use debian:12 base image (#2205) (#2220)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v34](https://github.com/stashed/mysql/releases/tag/5.7.25-v34)
+
+- [58817a8a](https://github.com/stashed/mysql/commit/58817a8a) Prepare for release 5.7.25-v33 (#807)
+- [d66c5633](https://github.com/stashed/mysql/commit/d66c5633) [cherry-pick] Add support for providing multiple dump args (#802) (#803)
+
+
+### [8.0.3-v33](https://github.com/stashed/mysql/releases/tag/8.0.3-v33)
+
+- [683a19f1](https://github.com/stashed/mysql/commit/683a19f1) Prepare for release 8.0.3-v33 (#810)
+- [07d774a0](https://github.com/stashed/mysql/commit/07d774a0) [cherry-pick] Add support for providing multiple dump args (#802) (#806)
+- [cc9420a7](https://github.com/stashed/mysql/commit/cc9420a7) [cherry-pick] Use debian:12 base image (#796) (#800)
+- [7533b851](https://github.com/stashed/mysql/commit/7533b851) Remove docker registry support (#795)
+
+
+### [8.0.14-v33](https://github.com/stashed/mysql/releases/tag/8.0.14-v33)
+
+- [c600101a](https://github.com/stashed/mysql/commit/c600101a) Prepare for release 8.0.14-v33 (#808)
+- [6ad5f067](https://github.com/stashed/mysql/commit/6ad5f067) [cherry-pick] Add support for providing multiple dump args (#802) (#804)
+- [4519bfaa](https://github.com/stashed/mysql/commit/4519bfaa) [cherry-pick] Use debian:12 base image (#796) (#798)
+- [240674b5](https://github.com/stashed/mysql/commit/240674b5) Remove docker registry support (#793)
+
+
+### [8.0.21-v27](https://github.com/stashed/mysql/releases/tag/8.0.21-v27)
+
+- [d86ac5d7](https://github.com/stashed/mysql/commit/d86ac5d7) Prepare for release 8.0.21-v27 (#809)
+- [5bbf3746](https://github.com/stashed/mysql/commit/5bbf3746) [cherry-pick] Add support for providing multiple dump args (#802) (#805)
+- [321d4b46](https://github.com/stashed/mysql/commit/321d4b46) [cherry-pick] Use debian:12 base image (#796) (#799)
+- [a1c214b1](https://github.com/stashed/mysql/commit/a1c214b1) Remove docker registry support (#794)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v21](https://github.com/stashed/nats/releases/tag/2.6.1-v21)
+
+- [434cc9a](https://github.com/stashed/nats/commit/434cc9a) Prepare for release 2.6.1-v21 (#160)
+- [c905550](https://github.com/stashed/nats/commit/c905550) Use debian:12 base image (#157) (#158)
+- [157dde7](https://github.com/stashed/nats/commit/157dde7) Use debian:12 base image (#154) (#155)
+
+
+### [2.8.2-v16](https://github.com/stashed/nats/releases/tag/2.8.2-v16)
+
+- [dae9f36](https://github.com/stashed/nats/commit/dae9f36) Prepare for release 2.8.2-v16 (#161)
+- [0cbaec7](https://github.com/stashed/nats/commit/0cbaec7) [cherry-pick] Use debian:12 base image (#157) (#159)
+- [0530b04](https://github.com/stashed/nats/commit/0530b04) [cherry-pick] Use debian:12 base image (#154) (#156)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v28](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v28)
+
+- [a27e9057](https://github.com/stashed/percona-xtradb/commit/a27e9057) Prepare for release 5.7-v28 (#329)
+- [b1ed0e79](https://github.com/stashed/percona-xtradb/commit/b1ed0e79) Use debian:12 base image (#327) (#328)
+- [f09b7459](https://github.com/stashed/percona-xtradb/commit/f09b7459) [cherry-pick] Use debian:12 base image (#325) (#326)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v32](https://github.com/stashed/postgres/releases/tag/9.6.19-v32)
+
+- [3bae251e](https://github.com/stashed/postgres/commit/3bae251e) Prepare for release 9.6.19-v32 (#1373)
+- [c555e6b8](https://github.com/stashed/postgres/commit/c555e6b8) Use debian:12 base image (#1356) (#1364)
+- [5605ba9c](https://github.com/stashed/postgres/commit/5605ba9c) Fix ci (#1355)
+- [4bb344d5](https://github.com/stashed/postgres/commit/4bb344d5) Remove docker registry (#1347)
+
+
+### [10.14-v32](https://github.com/stashed/postgres/releases/tag/10.14-v32)
+
+- [aa4657a6](https://github.com/stashed/postgres/commit/aa4657a6) Prepare for release 10.14-v32 (#1366)
+- [9bbd920b](https://github.com/stashed/postgres/commit/9bbd920b) Use debian:12 base image (#1356) (#1357)
+- [3b30ab34](https://github.com/stashed/postgres/commit/3b30ab34) Fix ci (#1348)
+- [7f5e6613](https://github.com/stashed/postgres/commit/7f5e6613) Remove docker registry (#1340)
+
+
+### [11.9-v32](https://github.com/stashed/postgres/releases/tag/11.9-v32)
+
+- [431f2f10](https://github.com/stashed/postgres/commit/431f2f10) Prepare for release 11.9-v32 (#1367)
+- [8af85dc1](https://github.com/stashed/postgres/commit/8af85dc1) Use debian:12 base image (#1356) (#1358)
+- [0d2a64fd](https://github.com/stashed/postgres/commit/0d2a64fd) Fix ci (#1349)
+- [1c5830ee](https://github.com/stashed/postgres/commit/1c5830ee) Remove docker registry (#1341)
+
+
+### [12.4-v32](https://github.com/stashed/postgres/releases/tag/12.4-v32)
+
+- [529981a3](https://github.com/stashed/postgres/commit/529981a3) Prepare for release 12.4-v32 (#1368)
+- [f7e4e660](https://github.com/stashed/postgres/commit/f7e4e660) Use debian:12 base image (#1356) (#1359)
+- [557c5946](https://github.com/stashed/postgres/commit/557c5946) Fix ci (#1350)
+- [90f32a1f](https://github.com/stashed/postgres/commit/90f32a1f) Remove docker registry (#1342)
+
+
+### [13.1-v29](https://github.com/stashed/postgres/releases/tag/13.1-v29)
+
+- [998cba50](https://github.com/stashed/postgres/commit/998cba50) Prepare for release 13.1-v29 (#1369)
+- [1a52d04b](https://github.com/stashed/postgres/commit/1a52d04b) Use debian:12 base image (#1356) (#1360)
+- [f32c0a37](https://github.com/stashed/postgres/commit/f32c0a37) Fix ci (#1351)
+- [5fa262a2](https://github.com/stashed/postgres/commit/5fa262a2) Remove docker registry (#1343)
+
+
+### [14.0-v21](https://github.com/stashed/postgres/releases/tag/14.0-v21)
+
+- [aaaebf71](https://github.com/stashed/postgres/commit/aaaebf71) Prepare for release 14.0-v21 (#1370)
+- [98335c4a](https://github.com/stashed/postgres/commit/98335c4a) Use debian:12 base image (#1356) (#1361)
+- [105f7907](https://github.com/stashed/postgres/commit/105f7907) Fix ci (#1352)
+- [a765c0d9](https://github.com/stashed/postgres/commit/a765c0d9) Remove docker registry (#1344)
+
+
+### [15.1-v13](https://github.com/stashed/postgres/releases/tag/15.1-v13)
+
+- [c28f4b49](https://github.com/stashed/postgres/commit/c28f4b49) Prepare for release 15.1-v13 (#1371)
+- [3cc8aef2](https://github.com/stashed/postgres/commit/3cc8aef2) Use debian:12 base image (#1356) (#1362)
+- [246e3a4c](https://github.com/stashed/postgres/commit/246e3a4c) Fix ci (#1353)
+- [dda4a557](https://github.com/stashed/postgres/commit/dda4a557) Remove docker registry (#1345)
+
+
+### [16.1-v2](https://github.com/stashed/postgres/releases/tag/16.1-v2)
+
+- [b78b6322](https://github.com/stashed/postgres/commit/b78b6322) Prepare for release 16.1-v2 (#1372)
+- [8352a9b3](https://github.com/stashed/postgres/commit/8352a9b3) Use debian:12 base image (#1356) (#1363)
+- [b07338b7](https://github.com/stashed/postgres/commit/b07338b7) Fix ci (#1354)
+- [3b2ec15c](https://github.com/stashed/postgres/commit/3b2ec15c) Remove docker registry (#1346)
+
+
+### [17.2](https://github.com/stashed/postgres/releases/tag/17.2)
+
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v21](https://github.com/stashed/redis/releases/tag/5.0.13-v21)
+
+- [0eb9fce](https://github.com/stashed/redis/commit/0eb9fce) Prepare for release 5.0.13-v21 (#243)
+- [5a8f4c0](https://github.com/stashed/redis/commit/5a8f4c0) Use debian:12 base image (#239) (#240)
+- [b35422d](https://github.com/stashed/redis/commit/b35422d) Remove docker registry (#236)
+
+
+### [6.2.5-v21](https://github.com/stashed/redis/releases/tag/6.2.5-v21)
+
+- [8cadd6c](https://github.com/stashed/redis/commit/8cadd6c) Prepare for release 6.2.5-v21 (#244)
+- [e4c7393](https://github.com/stashed/redis/commit/e4c7393) Use debian:12 base image (#239) (#241)
+- [b4aa39f](https://github.com/stashed/redis/commit/b4aa39f) Remove docker registry (#237)
+
+
+### [7.0.5-v14](https://github.com/stashed/redis/releases/tag/7.0.5-v14)
+
+- [e3ac0a9](https://github.com/stashed/redis/commit/e3ac0a9) Prepare for release 7.0.5-v14 (#246)
+- [09d4fbd](https://github.com/stashed/redis/commit/09d4fbd) Use debian:12 base image (#239) (#242)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.37.0](https://github.com/stashed/stash/releases/tag/v0.37.0)
+
+- [a4703c42](https://github.com/stashed/stash/commit/a4703c429) Prepare for release v0.37.0 (#1587)
+- [771f9c2a](https://github.com/stashed/stash/commit/771f9c2a0) Use kind v0.25.0 (#1585)
+- [6692288a](https://github.com/stashed/stash/commit/6692288a3) Use debian:12 base image (#1584)
+- [018ff2f7](https://github.com/stashed/stash/commit/018ff2f7f) Use debian:12 base image (#1582)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.18.0](https://github.com/stashed/ui-server/releases/tag/v0.18.0)
+
+- [c9376e31](https://github.com/stashed/ui-server/commit/c9376e31) Prepare for release v0.18.0 (#44)
+- [7f38e876](https://github.com/stashed/ui-server/commit/7f38e876) Use debian:12 base image (#43)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v13](https://github.com/stashed/vault/releases/tag/1.10.3-v13)
+
+- [49099011](https://github.com/stashed/vault/commit/49099011) Prepare for release 1.10.3-v13 (#47)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.12.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/77
Signed-off-by: 1gtm <1gtm@appscode.com>