### PR TITLE
Prepare for release v2025.7.31

### DIFF
--- a/docs/CHANGELOG-v2025.7.31.md
+++ b/docs/CHANGELOG-v2025.7.31.md
@@ -1,0 +1,443 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2025.7.31
+    name: Changelog-v2025.7.31
+    parent: welcome
+    weight: 20250731
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.7.31/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.7.31/
+---
+
+# Stash v2025.7.31 (2025-08-02)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.41.0](https://github.com/stashed/apimachinery/releases/tag/v0.41.0)
+
+- [f9825ca2](https://github.com/stashed/apimachinery/commit/f9825ca2) Show restic command ouput (#243)
+- [3cc491bb](https://github.com/stashed/apimachinery/commit/3cc491bb) Add Automatic Restic Unlock feature (#242)
+- [f559003d](https://github.com/stashed/apimachinery/commit/f559003d) Test against k8s 1.33 (#241)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.41.0](https://github.com/stashed/cli/releases/tag/v0.41.0)
+
+- [65244b21](https://github.com/stashed/cli/commit/65244b21) Prepare for release v0.41.0 (#214)
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v37](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v37)
+
+- [5ac7d42e](https://github.com/stashed/elasticsearch/commit/5ac7d42e) Prepare for release 5.6.4-v37 (#1680)
+- [8a5050c7](https://github.com/stashed/elasticsearch/commit/8a5050c7) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1670)
+- [f1051318](https://github.com/stashed/elasticsearch/commit/f1051318) [cherry-pick] Test against k8s 1.33 (#1658) (#1659)
+
+
+### [6.2.4-v37](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v37)
+
+- [ef32fa2c](https://github.com/stashed/elasticsearch/commit/ef32fa2c) Prepare for release 6.2.4-v37 (#1681)
+- [65ddcd33](https://github.com/stashed/elasticsearch/commit/65ddcd33) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1671)
+- [2c9f7bf2](https://github.com/stashed/elasticsearch/commit/2c9f7bf2) [cherry-pick] Test against k8s 1.33 (#1658) (#1660)
+
+
+### [6.3.0-v37](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v37)
+
+- [91d2b37a](https://github.com/stashed/elasticsearch/commit/91d2b37a) Prepare for release 6.3.0-v37 (#1682)
+- [e9e6ae83](https://github.com/stashed/elasticsearch/commit/e9e6ae83) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1672)
+- [914f1d25](https://github.com/stashed/elasticsearch/commit/914f1d25) [cherry-pick] Test against k8s 1.33 (#1658) (#1661)
+
+
+### [6.4.0-v37](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v37)
+
+- [d4c66ee8](https://github.com/stashed/elasticsearch/commit/d4c66ee8) Prepare for release 6.4.0-v37 (#1683)
+- [3ca6254e](https://github.com/stashed/elasticsearch/commit/3ca6254e) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1673)
+- [67fd31ab](https://github.com/stashed/elasticsearch/commit/67fd31ab) [cherry-pick] Test against k8s 1.33 (#1658) (#1662)
+
+
+### [6.5.3-v37](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v37)
+
+- [d61926b6](https://github.com/stashed/elasticsearch/commit/d61926b6) Prepare for release 6.5.3-v37 (#1684)
+- [fba47b2d](https://github.com/stashed/elasticsearch/commit/fba47b2d) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1674)
+- [9080f7e4](https://github.com/stashed/elasticsearch/commit/9080f7e4) [cherry-pick] Test against k8s 1.33 (#1658) (#1663)
+
+
+### [6.8.0-v37](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v37)
+
+- [d76d0168](https://github.com/stashed/elasticsearch/commit/d76d0168) Prepare for release 6.8.0-v37 (#1685)
+- [77b620af](https://github.com/stashed/elasticsearch/commit/77b620af) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1675)
+- [608c1265](https://github.com/stashed/elasticsearch/commit/608c1265) [cherry-pick] Test against k8s 1.33 (#1658) (#1664)
+
+
+### [7.2.0-v37](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v37)
+
+- [d3a1b472](https://github.com/stashed/elasticsearch/commit/d3a1b472) Prepare for release 7.2.0-v37 (#1687)
+- [05c4a81b](https://github.com/stashed/elasticsearch/commit/05c4a81b) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1677)
+- [2834cafe](https://github.com/stashed/elasticsearch/commit/2834cafe) [cherry-pick] Test against k8s 1.33 (#1658) (#1666)
+
+
+### [7.3.2-v37](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v37)
+
+- [517164d9](https://github.com/stashed/elasticsearch/commit/517164d9) Prepare for release 7.3.2-v37 (#1688)
+- [7e63f7c0](https://github.com/stashed/elasticsearch/commit/7e63f7c0) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1678)
+- [58ddb68c](https://github.com/stashed/elasticsearch/commit/58ddb68c) [cherry-pick] Test against k8s 1.33 (#1658) (#1667)
+
+
+### [7.14.0-v23](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v23)
+
+- [a7fc36d8](https://github.com/stashed/elasticsearch/commit/a7fc36d8) Prepare for release 7.14.0-v23 (#1686)
+- [0601cb67](https://github.com/stashed/elasticsearch/commit/0601cb67) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1676)
+- [7ba3213d](https://github.com/stashed/elasticsearch/commit/7ba3213d) [cherry-pick] Test against k8s 1.33 (#1658) (#1665)
+
+
+### [8.2.0-v20](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v20)
+
+- [d579eb34](https://github.com/stashed/elasticsearch/commit/d579eb34) Prepare for release 8.2.0-v20 (#1689)
+- [c3ace5fe](https://github.com/stashed/elasticsearch/commit/c3ace5fe) [cherry-pick] Add Automatic Restic Unlock feature (#1669) (#1679)
+- [34f99bfc](https://github.com/stashed/elasticsearch/commit/34f99bfc) [cherry-pick] Test against k8s 1.33 (#1658) (#1668)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.41.0](https://github.com/stashed/enterprise/releases/tag/v0.41.0)
+
+- [3340f906](https://github.com/stashed/enterprise/commit/3340f9060) Prepare for release v0.41.0 (#274)
+- [3175fb7a](https://github.com/stashed/enterprise/commit/3175fb7a0) Failed BackupSession while Backup Pod not Exist (#272)
+- [7743fbf8](https://github.com/stashed/enterprise/commit/7743fbf8c) Add Automatic Restic Unlock feature (#273)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v24](https://github.com/stashed/etcd/releases/tag/3.5.0-v24)
+
+- [191a495](https://github.com/stashed/etcd/commit/191a495) Prepare for release 3.5.0-v24 (#124)
+- [570dd4a](https://github.com/stashed/etcd/commit/570dd4a) [cherry-pick] Add Automatic Restic Unlock feature (#122) (#123)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2025.7.31](https://github.com/stashed/installer/releases/tag/v2025.7.31)
+
+- [db4260e3](https://github.com/stashed/installer/commit/db4260e3) Prepare for release v2025.7.31 (#499)
+- [657ea944](https://github.com/stashed/installer/commit/657ea944) Update cve report (#498)
+- [1931c98f](https://github.com/stashed/installer/commit/1931c98f) Update cve report (#497)
+- [64cd7a2b](https://github.com/stashed/installer/commit/64cd7a2b) Update cve report (#496)
+- [5468a08f](https://github.com/stashed/installer/commit/5468a08f) Fix templating for taskqueue (#495)
+- [f948f2dd](https://github.com/stashed/installer/commit/f948f2dd) Update cve report (#494)
+- [10cac523](https://github.com/stashed/installer/commit/10cac523) Update cve report (#493)
+- [f5682560](https://github.com/stashed/installer/commit/f5682560) Update cve report (#492)
+- [b427908a](https://github.com/stashed/installer/commit/b427908a) Update cve report (#491)
+- [836e6788](https://github.com/stashed/installer/commit/836e6788) Update cve report (#490)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.2.0-v5](https://github.com/stashed/kubedump/releases/tag/0.2.0-v5)
+
+- [b9af442](https://github.com/stashed/kubedump/commit/b9af442) Prepare for release 0.2.0-v5 (#95)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.5.8-v31](https://github.com/stashed/mariadb/releases/tag/10.5.8-v31)
+
+- [45e36b53](https://github.com/stashed/mariadb/commit/45e36b53) Prepare for release 10.5.8-v31 (#275)
+- [b1ea0de3](https://github.com/stashed/mariadb/commit/b1ea0de3) [cherry-pick] Add Automatic Restic Unlock feature (#273) (#274)
+- [deb3097d](https://github.com/stashed/mariadb/commit/deb3097d) [cherry-pick] Test against k8s 1.33 (#271) (#272)
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v38](https://github.com/stashed/mongodb/releases/tag/3.4.17-v38)
+
+- [5fd93dcc](https://github.com/stashed/mongodb/commit/5fd93dcc) Prepare for release 3.4.17-v38 (#2424)
+- [54c06081](https://github.com/stashed/mongodb/commit/54c06081) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2409)
+- [5c6bad5f](https://github.com/stashed/mongodb/commit/5c6bad5f) [cherry-pick] Test against k8s 1.33 (#2392) (#2393)
+
+
+### [3.4.22-v38](https://github.com/stashed/mongodb/releases/tag/3.4.22-v38)
+
+- [b634b435](https://github.com/stashed/mongodb/commit/b634b435) Prepare for release 3.4.22-v38 (#2425)
+- [9921031a](https://github.com/stashed/mongodb/commit/9921031a) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2410)
+- [00f5166f](https://github.com/stashed/mongodb/commit/00f5166f) [cherry-pick] Test against k8s 1.33 (#2392) (#2394)
+
+
+### [3.6.8-v38](https://github.com/stashed/mongodb/releases/tag/3.6.8-v38)
+
+- [717fab40](https://github.com/stashed/mongodb/commit/717fab40) Prepare for release 3.6.8-v38 (#2427)
+- [d3b2f64d](https://github.com/stashed/mongodb/commit/d3b2f64d) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2412)
+- [362bf7f8](https://github.com/stashed/mongodb/commit/362bf7f8) [cherry-pick] Test against k8s 1.33 (#2392) (#2396)
+
+
+### [3.6.13-v38](https://github.com/stashed/mongodb/releases/tag/3.6.13-v38)
+
+- [a5aafa55](https://github.com/stashed/mongodb/commit/a5aafa55) Prepare for release 3.6.13-v38 (#2426)
+- [97df90c6](https://github.com/stashed/mongodb/commit/97df90c6) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2411)
+- [be480770](https://github.com/stashed/mongodb/commit/be480770) [cherry-pick] Test against k8s 1.33 (#2392) (#2395)
+
+
+### [4.0.3-v38](https://github.com/stashed/mongodb/releases/tag/4.0.3-v38)
+
+- [f48ce49d](https://github.com/stashed/mongodb/commit/f48ce49d) Prepare for release 4.0.3-v38 (#2429)
+- [5cfc3fe1](https://github.com/stashed/mongodb/commit/5cfc3fe1) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2414)
+- [8fda5d46](https://github.com/stashed/mongodb/commit/8fda5d46) [cherry-pick] Test against k8s 1.33 (#2392) (#2398)
+
+
+### [4.0.5-v38](https://github.com/stashed/mongodb/releases/tag/4.0.5-v38)
+
+- [d4f809ae](https://github.com/stashed/mongodb/commit/d4f809ae) Prepare for release 4.0.5-v38 (#2430)
+- [af158f7e](https://github.com/stashed/mongodb/commit/af158f7e) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2415)
+- [9c5c6b45](https://github.com/stashed/mongodb/commit/9c5c6b45) [cherry-pick] Test against k8s 1.33 (#2392) (#2399)
+
+
+### [4.0.11-v38](https://github.com/stashed/mongodb/releases/tag/4.0.11-v38)
+
+- [cc90e881](https://github.com/stashed/mongodb/commit/cc90e881) Prepare for release 4.0.11-v38 (#2428)
+- [f051bfcb](https://github.com/stashed/mongodb/commit/f051bfcb) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2413)
+- [801ded00](https://github.com/stashed/mongodb/commit/801ded00) [cherry-pick] Test against k8s 1.33 (#2392) (#2397)
+
+
+### [4.1.4-v38](https://github.com/stashed/mongodb/releases/tag/4.1.4-v38)
+
+- [d32ae4fa](https://github.com/stashed/mongodb/commit/d32ae4fa) Prepare for release 4.1.4-v38 (#2432)
+- [c05ed731](https://github.com/stashed/mongodb/commit/c05ed731) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2417)
+- [3fcdb4dc](https://github.com/stashed/mongodb/commit/3fcdb4dc) [cherry-pick] Test against k8s 1.33 (#2392) (#2401)
+
+
+### [4.1.7-v38](https://github.com/stashed/mongodb/releases/tag/4.1.7-v38)
+
+- [ee842555](https://github.com/stashed/mongodb/commit/ee842555) Prepare for release 4.1.7-v38 (#2433)
+- [5006ae67](https://github.com/stashed/mongodb/commit/5006ae67) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2418)
+- [5493889d](https://github.com/stashed/mongodb/commit/5493889d) [cherry-pick] Test against k8s 1.33 (#2392) (#2402)
+
+
+### [4.1.13-v38](https://github.com/stashed/mongodb/releases/tag/4.1.13-v38)
+
+- [d4d2cffc](https://github.com/stashed/mongodb/commit/d4d2cffc) Prepare for release 4.1.13-v38 (#2431)
+- [1900d32f](https://github.com/stashed/mongodb/commit/1900d32f) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2416)
+- [16ffd473](https://github.com/stashed/mongodb/commit/16ffd473) [cherry-pick] Test against k8s 1.33 (#2392) (#2400)
+
+
+### [4.2.3-v38](https://github.com/stashed/mongodb/releases/tag/4.2.3-v38)
+
+- [9068b19c](https://github.com/stashed/mongodb/commit/9068b19c) Prepare for release 4.2.3-v38 (#2434)
+- [ad3f7ac7](https://github.com/stashed/mongodb/commit/ad3f7ac7) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2419)
+- [0758484f](https://github.com/stashed/mongodb/commit/0758484f) [cherry-pick] Test against k8s 1.33 (#2392) (#2403)
+
+
+### [4.4.6-v29](https://github.com/stashed/mongodb/releases/tag/4.4.6-v29)
+
+- [9bb5b20d](https://github.com/stashed/mongodb/commit/9bb5b20d) Prepare for release 4.4.6-v29 (#2435)
+- [aea85f5a](https://github.com/stashed/mongodb/commit/aea85f5a) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2420)
+- [08e4450b](https://github.com/stashed/mongodb/commit/08e4450b) [cherry-pick] Test against k8s 1.33 (#2392) (#2404)
+
+
+### [5.0.3-v26](https://github.com/stashed/mongodb/releases/tag/5.0.3-v26)
+
+- [b485166b](https://github.com/stashed/mongodb/commit/b485166b) Prepare for release 5.0.3-v26 (#2437)
+- [19568660](https://github.com/stashed/mongodb/commit/19568660) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2422)
+- [a33d2f46](https://github.com/stashed/mongodb/commit/a33d2f46) [cherry-pick] Test against k8s 1.33 (#2392) (#2406)
+
+
+### [5.0.15-v11](https://github.com/stashed/mongodb/releases/tag/5.0.15-v11)
+
+- [e1a668d7](https://github.com/stashed/mongodb/commit/e1a668d7) Prepare for release 5.0.15-v11 (#2436)
+- [cfea0124](https://github.com/stashed/mongodb/commit/cfea0124) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2421)
+- [b71013a1](https://github.com/stashed/mongodb/commit/b71013a1) [cherry-pick] Test against k8s 1.33 (#2392) (#2405)
+
+
+### [6.0.5-v14](https://github.com/stashed/mongodb/releases/tag/6.0.5-v14)
+
+- [027dcaf1](https://github.com/stashed/mongodb/commit/027dcaf1) Prepare for release 6.0.5-v14 (#2438)
+- [da676383](https://github.com/stashed/mongodb/commit/da676383) [cherry-pick] Add Automatic Restic Unlock feature (#2408) (#2423)
+- [3f646642](https://github.com/stashed/mongodb/commit/3f646642) [cherry-pick] Test against k8s 1.33 (#2392) (#2407)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v38](https://github.com/stashed/mysql/releases/tag/5.7.25-v38)
+
+- [a22a6292](https://github.com/stashed/mysql/commit/a22a6292) Prepare for release 5.7.25-v38 (#860)
+- [ab38d1b4](https://github.com/stashed/mysql/commit/ab38d1b4) [cherry-pick] Add Automatic Restic Unlock feature (#855) (#856)
+- [d021f40f](https://github.com/stashed/mysql/commit/d021f40f) [cherry-pick] Test against k8s 1.33 (#850) (#851)
+
+
+### [8.0.3-v37](https://github.com/stashed/mysql/releases/tag/8.0.3-v37)
+
+- [79006a2f](https://github.com/stashed/mysql/commit/79006a2f) Prepare for release 8.0.3-v37 (#863)
+- [567fe445](https://github.com/stashed/mysql/commit/567fe445) [cherry-pick] Add Automatic Restic Unlock feature (#855) (#859)
+- [6b8c1e15](https://github.com/stashed/mysql/commit/6b8c1e15) [cherry-pick] Test against k8s 1.33 (#850) (#854)
+
+
+### [8.0.14-v37](https://github.com/stashed/mysql/releases/tag/8.0.14-v37)
+
+- [474d39c9](https://github.com/stashed/mysql/commit/474d39c9) Prepare for release 8.0.14-v37 (#861)
+- [5d35512a](https://github.com/stashed/mysql/commit/5d35512a) [cherry-pick] Add Automatic Restic Unlock feature (#855) (#857)
+- [64c58e41](https://github.com/stashed/mysql/commit/64c58e41) [cherry-pick] Test against k8s 1.33 (#850) (#852)
+
+
+### [8.0.21-v31](https://github.com/stashed/mysql/releases/tag/8.0.21-v31)
+
+- [c0853e70](https://github.com/stashed/mysql/commit/c0853e70) Prepare for release 8.0.21-v31 (#862)
+- [4bcfbf8a](https://github.com/stashed/mysql/commit/4bcfbf8a) [cherry-pick] Add Automatic Restic Unlock feature (#855) (#858)
+- [6db9e608](https://github.com/stashed/mysql/commit/6db9e608) [cherry-pick] Test against k8s 1.33 (#850) (#853)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v25](https://github.com/stashed/nats/releases/tag/2.6.1-v25)
+
+- [45e2aa1](https://github.com/stashed/nats/commit/45e2aa1) Prepare for release 2.6.1-v25 (#186)
+- [87770a8](https://github.com/stashed/nats/commit/87770a8) [cherry-pick] Add Automatic Restic Unlock feature (#183) (#184)
+
+
+### [2.8.2-v20](https://github.com/stashed/nats/releases/tag/2.8.2-v20)
+
+- [36e03a7](https://github.com/stashed/nats/commit/36e03a7) Prepare for release 2.8.2-v20 (#187)
+- [4bbda6f](https://github.com/stashed/nats/commit/4bbda6f) [cherry-pick] Add Automatic Restic Unlock feature (#183) (#185)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v32](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v32)
+
+- [088e2440](https://github.com/stashed/percona-xtradb/commit/088e2440) Prepare for release 5.7-v32 (#352)
+- [f5f89038](https://github.com/stashed/percona-xtradb/commit/f5f89038) [cherry-pick] Add Automatic Restic Unlock feature (#348) (#349)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v36](https://github.com/stashed/postgres/releases/tag/9.6.19-v36)
+
+- [b9955e5f](https://github.com/stashed/postgres/commit/b9955e5f) Prepare for release 9.6.19-v36 (#1483)
+- [70678d01](https://github.com/stashed/postgres/commit/70678d01) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1474)
+- [868f7b56](https://github.com/stashed/postgres/commit/868f7b56) [cherry-pick] Test against k8s 1.33 (#1455) (#1464)
+
+
+### [10.14-v36](https://github.com/stashed/postgres/releases/tag/10.14-v36)
+
+- [c410bfb6](https://github.com/stashed/postgres/commit/c410bfb6) Prepare for release 10.14-v36 (#1475)
+- [876248ac](https://github.com/stashed/postgres/commit/876248ac) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1466)
+- [e1e1e29e](https://github.com/stashed/postgres/commit/e1e1e29e) [cherry-pick] Test against k8s 1.33 (#1455) (#1456)
+
+
+### [11.9-v36](https://github.com/stashed/postgres/releases/tag/11.9-v36)
+
+- [274f7bd3](https://github.com/stashed/postgres/commit/274f7bd3) Prepare for release 11.9-v36 (#1476)
+- [c0e66cfe](https://github.com/stashed/postgres/commit/c0e66cfe) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1467)
+- [b4f995fa](https://github.com/stashed/postgres/commit/b4f995fa) [cherry-pick] Test against k8s 1.33 (#1455) (#1457)
+
+
+### [12.4-v36](https://github.com/stashed/postgres/releases/tag/12.4-v36)
+
+- [e6503dc0](https://github.com/stashed/postgres/commit/e6503dc0) Prepare for release 12.4-v36 (#1477)
+- [13d9d0aa](https://github.com/stashed/postgres/commit/13d9d0aa) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1468)
+- [25acefea](https://github.com/stashed/postgres/commit/25acefea) [cherry-pick] Test against k8s 1.33 (#1455) (#1458)
+
+
+### [13.1-v33](https://github.com/stashed/postgres/releases/tag/13.1-v33)
+
+- [3c56301c](https://github.com/stashed/postgres/commit/3c56301c) Prepare for release 13.1-v33 (#1478)
+- [d0449b8c](https://github.com/stashed/postgres/commit/d0449b8c) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1469)
+- [bd1355d5](https://github.com/stashed/postgres/commit/bd1355d5) [cherry-pick] Test against k8s 1.33 (#1455) (#1459)
+
+
+### [14.0-v25](https://github.com/stashed/postgres/releases/tag/14.0-v25)
+
+- [e290734d](https://github.com/stashed/postgres/commit/e290734d) Prepare for release 14.0-v25 (#1479)
+- [c1685df0](https://github.com/stashed/postgres/commit/c1685df0) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1470)
+- [3b48c729](https://github.com/stashed/postgres/commit/3b48c729) [cherry-pick] Test against k8s 1.33 (#1455) (#1460)
+
+
+### [15.1-v17](https://github.com/stashed/postgres/releases/tag/15.1-v17)
+
+- [8236834a](https://github.com/stashed/postgres/commit/8236834a) Prepare for release 15.1-v17 (#1480)
+- [8df26136](https://github.com/stashed/postgres/commit/8df26136) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1471)
+- [4fec04a1](https://github.com/stashed/postgres/commit/4fec04a1) [cherry-pick] Test against k8s 1.33 (#1455) (#1461)
+
+
+### [16.1-v6](https://github.com/stashed/postgres/releases/tag/16.1-v6)
+
+- [d3ab8046](https://github.com/stashed/postgres/commit/d3ab8046) Prepare for release 16.1-v6 (#1481)
+- [6675c7da](https://github.com/stashed/postgres/commit/6675c7da) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1472)
+- [bbd94b15](https://github.com/stashed/postgres/commit/bbd94b15) [cherry-pick] Test against k8s 1.33 (#1455) (#1462)
+
+
+### [17.2-v4](https://github.com/stashed/postgres/releases/tag/17.2-v4)
+
+- [faa4de60](https://github.com/stashed/postgres/commit/faa4de60) Prepare for release 17.2-v4 (#1482)
+- [ba815b65](https://github.com/stashed/postgres/commit/ba815b65) [cherry-pick] Add Automatic Restic Unlock feature (#1465) (#1473)
+- [56b5d976](https://github.com/stashed/postgres/commit/56b5d976) [cherry-pick] Test against k8s 1.33 (#1455) (#1463)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v25](https://github.com/stashed/redis/releases/tag/5.0.13-v25)
+
+- [9446cbf](https://github.com/stashed/redis/commit/9446cbf) Prepare for release 5.0.13-v25 (#278)
+- [a763c4d](https://github.com/stashed/redis/commit/a763c4d) [cherry-pick] Add Automatic Restic Unlock feature (#274) (#275)
+
+
+### [6.2.5-v25](https://github.com/stashed/redis/releases/tag/6.2.5-v25)
+
+- [7e2612c](https://github.com/stashed/redis/commit/7e2612c) Prepare for release 6.2.5-v25 (#279)
+- [c8e0f3a](https://github.com/stashed/redis/commit/c8e0f3a) [cherry-pick] Add Automatic Restic Unlock feature (#274) (#276)
+
+
+### [7.0.5-v18](https://github.com/stashed/redis/releases/tag/7.0.5-v18)
+
+- [350c04f](https://github.com/stashed/redis/commit/350c04f) Prepare for release 7.0.5-v18 (#280)
+- [6c43bbd](https://github.com/stashed/redis/commit/6c43bbd) [cherry-pick] Add Automatic Restic Unlock feature (#274) (#277)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.41.0](https://github.com/stashed/stash/releases/tag/v0.41.0)
+
+- [8d84b02e](https://github.com/stashed/stash/commit/8d84b02ed) Prepare for release v0.41.0 (#1603)
+- [c7f4eb8e](https://github.com/stashed/stash/commit/c7f4eb8ef) Test against k8s 1.33 (#1602)
+- [4ddb96f4](https://github.com/stashed/stash/commit/4ddb96f4e) Update deps
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.22.0](https://github.com/stashed/ui-server/releases/tag/v0.22.0)
+
+- [ca7d9a52](https://github.com/stashed/ui-server/commit/ca7d9a52) Prepare for release v0.22.0 (#51)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v17](https://github.com/stashed/vault/releases/tag/1.10.3-v17)
+
+- [1bb529e9](https://github.com/stashed/vault/commit/1bb529e9) Prepare for release 1.10.3-v17 (#65)
+- [8113127b](https://github.com/stashed/vault/commit/8113127b) [cherry-pick] Add Automatic Restic Unlock feature (#63) (#64)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2025.7.31
Release-tracker: https://github.com/stashed/CHANGELOG/pull/83
Signed-off-by: 1gtm <1gtm@appscode.com>