### PR TITLE
Prepare for release v2025.6.30

### DIFF
--- a/docs/CHANGELOG-v2025.6.30.md
+++ b/docs/CHANGELOG-v2025.6.30.md
@@ -1,0 +1,475 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2025.6.30
+    name: Changelog-v2025.6.30
+    parent: welcome
+    weight: 20250630
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.6.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.6.30/
+---
+
+# Stash v2025.6.30 (2025-06-27)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.40.0](https://github.com/stashed/apimachinery/releases/tag/v0.40.0)
+
+- [ebed5dcc](https://github.com/stashed/apimachinery/commit/ebed5dcc) Update vulnerable deps
+- [dba46622](https://github.com/stashed/apimachinery/commit/dba46622) Test against k8s 1.32 (#240)
+- [30149e76](https://github.com/stashed/apimachinery/commit/30149e76) Test against k8s 1.32 (#239)
+- [a5b165eb](https://github.com/stashed/apimachinery/commit/a5b165eb) Test against k8s 1.32 (#238)
+- [95844d1b](https://github.com/stashed/apimachinery/commit/95844d1b) Test against k8s 1.32 (#237)
+- [9e1f46fe](https://github.com/stashed/apimachinery/commit/9e1f46fe) Use Go 1.24 (#235)
+- [d3ef3bcd](https://github.com/stashed/apimachinery/commit/d3ef3bcd) Use Go 1.24 (#234)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.40.0](https://github.com/stashed/cli/releases/tag/v0.40.0)
+
+- [ea013162](https://github.com/stashed/cli/commit/ea013162) Prepare for release v0.40.0 (#213)
+- [f6e7b2cb](https://github.com/stashed/cli/commit/f6e7b2cb) Use Go 1.24 (#212)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v36](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v36)
+
+- [3e90df71](https://github.com/stashed/elasticsearch/commit/3e90df71) Prepare for release 5.6.4-v36 (#1647)
+- [657d6c15](https://github.com/stashed/elasticsearch/commit/657d6c15) Use Go 1.24 (#1636) (#1637)
+
+
+### [6.2.4-v36](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v36)
+
+- [0c5a115d](https://github.com/stashed/elasticsearch/commit/0c5a115d) Prepare for release 6.2.4-v36 (#1648)
+- [b2034944](https://github.com/stashed/elasticsearch/commit/b2034944) Use Go 1.24 (#1636) (#1638)
+
+
+### [6.3.0-v36](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v36)
+
+- [37596a84](https://github.com/stashed/elasticsearch/commit/37596a84) Prepare for release 6.3.0-v36 (#1649)
+- [03f1d3d8](https://github.com/stashed/elasticsearch/commit/03f1d3d8) Use Go 1.24 (#1636) (#1639)
+
+
+### [6.4.0-v36](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v36)
+
+- [d9ecb3c4](https://github.com/stashed/elasticsearch/commit/d9ecb3c4) Prepare for release 6.4.0-v36 (#1650)
+- [988e213c](https://github.com/stashed/elasticsearch/commit/988e213c) Use Go 1.24 (#1636) (#1640)
+
+
+### [6.5.3-v36](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v36)
+
+- [5b72bf6f](https://github.com/stashed/elasticsearch/commit/5b72bf6f) Prepare for release 6.5.3-v36 (#1651)
+- [a43f3373](https://github.com/stashed/elasticsearch/commit/a43f3373) Use Go 1.24 (#1636) (#1641)
+
+
+### [6.8.0-v36](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v36)
+
+- [95e5de70](https://github.com/stashed/elasticsearch/commit/95e5de70) Prepare for release 6.8.0-v36 (#1652)
+- [aecfa591](https://github.com/stashed/elasticsearch/commit/aecfa591) Use Go 1.24 (#1636) (#1642)
+
+
+### [7.2.0-v36](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v36)
+
+- [5a768a07](https://github.com/stashed/elasticsearch/commit/5a768a07) Prepare for release 7.2.0-v36 (#1654)
+- [f907477f](https://github.com/stashed/elasticsearch/commit/f907477f) Use Go 1.24 (#1636) (#1644)
+
+
+### [7.3.2-v36](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v36)
+
+- [4261f70e](https://github.com/stashed/elasticsearch/commit/4261f70e) Prepare for release 7.3.2-v36 (#1655)
+- [b5509445](https://github.com/stashed/elasticsearch/commit/b5509445) Use Go 1.24 (#1636) (#1645)
+
+
+### [7.14.0-v22](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v22)
+
+- [c31fbb60](https://github.com/stashed/elasticsearch/commit/c31fbb60) Prepare for release 7.14.0-v22 (#1653)
+- [fd446a94](https://github.com/stashed/elasticsearch/commit/fd446a94) Use Go 1.24 (#1636) (#1643)
+
+
+### [8.2.0-v19](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v19)
+
+- [4bbdecb9](https://github.com/stashed/elasticsearch/commit/4bbdecb9) Prepare for release 8.2.0-v19 (#1656)
+- [9c717d5c](https://github.com/stashed/elasticsearch/commit/9c717d5c) Use Go 1.24 (#1636) (#1646)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.40.0](https://github.com/stashed/enterprise/releases/tag/v0.40.0)
+
+- [991adf2c](https://github.com/stashed/enterprise/commit/991adf2c3) Prepare for release v0.40.0 (#271)
+- [5833e645](https://github.com/stashed/enterprise/commit/5833e645e) Update go.sum
+- [3b34fefb](https://github.com/stashed/enterprise/commit/3b34fefba) Add task queue feature for concurrent backupSessions (#270)
+- [1102e66a](https://github.com/stashed/enterprise/commit/1102e66af) Incrorporate with k8s-v32 changes (#269)
+- [dbe516c2](https://github.com/stashed/enterprise/commit/dbe516c2c) Stop publishing to docker hub
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v23](https://github.com/stashed/etcd/releases/tag/3.5.0-v23)
+
+- [84543a3](https://github.com/stashed/etcd/commit/84543a3) Prepare for release 3.5.0-v23 (#120)
+- [1115070](https://github.com/stashed/etcd/commit/1115070) Use Go 1.24 (#118) (#119)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2025.6.30](https://github.com/stashed/installer/releases/tag/v2025.6.30)
+
+- [2a0577f9](https://github.com/stashed/installer/commit/2a0577f9) Prepare for release v2025.6.30 (#483)
+- [a7968b37](https://github.com/stashed/installer/commit/a7968b37) Add enableTaskQueue feature for taskqueue (#475)
+- [e0518e26](https://github.com/stashed/installer/commit/e0518e26) Update cve report (#482)
+- [28728b32](https://github.com/stashed/installer/commit/28728b32) Update cve report (#481)
+- [770d1af7](https://github.com/stashed/installer/commit/770d1af7) Update cve report (#480)
+- [0fb1b60f](https://github.com/stashed/installer/commit/0fb1b60f) Update cve report (#479)
+- [ddef1625](https://github.com/stashed/installer/commit/ddef1625) Update cve report (#478)
+- [5b5b1cf4](https://github.com/stashed/installer/commit/5b5b1cf4) Update cve report (#477)
+- [61bb9a9c](https://github.com/stashed/installer/commit/61bb9a9c) Update cve report (#476)
+- [061e7f40](https://github.com/stashed/installer/commit/061e7f40) Update cve report (#474)
+- [36bc481e](https://github.com/stashed/installer/commit/36bc481e) Update cve report (#473)
+- [1bad65cb](https://github.com/stashed/installer/commit/1bad65cb) Update cve report (#472)
+- [1df2f52f](https://github.com/stashed/installer/commit/1df2f52f) Update cve report (#471)
+- [414477eb](https://github.com/stashed/installer/commit/414477eb) Update cve report (#470)
+- [3b831874](https://github.com/stashed/installer/commit/3b831874) Update cve report (#469)
+- [1dc8d0e5](https://github.com/stashed/installer/commit/1dc8d0e5) Update cve report (#468)
+- [af6e6b9f](https://github.com/stashed/installer/commit/af6e6b9f) Update cve report (#467)
+- [a7545cef](https://github.com/stashed/installer/commit/a7545cef) Update cve report (#466)
+- [00ac7508](https://github.com/stashed/installer/commit/00ac7508) Update cve report (#465)
+- [93a525c1](https://github.com/stashed/installer/commit/93a525c1) Update cve report (#464)
+- [78a91b3b](https://github.com/stashed/installer/commit/78a91b3b) Update cve report (#463)
+- [6755a475](https://github.com/stashed/installer/commit/6755a475) Update cve report (#462)
+- [f3e1dd73](https://github.com/stashed/installer/commit/f3e1dd73) Update cve report (#461)
+- [ccaebdd9](https://github.com/stashed/installer/commit/ccaebdd9) Update cve report (#460)
+- [71c5db61](https://github.com/stashed/installer/commit/71c5db61) Update cve report (#459)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.2.0-v4](https://github.com/stashed/kubedump/releases/tag/0.2.0-v4)
+
+- [48b34a2](https://github.com/stashed/kubedump/commit/48b34a2) Prepare for release 0.2.0-v4 (#92)
+- [bd041c2](https://github.com/stashed/kubedump/commit/bd041c2) Use Go 1.24 (#89) (#91)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v30](https://github.com/stashed/mariadb/releases/tag/10.5.8-v30)
+
+- [c79644b3](https://github.com/stashed/mariadb/commit/c79644b3) Prepare for release 10.5.8-v30 (#269)
+- [aa004e5e](https://github.com/stashed/mariadb/commit/aa004e5e) Use ubuntu-latest (#267) (#268)
+- [262d7bd7](https://github.com/stashed/mariadb/commit/262d7bd7) Use Go 1.24 (#265) (#266)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v37](https://github.com/stashed/mongodb/releases/tag/3.4.17-v37)
+
+- [c3f23d7f](https://github.com/stashed/mongodb/commit/c3f23d7f) Prepare for release 3.4.17-v37 (#2376)
+- [340547a1](https://github.com/stashed/mongodb/commit/340547a1) [cherry-pick] Use ubuntu-latest (#2356) (#2357)
+- [fb53db50](https://github.com/stashed/mongodb/commit/fb53db50) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2341)
+- [f02bb8be](https://github.com/stashed/mongodb/commit/f02bb8be) Use Go 1.24 (#2317) (#2318)
+
+
+### [3.4.22-v37](https://github.com/stashed/mongodb/releases/tag/3.4.22-v37)
+
+- [1039663c](https://github.com/stashed/mongodb/commit/1039663c) Prepare for release 3.4.22-v37 (#2377)
+- [62caeced](https://github.com/stashed/mongodb/commit/62caeced) [cherry-pick] Use ubuntu-latest (#2356) (#2358)
+- [0c4ab1f0](https://github.com/stashed/mongodb/commit/0c4ab1f0) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2342)
+- [29feabe7](https://github.com/stashed/mongodb/commit/29feabe7) Use Go 1.24 (#2317) (#2319)
+
+
+### [3.6.8-v37](https://github.com/stashed/mongodb/releases/tag/3.6.8-v37)
+
+- [53c67d37](https://github.com/stashed/mongodb/commit/53c67d37) Prepare for release 3.6.8-v37 (#2379)
+- [32373250](https://github.com/stashed/mongodb/commit/32373250) [cherry-pick] Use ubuntu-latest (#2356) (#2360)
+- [287f9292](https://github.com/stashed/mongodb/commit/287f9292) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2344)
+- [dce89326](https://github.com/stashed/mongodb/commit/dce89326) Use Go 1.24 (#2317) (#2321)
+
+
+### [3.6.13-v37](https://github.com/stashed/mongodb/releases/tag/3.6.13-v37)
+
+- [0f837802](https://github.com/stashed/mongodb/commit/0f837802) Prepare for release 3.6.13-v37 (#2378)
+- [8d45fd7f](https://github.com/stashed/mongodb/commit/8d45fd7f) [cherry-pick] Use ubuntu-latest (#2356) (#2359)
+- [8790623d](https://github.com/stashed/mongodb/commit/8790623d) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2343)
+- [ef63e0d6](https://github.com/stashed/mongodb/commit/ef63e0d6) Use Go 1.24 (#2317) (#2320)
+
+
+### [4.0.3-v37](https://github.com/stashed/mongodb/releases/tag/4.0.3-v37)
+
+- [4927253b](https://github.com/stashed/mongodb/commit/4927253b) Prepare for release 4.0.3-v37 (#2381)
+- [72e1b58d](https://github.com/stashed/mongodb/commit/72e1b58d) [cherry-pick] Use ubuntu-latest (#2356) (#2362)
+- [7cf30403](https://github.com/stashed/mongodb/commit/7cf30403) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2346)
+- [4a5b2064](https://github.com/stashed/mongodb/commit/4a5b2064) Use Go 1.24 (#2317) (#2323)
+
+
+### [4.0.5-v37](https://github.com/stashed/mongodb/releases/tag/4.0.5-v37)
+
+- [1a666f44](https://github.com/stashed/mongodb/commit/1a666f44) Prepare for release 4.0.5-v37 (#2382)
+- [30bb735e](https://github.com/stashed/mongodb/commit/30bb735e) Use ubuntu-latest (#2356) (#2363)
+- [a5443064](https://github.com/stashed/mongodb/commit/a5443064) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2347)
+- [f002dabc](https://github.com/stashed/mongodb/commit/f002dabc) Use Go 1.24 (#2317) (#2324)
+
+
+### [4.0.11-v37](https://github.com/stashed/mongodb/releases/tag/4.0.11-v37)
+
+- [0a827f87](https://github.com/stashed/mongodb/commit/0a827f87) Prepare for release 4.0.11-v37 (#2380)
+- [0549a57a](https://github.com/stashed/mongodb/commit/0549a57a) [cherry-pick] Use ubuntu-latest (#2356) (#2361)
+- [b648b638](https://github.com/stashed/mongodb/commit/b648b638) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2345)
+- [5829b653](https://github.com/stashed/mongodb/commit/5829b653) Use Go 1.24 (#2317) (#2322)
+
+
+### [4.1.4-v37](https://github.com/stashed/mongodb/releases/tag/4.1.4-v37)
+
+- [50c8b474](https://github.com/stashed/mongodb/commit/50c8b474) Prepare for release 4.1.4-v37 (#2384)
+- [b2de57a2](https://github.com/stashed/mongodb/commit/b2de57a2) Use ubuntu-latest (#2356) (#2365)
+- [1e3be3f4](https://github.com/stashed/mongodb/commit/1e3be3f4) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2349)
+- [ecdf8b0b](https://github.com/stashed/mongodb/commit/ecdf8b0b) Use Go 1.24 (#2317) (#2326)
+
+
+### [4.1.7-v37](https://github.com/stashed/mongodb/releases/tag/4.1.7-v37)
+
+- [1ca43f78](https://github.com/stashed/mongodb/commit/1ca43f78) Prepare for release 4.1.7-v37 (#2385)
+- [48b63b13](https://github.com/stashed/mongodb/commit/48b63b13) Use ubuntu-latest (#2356) (#2366)
+- [484cc320](https://github.com/stashed/mongodb/commit/484cc320) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2350)
+- [a519484f](https://github.com/stashed/mongodb/commit/a519484f) Use Go 1.24 (#2317) (#2327)
+
+
+### [4.1.13-v37](https://github.com/stashed/mongodb/releases/tag/4.1.13-v37)
+
+- [0ab97946](https://github.com/stashed/mongodb/commit/0ab97946) Prepare for release 4.1.13-v37 (#2383)
+- [9e2c76d7](https://github.com/stashed/mongodb/commit/9e2c76d7) Use ubuntu-latest (#2356) (#2364)
+- [9e198dee](https://github.com/stashed/mongodb/commit/9e198dee) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2348)
+- [7724fb1a](https://github.com/stashed/mongodb/commit/7724fb1a) Use Go 1.24 (#2317) (#2325)
+
+
+### [4.2.3-v37](https://github.com/stashed/mongodb/releases/tag/4.2.3-v37)
+
+- [b94bad22](https://github.com/stashed/mongodb/commit/b94bad22) Prepare for release 4.2.3-v37 (#2386)
+- [e4139f01](https://github.com/stashed/mongodb/commit/e4139f01) Use ubuntu-latest (#2356) (#2367)
+- [203edd4c](https://github.com/stashed/mongodb/commit/203edd4c) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2351)
+- [d488daa2](https://github.com/stashed/mongodb/commit/d488daa2) Use Go 1.24 (#2317) (#2328)
+
+
+### [4.4.6-v28](https://github.com/stashed/mongodb/releases/tag/4.4.6-v28)
+
+- [b1a3dba1](https://github.com/stashed/mongodb/commit/b1a3dba1) Prepare for release 4.4.6-v28 (#2387)
+- [174d8653](https://github.com/stashed/mongodb/commit/174d8653) Use ubuntu-latest (#2356) (#2368)
+- [807914fa](https://github.com/stashed/mongodb/commit/807914fa) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2352)
+- [cf7dd4e5](https://github.com/stashed/mongodb/commit/cf7dd4e5) Use Go 1.24 (#2317) (#2329)
+
+
+### [5.0.3-v25](https://github.com/stashed/mongodb/releases/tag/5.0.3-v25)
+
+- [6d396d29](https://github.com/stashed/mongodb/commit/6d396d29) Prepare for release 5.0.3-v25 (#2389)
+- [aeaf62c1](https://github.com/stashed/mongodb/commit/aeaf62c1) Use ubuntu-latest (#2356) (#2371)
+- [67b2d0d6](https://github.com/stashed/mongodb/commit/67b2d0d6) extract json before unmarshal (#2335)
+- [9cd90950](https://github.com/stashed/mongodb/commit/9cd90950) Extract json before unmarshal in mongodb commands (#2340) (#2355)
+- [f4c333db](https://github.com/stashed/mongodb/commit/f4c333db) Use Go 1.24 (#2317) (#2331)
+
+
+### [5.0.15-v10](https://github.com/stashed/mongodb/releases/tag/5.0.15-v10)
+
+- [fd2ef311](https://github.com/stashed/mongodb/commit/fd2ef311) Prepare for release 5.0.15-v10 (#2388)
+- [096a6bef](https://github.com/stashed/mongodb/commit/096a6bef) Use ubuntu-latest (#2356) (#2369)
+- [e4b17e70](https://github.com/stashed/mongodb/commit/e4b17e70) Extract json before unmarshal (#2334)
+- [3f2ad4cd](https://github.com/stashed/mongodb/commit/3f2ad4cd) [cherry-pick] Extract json before unmarshal in mongodb commands (#2340) (#2353)
+- [b94ed8b4](https://github.com/stashed/mongodb/commit/b94ed8b4) Use Go 1.24 (#2317) (#2330)
+
+
+### [6.0.5-v13](https://github.com/stashed/mongodb/releases/tag/6.0.5-v13)
+
+- [c0191c04](https://github.com/stashed/mongodb/commit/c0191c04) Prepare for release 6.0.5-v13 (#2390)
+- [85dfe1e5](https://github.com/stashed/mongodb/commit/85dfe1e5) Use ubuntu-latest (#2356) (#2374)
+- [ead9823a](https://github.com/stashed/mongodb/commit/ead9823a) extract json before unmarshal and use `65534` USER in dockerfile (#2333)
+- [fd7c4b33](https://github.com/stashed/mongodb/commit/fd7c4b33) Extract json before unmarshal in mongodb commands (#2340) (#2354)
+- [7acdcec0](https://github.com/stashed/mongodb/commit/7acdcec0) Update CI runners image version
+- [739272b6](https://github.com/stashed/mongodb/commit/739272b6) Use Go 1.24 (#2317) (#2332)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v37](https://github.com/stashed/mysql/releases/tag/5.7.25-v37)
+
+- [920a4ec6](https://github.com/stashed/mysql/commit/920a4ec6) Prepare for release 5.7.25-v37 (#845)
+- [8123bff1](https://github.com/stashed/mysql/commit/8123bff1) Use ubuntu-latest (#840) (#841)
+- [b602d8f2](https://github.com/stashed/mysql/commit/b602d8f2) Use Go 1.24 (#835) (#836)
+
+
+### [8.0.3-v36](https://github.com/stashed/mysql/releases/tag/8.0.3-v36)
+
+- [177ac8fe](https://github.com/stashed/mysql/commit/177ac8fe) Prepare for release 8.0.3-v36 (#848)
+- [b250fb34](https://github.com/stashed/mysql/commit/b250fb34) Use ubuntu-latest (#840) (#844)
+- [cf7890b0](https://github.com/stashed/mysql/commit/cf7890b0) Use Go 1.24 (#835) (#839)
+
+
+### [8.0.14-v36](https://github.com/stashed/mysql/releases/tag/8.0.14-v36)
+
+- [dca3844f](https://github.com/stashed/mysql/commit/dca3844f) Prepare for release 8.0.14-v36 (#846)
+- [a97db90c](https://github.com/stashed/mysql/commit/a97db90c) Use ubuntu-latest (#840) (#842)
+- [9e268c96](https://github.com/stashed/mysql/commit/9e268c96) Use Go 1.24 (#835) (#837)
+
+
+### [8.0.21-v30](https://github.com/stashed/mysql/releases/tag/8.0.21-v30)
+
+- [bb6b4a71](https://github.com/stashed/mysql/commit/bb6b4a71) Prepare for release 8.0.21-v30 (#847)
+- [bc6dd0c2](https://github.com/stashed/mysql/commit/bc6dd0c2) Use ubuntu-latest (#840) (#843)
+- [d88dd7c0](https://github.com/stashed/mysql/commit/d88dd7c0) Use Go 1.24 (#835) (#838)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v24](https://github.com/stashed/nats/releases/tag/2.6.1-v24)
+
+- [4e0da1e](https://github.com/stashed/nats/commit/4e0da1e) Prepare for release 2.6.1-v24 (#180)
+- [ad37719](https://github.com/stashed/nats/commit/ad37719) Use Go 1.24 (#177) (#178)
+
+
+### [2.8.2-v19](https://github.com/stashed/nats/releases/tag/2.8.2-v19)
+
+- [738c4ac](https://github.com/stashed/nats/commit/738c4ac) Prepare for release 2.8.2-v19 (#181)
+- [76de72c](https://github.com/stashed/nats/commit/76de72c) Use Go 1.24 (#177) (#179)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v31](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v31)
+
+- [19509b4b](https://github.com/stashed/percona-xtradb/commit/19509b4b) Prepare for release 5.7-v31 (#346)
+- [889a824d](https://github.com/stashed/percona-xtradb/commit/889a824d) Use Go 1.24 (#342) (#343)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v35](https://github.com/stashed/postgres/releases/tag/9.6.19-v35)
+
+- [132369d2](https://github.com/stashed/postgres/commit/132369d2) Prepare for release 9.6.19-v35 (#1453)
+- [56005629](https://github.com/stashed/postgres/commit/56005629) Use ubuntu-latest (#1435) (#1444)
+- [6260f257](https://github.com/stashed/postgres/commit/6260f257) Use Go 1.24 (#1418) (#1427)
+
+
+### [10.14-v35](https://github.com/stashed/postgres/releases/tag/10.14-v35)
+
+- [231ba9d1](https://github.com/stashed/postgres/commit/231ba9d1) Prepare for release 10.14-v35 (#1431)
+- [d04aa599](https://github.com/stashed/postgres/commit/d04aa599) Use ubuntu-latest (#1435) (#1436)
+- [d9671477](https://github.com/stashed/postgres/commit/d9671477) Use Go 1.24 (#1418) (#1419)
+
+
+### [11.9-v35](https://github.com/stashed/postgres/releases/tag/11.9-v35)
+
+- [22dd8be0](https://github.com/stashed/postgres/commit/22dd8be0) Prepare for release 11.9-v35 (#1432)
+- [88580606](https://github.com/stashed/postgres/commit/88580606) Use ubuntu-latest (#1435) (#1437)
+- [9cd63173](https://github.com/stashed/postgres/commit/9cd63173) Use Go 1.24 (#1418) (#1420)
+
+
+### [12.4-v35](https://github.com/stashed/postgres/releases/tag/12.4-v35)
+
+- [09ab27de](https://github.com/stashed/postgres/commit/09ab27de) Prepare for release 12.4-v35 (#1433)
+- [77de4622](https://github.com/stashed/postgres/commit/77de4622) Use ubuntu-latest (#1435) (#1438)
+- [09a0a2c5](https://github.com/stashed/postgres/commit/09a0a2c5) Use Go 1.24 (#1418) (#1421)
+
+
+### [13.1-v32](https://github.com/stashed/postgres/releases/tag/13.1-v32)
+
+- [b37c89b1](https://github.com/stashed/postgres/commit/b37c89b1) Prepare for release 13.1-v32 (#1434)
+- [9b6d66af](https://github.com/stashed/postgres/commit/9b6d66af) Use ubuntu-latest (#1435) (#1439)
+- [15a4986e](https://github.com/stashed/postgres/commit/15a4986e) Use Go 1.24 (#1418) (#1422)
+
+
+### [14.0-v24](https://github.com/stashed/postgres/releases/tag/14.0-v24)
+
+- [5ae21436](https://github.com/stashed/postgres/commit/5ae21436) Prepare for release 14.0-v24 (#1449)
+- [67427722](https://github.com/stashed/postgres/commit/67427722) Use ubuntu-latest (#1435) (#1440)
+- [8e132f94](https://github.com/stashed/postgres/commit/8e132f94) Use Go 1.24 (#1418) (#1423)
+
+
+### [15.1-v16](https://github.com/stashed/postgres/releases/tag/15.1-v16)
+
+- [306b27f2](https://github.com/stashed/postgres/commit/306b27f2) Prepare for release 15.1-v16 (#1450)
+- [10ae014f](https://github.com/stashed/postgres/commit/10ae014f) Use ubuntu-latest (#1435) (#1441)
+- [d919488a](https://github.com/stashed/postgres/commit/d919488a) Use Go 1.24 (#1418) (#1424)
+
+
+### [16.1-v5](https://github.com/stashed/postgres/releases/tag/16.1-v5)
+
+- [92088205](https://github.com/stashed/postgres/commit/92088205) Prepare for release 16.1-v5 (#1451)
+- [19424ed5](https://github.com/stashed/postgres/commit/19424ed5) Use ubuntu-latest (#1435) (#1442)
+- [e9f07128](https://github.com/stashed/postgres/commit/e9f07128) Use Go 1.24 (#1418) (#1425)
+
+
+### [17.2-v3](https://github.com/stashed/postgres/releases/tag/17.2-v3)
+
+- [ee9f7399](https://github.com/stashed/postgres/commit/ee9f7399) Prepare for release 17.2-v3 (#1452)
+- [4f272c5b](https://github.com/stashed/postgres/commit/4f272c5b) Use ubuntu-latest (#1435) (#1443)
+- [f4919129](https://github.com/stashed/postgres/commit/f4919129) Use Go 1.24 (#1418) (#1426)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v24](https://github.com/stashed/redis/releases/tag/5.0.13-v24)
+
+- [ae7d293](https://github.com/stashed/redis/commit/ae7d293) Prepare for release 5.0.13-v24 (#270)
+- [96925d3](https://github.com/stashed/redis/commit/96925d3) Use Go 1.24 (#266) (#267)
+
+
+### [6.2.5-v24](https://github.com/stashed/redis/releases/tag/6.2.5-v24)
+
+- [5321c47](https://github.com/stashed/redis/commit/5321c47) Prepare for release 6.2.5-v24 (#271)
+- [198128d](https://github.com/stashed/redis/commit/198128d) Use Go 1.24 (#266) (#268)
+
+
+### [7.0.5-v17](https://github.com/stashed/redis/releases/tag/7.0.5-v17)
+
+- [0f12e09](https://github.com/stashed/redis/commit/0f12e09) Prepare for release 7.0.5-v17 (#272)
+- [3c51731](https://github.com/stashed/redis/commit/3c51731) Use Go 1.24 (#266) (#269)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.40.0](https://github.com/stashed/stash/releases/tag/v0.40.0)
+
+- [ab6e434a](https://github.com/stashed/stash/commit/ab6e434a8) Prepare for release v0.40.0 (#1601)
+- [4e393a9d](https://github.com/stashed/stash/commit/4e393a9d6) Stop publishing to docker hub
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.21.0](https://github.com/stashed/ui-server/releases/tag/v0.21.0)
+
+- [7c4d7ec2](https://github.com/stashed/ui-server/commit/7c4d7ec2) Prepare for release v0.21.0 (#50)
+- [de51d640](https://github.com/stashed/ui-server/commit/de51d640) Use Go 1.24 (#49)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v16](https://github.com/stashed/vault/releases/tag/1.10.3-v16)
+
+- [b865d799](https://github.com/stashed/vault/commit/b865d799) Prepare for release 1.10.3-v16 (#61)
+- [d973b761](https://github.com/stashed/vault/commit/d973b761) Use Go 1.24 (#59) (#60)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2025.6.30
Release-tracker: https://github.com/stashed/CHANGELOG/pull/82
Signed-off-by: 1gtm <1gtm@appscode.com>