### PR TITLE
Prepare for release v2025.1.9

### DIFF
--- a/docs/CHANGELOG-v2025.1.9.md
+++ b/docs/CHANGELOG-v2025.1.9.md
@@ -1,0 +1,365 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2025.1.9
+    name: Changelog-v2025.1.9
+    parent: welcome
+    weight: 20250109
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.1.9/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.1.9/
+---
+
+# Stash v2025.1.9 (2025-01-08)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.38.0](https://github.com/stashed/apimachinery/releases/tag/v0.38.0)
+
+- [498a6be5](https://github.com/stashed/apimachinery/commit/498a6be5) Print license expiration timestamp
+- [5284189f](https://github.com/stashed/apimachinery/commit/5284189f) Fix patching
+- [47ce09a4](https://github.com/stashed/apimachinery/commit/47ce09a4) Update github action modules (#231)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.38.0](https://github.com/stashed/cli/releases/tag/v0.38.0)
+
+- [cad2245d](https://github.com/stashed/cli/commit/cad2245d) Prepare for release v0.38.0 (#209)
+- [8a3c87ab](https://github.com/stashed/cli/commit/8a3c87ab) Update website link
+- [107959f1](https://github.com/stashed/cli/commit/107959f1) Update github action modules (#207)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v34](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v34)
+
+- [bde4b6d0](https://github.com/stashed/elasticsearch/commit/bde4b6d0) Prepare for release 5.6.4-v34 (#1592)
+
+
+### [6.2.4-v34](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v34)
+
+- [3cba0f11](https://github.com/stashed/elasticsearch/commit/3cba0f11) Prepare for release 6.2.4-v34 (#1593)
+
+
+### [6.3.0-v34](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v34)
+
+- [e236c166](https://github.com/stashed/elasticsearch/commit/e236c166) Prepare for release 6.3.0-v34 (#1594)
+
+
+### [6.4.0-v34](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v34)
+
+- [26ce88af](https://github.com/stashed/elasticsearch/commit/26ce88af) Prepare for release 6.4.0-v34 (#1595)
+
+
+### [6.5.3-v34](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v34)
+
+- [134e2307](https://github.com/stashed/elasticsearch/commit/134e2307) Prepare for release 6.5.3-v34 (#1596)
+
+
+### [6.8.0-v34](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v34)
+
+- [fbbbd83e](https://github.com/stashed/elasticsearch/commit/fbbbd83e) Prepare for release 6.8.0-v34 (#1597)
+
+
+### [7.2.0-v34](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v34)
+
+- [964b8382](https://github.com/stashed/elasticsearch/commit/964b8382) Prepare for release 7.2.0-v34 (#1599)
+
+
+### [7.3.2-v34](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v34)
+
+- [a2ed9fd2](https://github.com/stashed/elasticsearch/commit/a2ed9fd2) Prepare for release 7.3.2-v34 (#1600)
+
+
+### [7.14.0-v20](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v20)
+
+- [f4adf6e4](https://github.com/stashed/elasticsearch/commit/f4adf6e4) Prepare for release 7.14.0-v20 (#1598)
+
+
+### [8.2.0-v17](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v17)
+
+- [1453067d](https://github.com/stashed/elasticsearch/commit/1453067d) Prepare for release 8.2.0-v17 (#1601)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.38.0](https://github.com/stashed/enterprise/releases/tag/v0.38.0)
+
+- [9d7359fb](https://github.com/stashed/enterprise/commit/9d7359fb0) Prepare for release v0.38.0 (#263)
+- [ff2132de](https://github.com/stashed/enterprise/commit/ff2132ded) Update github action modules (#261)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v21](https://github.com/stashed/etcd/releases/tag/3.5.0-v21)
+
+- [faff449](https://github.com/stashed/etcd/commit/faff449) Prepare for release 3.5.0-v21 (#110)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2025.1.9](https://github.com/stashed/installer/releases/tag/v2025.1.9)
+
+- [50ebd27e](https://github.com/stashed/installer/commit/50ebd27e) Prepare for release v2025.1.9 (#389)
+- [bf00e04e](https://github.com/stashed/installer/commit/bf00e04e) Update cve report (#388)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.2.0-v2](https://github.com/stashed/kubedump/releases/tag/0.2.0-v2)
+
+- [46b182e](https://github.com/stashed/kubedump/commit/46b182e) Prepare for release 0.2.0-v2 (#79)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v28](https://github.com/stashed/mariadb/releases/tag/10.5.8-v28)
+
+- [5ca38f79](https://github.com/stashed/mariadb/commit/5ca38f79) Prepare for release 10.5.8-v28 (#258)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v35](https://github.com/stashed/mongodb/releases/tag/3.4.17-v35)
+
+- [4465b3d2](https://github.com/stashed/mongodb/commit/4465b3d2) Prepare for release 3.4.17-v35 (#2253)
+- [1bd26b49](https://github.com/stashed/mongodb/commit/1bd26b49) [cherry-pick] Update github action modules (#2237) (#2238)
+
+
+### [3.4.22-v35](https://github.com/stashed/mongodb/releases/tag/3.4.22-v35)
+
+- [0cc7b736](https://github.com/stashed/mongodb/commit/0cc7b736) Prepare for release 3.4.22-v35 (#2254)
+- [52d14959](https://github.com/stashed/mongodb/commit/52d14959) Update github action modules (#2237) (#2239)
+
+
+### [3.6.8-v35](https://github.com/stashed/mongodb/releases/tag/3.6.8-v35)
+
+- [cf104dd5](https://github.com/stashed/mongodb/commit/cf104dd5) Prepare for release 3.6.8-v35 (#2256)
+- [2f4dad74](https://github.com/stashed/mongodb/commit/2f4dad74) Update github action modules (#2237) (#2241)
+
+
+### [3.6.13-v35](https://github.com/stashed/mongodb/releases/tag/3.6.13-v35)
+
+- [7c55b6ac](https://github.com/stashed/mongodb/commit/7c55b6ac) Prepare for release 3.6.13-v35 (#2255)
+- [28107bc3](https://github.com/stashed/mongodb/commit/28107bc3) Update github action modules (#2237) (#2240)
+
+
+### [4.0.3-v35](https://github.com/stashed/mongodb/releases/tag/4.0.3-v35)
+
+- [81e23d1e](https://github.com/stashed/mongodb/commit/81e23d1e) Prepare for release 4.0.3-v35 (#2258)
+- [aaf7583b](https://github.com/stashed/mongodb/commit/aaf7583b) Update github action modules (#2237) (#2243)
+
+
+### [4.0.5-v35](https://github.com/stashed/mongodb/releases/tag/4.0.5-v35)
+
+- [c8155ef9](https://github.com/stashed/mongodb/commit/c8155ef9) Prepare for release 4.0.5-v35 (#2259)
+- [eec6152b](https://github.com/stashed/mongodb/commit/eec6152b) Update github action modules (#2237) (#2244)
+
+
+### [4.0.11-v35](https://github.com/stashed/mongodb/releases/tag/4.0.11-v35)
+
+- [a559af87](https://github.com/stashed/mongodb/commit/a559af87) Prepare for release 4.0.11-v35 (#2257)
+- [d8c2d720](https://github.com/stashed/mongodb/commit/d8c2d720) Update github action modules (#2237) (#2242)
+
+
+### [4.1.4-v35](https://github.com/stashed/mongodb/releases/tag/4.1.4-v35)
+
+- [97d59d84](https://github.com/stashed/mongodb/commit/97d59d84) Prepare for release 4.1.4-v35 (#2261)
+- [80e1a02f](https://github.com/stashed/mongodb/commit/80e1a02f) Update github action modules (#2237) (#2246)
+
+
+### [4.1.7-v35](https://github.com/stashed/mongodb/releases/tag/4.1.7-v35)
+
+- [663bf53d](https://github.com/stashed/mongodb/commit/663bf53d) Prepare for release 4.1.7-v35 (#2262)
+- [b8205b24](https://github.com/stashed/mongodb/commit/b8205b24) Update github action modules (#2237) (#2247)
+
+
+### [4.1.13-v35](https://github.com/stashed/mongodb/releases/tag/4.1.13-v35)
+
+- [54d299ff](https://github.com/stashed/mongodb/commit/54d299ff) Prepare for release 4.1.13-v35 (#2260)
+- [d2258afc](https://github.com/stashed/mongodb/commit/d2258afc) Update github action modules (#2237) (#2245)
+
+
+### [4.2.3-v35](https://github.com/stashed/mongodb/releases/tag/4.2.3-v35)
+
+- [ec44fe21](https://github.com/stashed/mongodb/commit/ec44fe21) Prepare for release 4.2.3-v35 (#2263)
+- [c33a7092](https://github.com/stashed/mongodb/commit/c33a7092) Update github action modules (#2237) (#2248)
+
+
+### [4.4.6-v26](https://github.com/stashed/mongodb/releases/tag/4.4.6-v26)
+
+- [d39714ec](https://github.com/stashed/mongodb/commit/d39714ec) Prepare for release 4.4.6-v26 (#2264)
+- [a2f27a49](https://github.com/stashed/mongodb/commit/a2f27a49) Update github action modules (#2237) (#2249)
+
+
+### [5.0.3-v23](https://github.com/stashed/mongodb/releases/tag/5.0.3-v23)
+
+- [24c25729](https://github.com/stashed/mongodb/commit/24c25729) Prepare for release 5.0.3-v23 (#2266)
+- [ab0e5df8](https://github.com/stashed/mongodb/commit/ab0e5df8) Update github action modules (#2237) (#2251)
+
+
+### [5.0.15-v8](https://github.com/stashed/mongodb/releases/tag/5.0.15-v8)
+
+- [86e3bf04](https://github.com/stashed/mongodb/commit/86e3bf04) Prepare for release 5.0.15-v8 (#2265)
+- [8e62c556](https://github.com/stashed/mongodb/commit/8e62c556) Update github action modules (#2237) (#2250)
+
+
+### [6.0.5-v11](https://github.com/stashed/mongodb/releases/tag/6.0.5-v11)
+
+- [67cff5f0](https://github.com/stashed/mongodb/commit/67cff5f0) Prepare for release 6.0.5-v11 (#2267)
+- [c863e013](https://github.com/stashed/mongodb/commit/c863e013) Update github action modules (#2237) (#2252)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v35](https://github.com/stashed/mysql/releases/tag/5.7.25-v35)
+
+- [575329d2](https://github.com/stashed/mysql/commit/575329d2) Prepare for release 5.7.25-v35 (#815)
+
+
+### [8.0.3-v34](https://github.com/stashed/mysql/releases/tag/8.0.3-v34)
+
+- [7c000b67](https://github.com/stashed/mysql/commit/7c000b67) Prepare for release 8.0.3-v34 (#818)
+
+
+### [8.0.14-v34](https://github.com/stashed/mysql/releases/tag/8.0.14-v34)
+
+- [38197fa3](https://github.com/stashed/mysql/commit/38197fa3) Prepare for release 8.0.14-v34 (#816)
+
+
+### [8.0.21-v28](https://github.com/stashed/mysql/releases/tag/8.0.21-v28)
+
+- [77e793e7](https://github.com/stashed/mysql/commit/77e793e7) Prepare for release 8.0.21-v28 (#817)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v22](https://github.com/stashed/nats/releases/tag/2.6.1-v22)
+
+- [a8c11b8](https://github.com/stashed/nats/commit/a8c11b8) Prepare for release 2.6.1-v22 (#165)
+
+
+### [2.8.2-v17](https://github.com/stashed/nats/releases/tag/2.8.2-v17)
+
+- [de67b44](https://github.com/stashed/nats/commit/de67b44) Prepare for release 2.8.2-v17 (#166)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v29](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v29)
+
+- [7e1b3fbc](https://github.com/stashed/percona-xtradb/commit/7e1b3fbc) Prepare for release 5.7-v29 (#333)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v33](https://github.com/stashed/postgres/releases/tag/9.6.19-v33)
+
+- [4c034aef](https://github.com/stashed/postgres/commit/4c034aef) Prepare for release 9.6.19-v33 (#1385)
+
+
+### [10.14-v33](https://github.com/stashed/postgres/releases/tag/10.14-v33)
+
+- [a6a1804d](https://github.com/stashed/postgres/commit/a6a1804d) Prepare for release 10.14-v33 (#1378)
+
+
+### [11.9-v33](https://github.com/stashed/postgres/releases/tag/11.9-v33)
+
+- [4f49de35](https://github.com/stashed/postgres/commit/4f49de35) Prepare for release 11.9-v33 (#1379)
+
+
+### [12.4-v33](https://github.com/stashed/postgres/releases/tag/12.4-v33)
+
+- [86ac876c](https://github.com/stashed/postgres/commit/86ac876c) Prepare for release 12.4-v33 (#1380)
+
+
+### [13.1-v30](https://github.com/stashed/postgres/releases/tag/13.1-v30)
+
+- [41819e5f](https://github.com/stashed/postgres/commit/41819e5f) Prepare for release 13.1-v30 (#1381)
+
+
+### [14.0-v22](https://github.com/stashed/postgres/releases/tag/14.0-v22)
+
+- [1e0cd351](https://github.com/stashed/postgres/commit/1e0cd351) Prepare for release 14.0-v22 (#1382)
+
+
+### [15.1-v14](https://github.com/stashed/postgres/releases/tag/15.1-v14)
+
+- [f5ddc525](https://github.com/stashed/postgres/commit/f5ddc525) Prepare for release 15.1-v14 (#1383)
+
+
+### [16.1-v3](https://github.com/stashed/postgres/releases/tag/16.1-v3)
+
+- [92e7938b](https://github.com/stashed/postgres/commit/92e7938b) Prepare for release 16.1-v3 (#1384)
+
+
+### [17.2-v1](https://github.com/stashed/postgres/releases/tag/17.2-v1)
+
+- [2bcfcf25](https://github.com/stashed/postgres/commit/2bcfcf25) Prepare for release v2025.1.9 (#1386) (#1387)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v22](https://github.com/stashed/redis/releases/tag/5.0.13-v22)
+
+- [64de9a5](https://github.com/stashed/redis/commit/64de9a5) Prepare for release 5.0.13-v22 (#250)
+
+
+### [6.2.5-v22](https://github.com/stashed/redis/releases/tag/6.2.5-v22)
+
+- [9159407](https://github.com/stashed/redis/commit/9159407) Prepare for release 6.2.5-v22 (#251)
+
+
+### [7.0.5-v15](https://github.com/stashed/redis/releases/tag/7.0.5-v15)
+
+- [432d847](https://github.com/stashed/redis/commit/432d847) Prepare for release 7.0.5-v15 (#252)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.38.0](https://github.com/stashed/stash/releases/tag/v0.38.0)
+
+- [149cbfb0](https://github.com/stashed/stash/commit/149cbfb0f) Prepare for release v0.38.0 (#1589)
+- [b2d2d3a5](https://github.com/stashed/stash/commit/b2d2d3a57) Update github action modules (#1588)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.19.0](https://github.com/stashed/ui-server/releases/tag/v0.19.0)
+
+- [41dc9b16](https://github.com/stashed/ui-server/commit/41dc9b16) Prepare for release v0.19.0 (#46)
+- [17d88fc2](https://github.com/stashed/ui-server/commit/17d88fc2) Update github action modules (#45)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v14](https://github.com/stashed/vault/releases/tag/1.10.3-v14)
+
+- [9067757e](https://github.com/stashed/vault/commit/9067757e) Prepare for release 1.10.3-v14 (#51)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2025.1.9
Release-tracker: https://github.com/stashed/CHANGELOG/pull/79
Signed-off-by: 1gtm <1gtm@appscode.com>