### PR TITLE
Prepare for release v2025.10.17

### DIFF
--- a/docs/CHANGELOG-v2025.10.17.md
+++ b/docs/CHANGELOG-v2025.10.17.md
@@ -1,0 +1,434 @@
+---
+title: Changelog | Stash
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-stash-v2025.10.17
+    name: Changelog-v2025.10.17
+    parent: welcome
+    weight: 20251017
+product_name: stash
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.10.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.10.17/
+---
+
+# Stash v2025.10.17 (2025-10-24)
+
+
+## [stashed/apimachinery](https://github.com/stashed/apimachinery)
+
+### [v0.42.0](https://github.com/stashed/apimachinery/releases/tag/v0.42.0)
+
+- [46651bfb](https://github.com/stashed/apimachinery/commit/46651bfb) Update deps
+- [99478c27](https://github.com/stashed/apimachinery/commit/99478c27) Test against k8s 1.34 (#246)
+- [c4f6d787](https://github.com/stashed/apimachinery/commit/c4f6d787) Use Go 1.25 (#245)
+- [033eab70](https://github.com/stashed/apimachinery/commit/033eab70) Test against k8s 1.33.2 (#244)
+
+
+
+## [stashed/cli](https://github.com/stashed/cli)
+
+### [v0.42.0](https://github.com/stashed/cli/releases/tag/v0.42.0)
+
+
+
+
+## [stashed/elasticsearch](https://github.com/stashed/elasticsearch)
+
+### [5.6.4-v38](https://github.com/stashed/elasticsearch/releases/tag/5.6.4-v38)
+
+- [d3e73ecb](https://github.com/stashed/elasticsearch/commit/d3e73ecb) Prepare for release 5.6.4-v38 (#1702)
+- [287c4411](https://github.com/stashed/elasticsearch/commit/287c4411) [cherry-pick] Use Go 1.25 (#1691) (#1692)
+
+
+### [6.2.4-v38](https://github.com/stashed/elasticsearch/releases/tag/6.2.4-v38)
+
+- [e173d2e0](https://github.com/stashed/elasticsearch/commit/e173d2e0) Prepare for release 6.2.4-v38 (#1703)
+- [4eb1ef5e](https://github.com/stashed/elasticsearch/commit/4eb1ef5e) [cherry-pick] Use Go 1.25 (#1691) (#1693)
+
+
+### [6.3.0-v38](https://github.com/stashed/elasticsearch/releases/tag/6.3.0-v38)
+
+- [f40864d3](https://github.com/stashed/elasticsearch/commit/f40864d3) Prepare for release 6.3.0-v38 (#1704)
+- [98e9d0f7](https://github.com/stashed/elasticsearch/commit/98e9d0f7) [cherry-pick] Use Go 1.25 (#1691) (#1694)
+
+
+### [6.4.0-v38](https://github.com/stashed/elasticsearch/releases/tag/6.4.0-v38)
+
+- [c20a0f27](https://github.com/stashed/elasticsearch/commit/c20a0f27) Prepare for release 6.4.0-v38 (#1705)
+- [586f69d0](https://github.com/stashed/elasticsearch/commit/586f69d0) [cherry-pick] Use Go 1.25 (#1691) (#1695)
+
+
+### [6.5.3-v38](https://github.com/stashed/elasticsearch/releases/tag/6.5.3-v38)
+
+- [11d61d23](https://github.com/stashed/elasticsearch/commit/11d61d23) Prepare for release 6.5.3-v38 (#1706)
+- [c065ff90](https://github.com/stashed/elasticsearch/commit/c065ff90) [cherry-pick] Use Go 1.25 (#1691) (#1696)
+
+
+### [6.8.0-v38](https://github.com/stashed/elasticsearch/releases/tag/6.8.0-v38)
+
+- [4dbec8c8](https://github.com/stashed/elasticsearch/commit/4dbec8c8) Prepare for release 6.8.0-v38 (#1707)
+- [188f760c](https://github.com/stashed/elasticsearch/commit/188f760c) [cherry-pick] Use Go 1.25 (#1691) (#1697)
+
+
+### [7.2.0-v38](https://github.com/stashed/elasticsearch/releases/tag/7.2.0-v38)
+
+- [e036f86d](https://github.com/stashed/elasticsearch/commit/e036f86d) Prepare for release 7.2.0-v38 (#1709)
+- [2845efb9](https://github.com/stashed/elasticsearch/commit/2845efb9) [cherry-pick] Use Go 1.25 (#1691) (#1699)
+
+
+### [7.3.2-v38](https://github.com/stashed/elasticsearch/releases/tag/7.3.2-v38)
+
+- [a58c677a](https://github.com/stashed/elasticsearch/commit/a58c677a) Prepare for release 7.3.2-v38 (#1710)
+- [2e0ce4f4](https://github.com/stashed/elasticsearch/commit/2e0ce4f4) [cherry-pick] Use Go 1.25 (#1691) (#1700)
+
+
+### [7.14.0-v24](https://github.com/stashed/elasticsearch/releases/tag/7.14.0-v24)
+
+- [dab40bf8](https://github.com/stashed/elasticsearch/commit/dab40bf8) Prepare for release 7.14.0-v24 (#1708)
+- [399de5e2](https://github.com/stashed/elasticsearch/commit/399de5e2) [cherry-pick] Use Go 1.25 (#1691) (#1698)
+
+
+### [8.2.0-v21](https://github.com/stashed/elasticsearch/releases/tag/8.2.0-v21)
+
+- [76bcf9cd](https://github.com/stashed/elasticsearch/commit/76bcf9cd) Prepare for release 8.2.0-v21 (#1711)
+- [a2a26934](https://github.com/stashed/elasticsearch/commit/a2a26934) [cherry-pick] Use Go 1.25 (#1691) (#1701)
+
+
+
+## [stashed/enterprise](https://github.com/stashed/enterprise)
+
+### [v0.42.0](https://github.com/stashed/enterprise/releases/tag/v0.42.0)
+
+- [041ec14e](https://github.com/stashed/enterprise/commit/041ec14e6) Prepare for release v0.42.0 (#276)
+- [9ee6fb4c](https://github.com/stashed/enterprise/commit/9ee6fb4ca) Update deps
+- [54be8099](https://github.com/stashed/enterprise/commit/54be80998) Use Go 1.25 (#275)
+
+
+
+## [stashed/etcd](https://github.com/stashed/etcd)
+
+### [3.5.0-v25](https://github.com/stashed/etcd/releases/tag/3.5.0-v25)
+
+- [fbfaee2](https://github.com/stashed/etcd/commit/fbfaee2) Prepare for release 3.5.0-v25 (#128)
+- [ec04d18](https://github.com/stashed/etcd/commit/ec04d18) [cherry-pick] Use Go 1.25 (#126) (#127)
+
+
+
+## [stashed/installer](https://github.com/stashed/installer)
+
+### [v2025.10.17](https://github.com/stashed/installer/releases/tag/v2025.10.17)
+
+- [8e25dbe5](https://github.com/stashed/installer/commit/8e25dbe5) Prepare for release v2025.10.17 (#532)
+- [5a5ad14b](https://github.com/stashed/installer/commit/5a5ad14b) Update cve report (#533)
+- [c39d7b4d](https://github.com/stashed/installer/commit/c39d7b4d) Fix mariadb 10.6.23 plugin (#531)
+- [3d06ccc6](https://github.com/stashed/installer/commit/3d06ccc6) Fix make file (#530)
+- [eb05dc25](https://github.com/stashed/installer/commit/eb05dc25) Update cve report (#529)
+- [7da7c0f0](https://github.com/stashed/installer/commit/7da7c0f0) Update cve report (#528)
+- [70b0f586](https://github.com/stashed/installer/commit/70b0f586) Update cve report (#527)
+- [7aedbdd5](https://github.com/stashed/installer/commit/7aedbdd5) Update cve report (#526)
+- [cf64b013](https://github.com/stashed/installer/commit/cf64b013) Update cve report (#525)
+- [038a2464](https://github.com/stashed/installer/commit/038a2464) Update cve report (#524)
+- [b47c6239](https://github.com/stashed/installer/commit/b47c6239) Update cve report (#523)
+- [9c6eddfe](https://github.com/stashed/installer/commit/9c6eddfe) Update cve report (#522)
+- [66bdc8d6](https://github.com/stashed/installer/commit/66bdc8d6) Update cve report (#521)
+- [109c5887](https://github.com/stashed/installer/commit/109c5887) Update cve report (#520)
+- [50ac2b45](https://github.com/stashed/installer/commit/50ac2b45) Update cve report (#519)
+- [49b064bf](https://github.com/stashed/installer/commit/49b064bf) Update cve report (#518)
+- [29af9a00](https://github.com/stashed/installer/commit/29af9a00) Update cve report (#517)
+- [3ced4e50](https://github.com/stashed/installer/commit/3ced4e50) Update cve report (#516)
+- [cb1224e5](https://github.com/stashed/installer/commit/cb1224e5) Update cve report (#515)
+- [a2d7de82](https://github.com/stashed/installer/commit/a2d7de82) Test against k8s 1.34 (#514)
+- [c91dd354](https://github.com/stashed/installer/commit/c91dd354) Update cve report (#513)
+- [3f1de0c7](https://github.com/stashed/installer/commit/3f1de0c7) Update cve report (#512)
+- [eb5233d1](https://github.com/stashed/installer/commit/eb5233d1) Update cve report (#511)
+- [f01dc083](https://github.com/stashed/installer/commit/f01dc083) Update cve report (#510)
+- [1f039f13](https://github.com/stashed/installer/commit/1f039f13) Update cve report (#509)
+- [ae2ca9f7](https://github.com/stashed/installer/commit/ae2ca9f7) Update cve report (#505)
+- [7d0b2c58](https://github.com/stashed/installer/commit/7d0b2c58) Use Go 1.25 (#508)
+- [0d087208](https://github.com/stashed/installer/commit/0d087208) Test against k8s 1.33.2 (#507)
+- [75b19ee0](https://github.com/stashed/installer/commit/75b19ee0) Test against k8s 1.33.2 (#506)
+- [b9252af8](https://github.com/stashed/installer/commit/b9252af8) Update cve report (#504)
+- [21e2ceae](https://github.com/stashed/installer/commit/21e2ceae) Update cve report (#503)
+- [f5fddd81](https://github.com/stashed/installer/commit/f5fddd81) Update cve report (#502)
+- [4b285b95](https://github.com/stashed/installer/commit/4b285b95) Update cve report (#501)
+- [450b8969](https://github.com/stashed/installer/commit/450b8969) Update cve report (#500)
+
+
+
+## [stashed/kubedump](https://github.com/stashed/kubedump)
+
+### [0.2.0-v6](https://github.com/stashed/kubedump/releases/tag/0.2.0-v6)
+
+- [c69b4ba](https://github.com/stashed/kubedump/commit/c69b4ba) Prepare for release 0.2.0-v6 (#100)
+- [c885a68](https://github.com/stashed/kubedump/commit/c885a68) [cherry-pick] Use Go 1.25 (#97) (#99)
+
+
+
+## [stashed/mariadb](https://github.com/stashed/mariadb)
+
+### [10.6.23-v1](https://github.com/stashed/mariadb/releases/tag/10.6.23-v1)
+
+
+
+### [10.6.24](https://github.com/stashed/mariadb/releases/tag/10.6.24)
+
+
+
+
+## [stashed/mongodb](https://github.com/stashed/mongodb)
+
+### [3.4.17-v39](https://github.com/stashed/mongodb/releases/tag/3.4.17-v39)
+
+- [ab3fec8a](https://github.com/stashed/mongodb/commit/ab3fec8a) Prepare for release 3.4.17-v39 (#2456)
+- [33c15fc5](https://github.com/stashed/mongodb/commit/33c15fc5) [cherry-pick] Use Go 1.25 (#2440) (#2441)
+
+
+### [3.4.22-v39](https://github.com/stashed/mongodb/releases/tag/3.4.22-v39)
+
+- [789409a4](https://github.com/stashed/mongodb/commit/789409a4) Prepare for release 3.4.22-v39 (#2457)
+- [925bc76a](https://github.com/stashed/mongodb/commit/925bc76a) [cherry-pick] Use Go 1.25 (#2440) (#2442)
+
+
+### [3.6.8-v39](https://github.com/stashed/mongodb/releases/tag/3.6.8-v39)
+
+- [13805599](https://github.com/stashed/mongodb/commit/13805599) Prepare for release 3.6.8-v39 (#2459)
+- [80790caa](https://github.com/stashed/mongodb/commit/80790caa) [cherry-pick] Use Go 1.25 (#2440) (#2444)
+
+
+### [3.6.13-v39](https://github.com/stashed/mongodb/releases/tag/3.6.13-v39)
+
+- [a06bad10](https://github.com/stashed/mongodb/commit/a06bad10) Prepare for release 3.6.13-v39 (#2458)
+- [171b79ab](https://github.com/stashed/mongodb/commit/171b79ab) [cherry-pick] Use Go 1.25 (#2440) (#2443)
+
+
+### [4.0.3-v39](https://github.com/stashed/mongodb/releases/tag/4.0.3-v39)
+
+- [7e54cf2f](https://github.com/stashed/mongodb/commit/7e54cf2f) Prepare for release 4.0.3-v39 (#2461)
+- [3043d9cf](https://github.com/stashed/mongodb/commit/3043d9cf) [cherry-pick] Use Go 1.25 (#2440) (#2446)
+
+
+### [4.0.5-v39](https://github.com/stashed/mongodb/releases/tag/4.0.5-v39)
+
+- [2ead3d1a](https://github.com/stashed/mongodb/commit/2ead3d1a) Prepare for release 4.0.5-v39 (#2462)
+- [864461f0](https://github.com/stashed/mongodb/commit/864461f0) [cherry-pick] Use Go 1.25 (#2440) (#2447)
+
+
+### [4.0.11-v39](https://github.com/stashed/mongodb/releases/tag/4.0.11-v39)
+
+- [ddb6afec](https://github.com/stashed/mongodb/commit/ddb6afec) Prepare for release 4.0.11-v39 (#2460)
+- [68f1bb8a](https://github.com/stashed/mongodb/commit/68f1bb8a) [cherry-pick] Use Go 1.25 (#2440) (#2445)
+
+
+### [4.1.4-v39](https://github.com/stashed/mongodb/releases/tag/4.1.4-v39)
+
+- [28480222](https://github.com/stashed/mongodb/commit/28480222) Prepare for release 4.1.4-v39 (#2464)
+- [9471bcb8](https://github.com/stashed/mongodb/commit/9471bcb8) [cherry-pick] Use Go 1.25 (#2440) (#2449)
+
+
+### [4.1.7-v39](https://github.com/stashed/mongodb/releases/tag/4.1.7-v39)
+
+- [da3e64b0](https://github.com/stashed/mongodb/commit/da3e64b0) Prepare for release 4.1.7-v39 (#2465)
+- [793761c4](https://github.com/stashed/mongodb/commit/793761c4) [cherry-pick] Use Go 1.25 (#2440) (#2450)
+
+
+### [4.1.13-v39](https://github.com/stashed/mongodb/releases/tag/4.1.13-v39)
+
+- [3997e197](https://github.com/stashed/mongodb/commit/3997e197) Prepare for release 4.1.13-v39 (#2463)
+- [22011159](https://github.com/stashed/mongodb/commit/22011159) [cherry-pick] Use Go 1.25 (#2440) (#2448)
+
+
+### [4.2.3-v39](https://github.com/stashed/mongodb/releases/tag/4.2.3-v39)
+
+- [974bb93a](https://github.com/stashed/mongodb/commit/974bb93a) Prepare for release 4.2.3-v39 (#2466)
+- [1b46a131](https://github.com/stashed/mongodb/commit/1b46a131) [cherry-pick] Use Go 1.25 (#2440) (#2451)
+
+
+### [4.4.6-v30](https://github.com/stashed/mongodb/releases/tag/4.4.6-v30)
+
+- [5d0d90cf](https://github.com/stashed/mongodb/commit/5d0d90cf) Prepare for release 4.4.6-v30 (#2467)
+- [b1a7b66d](https://github.com/stashed/mongodb/commit/b1a7b66d) [cherry-pick] Use Go 1.25 (#2440) (#2452)
+
+
+### [5.0.3-v27](https://github.com/stashed/mongodb/releases/tag/5.0.3-v27)
+
+- [170e19f8](https://github.com/stashed/mongodb/commit/170e19f8) Prepare for release 5.0.3-v27 (#2469)
+- [80376620](https://github.com/stashed/mongodb/commit/80376620) [cherry-pick] Use Go 1.25 (#2440) (#2454)
+
+
+### [5.0.15-v12](https://github.com/stashed/mongodb/releases/tag/5.0.15-v12)
+
+- [2d5d92f7](https://github.com/stashed/mongodb/commit/2d5d92f7) Prepare for release 5.0.15-v12 (#2468)
+- [18bc84f3](https://github.com/stashed/mongodb/commit/18bc84f3) [cherry-pick] Use Go 1.25 (#2440) (#2453)
+
+
+### [6.0.5-v15](https://github.com/stashed/mongodb/releases/tag/6.0.5-v15)
+
+- [c7bff9ba](https://github.com/stashed/mongodb/commit/c7bff9ba) Prepare for release 6.0.5-v15 (#2470)
+- [cc2b7641](https://github.com/stashed/mongodb/commit/cc2b7641) [cherry-pick] Use Go 1.25 (#2440) (#2455)
+
+
+
+## [stashed/mysql](https://github.com/stashed/mysql)
+
+### [5.7.25-v39](https://github.com/stashed/mysql/releases/tag/5.7.25-v39)
+
+- [96721821](https://github.com/stashed/mysql/commit/96721821) Prepare for release 5.7.25-v39 (#870)
+- [6f6eda90](https://github.com/stashed/mysql/commit/6f6eda90) [cherry-pick] Use Go 1.25 (#865) (#866)
+
+
+### [8.0.3-v38](https://github.com/stashed/mysql/releases/tag/8.0.3-v38)
+
+- [ac20304a](https://github.com/stashed/mysql/commit/ac20304a) Prepare for release 8.0.3-v38 (#873)
+- [347fc9d1](https://github.com/stashed/mysql/commit/347fc9d1) [cherry-pick] Use Go 1.25 (#865) (#869)
+
+
+### [8.0.14-v38](https://github.com/stashed/mysql/releases/tag/8.0.14-v38)
+
+- [c057137b](https://github.com/stashed/mysql/commit/c057137b) Prepare for release 8.0.14-v38 (#871)
+- [4f960fbe](https://github.com/stashed/mysql/commit/4f960fbe) [cherry-pick] Use Go 1.25 (#865) (#867)
+
+
+### [8.0.21-v32](https://github.com/stashed/mysql/releases/tag/8.0.21-v32)
+
+- [551ffa2a](https://github.com/stashed/mysql/commit/551ffa2a) Prepare for release 8.0.21-v32 (#872)
+- [e8106118](https://github.com/stashed/mysql/commit/e8106118) [cherry-pick] Use Go 1.25 (#865) (#868)
+
+
+
+## [stashed/nats](https://github.com/stashed/nats)
+
+### [2.6.1-v26](https://github.com/stashed/nats/releases/tag/2.6.1-v26)
+
+- [7debaaa](https://github.com/stashed/nats/commit/7debaaa) Prepare for release 2.6.1-v26 (#192)
+- [e418799](https://github.com/stashed/nats/commit/e418799) [cherry-pick] Use Go 1.25 (#189) (#190)
+
+
+### [2.8.2-v21](https://github.com/stashed/nats/releases/tag/2.8.2-v21)
+
+- [ac63cdf](https://github.com/stashed/nats/commit/ac63cdf) Prepare for release 2.8.2-v21 (#193)
+- [8320954](https://github.com/stashed/nats/commit/8320954) [cherry-pick] Use Go 1.25 (#189) (#191)
+
+
+
+## [stashed/percona-xtradb](https://github.com/stashed/percona-xtradb)
+
+### [5.7-v33](https://github.com/stashed/percona-xtradb/releases/tag/5.7-v33)
+
+- [ef785e28](https://github.com/stashed/percona-xtradb/commit/ef785e28) Prepare for release 5.7-v33 (#358)
+- [a2544748](https://github.com/stashed/percona-xtradb/commit/a2544748) [cherry-pick] Use Go 1.25 (#354) (#355)
+
+
+
+## [stashed/postgres](https://github.com/stashed/postgres)
+
+### [9.6.19-v37](https://github.com/stashed/postgres/releases/tag/9.6.19-v37)
+
+- [f43ea901](https://github.com/stashed/postgres/commit/f43ea901) Prepare for release 9.6.19-v37 (#1503)
+- [084a208c](https://github.com/stashed/postgres/commit/084a208c) [cherry-pick] Use Go 1.25 (#1485) (#1494)
+
+
+### [10.14-v37](https://github.com/stashed/postgres/releases/tag/10.14-v37)
+
+- [67195f1a](https://github.com/stashed/postgres/commit/67195f1a) Prepare for release 10.14-v37 (#1495)
+- [f24e5a27](https://github.com/stashed/postgres/commit/f24e5a27) [cherry-pick] Use Go 1.25 (#1485) (#1486)
+
+
+### [11.9-v37](https://github.com/stashed/postgres/releases/tag/11.9-v37)
+
+- [376d45be](https://github.com/stashed/postgres/commit/376d45be) Prepare for release 11.9-v37 (#1496)
+- [3f7c3442](https://github.com/stashed/postgres/commit/3f7c3442) [cherry-pick] Use Go 1.25 (#1485) (#1487)
+
+
+### [12.4-v37](https://github.com/stashed/postgres/releases/tag/12.4-v37)
+
+- [9c43a62f](https://github.com/stashed/postgres/commit/9c43a62f) Prepare for release 12.4-v37 (#1497)
+- [c8f43f91](https://github.com/stashed/postgres/commit/c8f43f91) [cherry-pick] Use Go 1.25 (#1485) (#1488)
+
+
+### [13.1-v34](https://github.com/stashed/postgres/releases/tag/13.1-v34)
+
+- [1a1fb535](https://github.com/stashed/postgres/commit/1a1fb535) Prepare for release 13.1-v34 (#1498)
+- [00898f73](https://github.com/stashed/postgres/commit/00898f73) [cherry-pick] Use Go 1.25 (#1485) (#1489)
+
+
+### [14.0-v26](https://github.com/stashed/postgres/releases/tag/14.0-v26)
+
+- [e2e51f8e](https://github.com/stashed/postgres/commit/e2e51f8e) Prepare for release 14.0-v26 (#1499)
+- [b2ab956d](https://github.com/stashed/postgres/commit/b2ab956d) [cherry-pick] Use Go 1.25 (#1485) (#1490)
+
+
+### [15.1-v18](https://github.com/stashed/postgres/releases/tag/15.1-v18)
+
+- [d98a85ff](https://github.com/stashed/postgres/commit/d98a85ff) Prepare for release 15.1-v18 (#1500)
+- [95e5d2c3](https://github.com/stashed/postgres/commit/95e5d2c3) [cherry-pick] Use Go 1.25 (#1485) (#1491)
+
+
+### [16.1-v7](https://github.com/stashed/postgres/releases/tag/16.1-v7)
+
+- [e9a2dcc5](https://github.com/stashed/postgres/commit/e9a2dcc5) Prepare for release 16.1-v7 (#1501)
+- [a8e43594](https://github.com/stashed/postgres/commit/a8e43594) [cherry-pick] Use Go 1.25 (#1485) (#1492)
+
+
+### [17.2-v5](https://github.com/stashed/postgres/releases/tag/17.2-v5)
+
+- [32de67bc](https://github.com/stashed/postgres/commit/32de67bc) Prepare for release 17.2-v5 (#1502)
+- [0afff103](https://github.com/stashed/postgres/commit/0afff103) [cherry-pick] Use Go 1.25 (#1485) (#1493)
+
+
+
+## [stashed/redis](https://github.com/stashed/redis)
+
+### [5.0.13-v26](https://github.com/stashed/redis/releases/tag/5.0.13-v26)
+
+- [1729f70](https://github.com/stashed/redis/commit/1729f70) Prepare for release 5.0.13-v26 (#286)
+- [4563762](https://github.com/stashed/redis/commit/4563762) [cherry-pick] Use Go 1.25 (#282) (#283)
+
+
+### [6.2.5-v26](https://github.com/stashed/redis/releases/tag/6.2.5-v26)
+
+- [c5a2aae](https://github.com/stashed/redis/commit/c5a2aae) Prepare for release 6.2.5-v26 (#287)
+- [0d0eae2](https://github.com/stashed/redis/commit/0d0eae2) [cherry-pick] Use Go 1.25 (#282) (#284)
+
+
+### [7.0.5-v19](https://github.com/stashed/redis/releases/tag/7.0.5-v19)
+
+- [9e7f34f](https://github.com/stashed/redis/commit/9e7f34f) Prepare for release 7.0.5-v19 (#288)
+- [6ab1b53](https://github.com/stashed/redis/commit/6ab1b53) [cherry-pick] Use Go 1.25 (#282) (#285)
+
+
+
+## [stashed/stash](https://github.com/stashed/stash)
+
+### [v0.42.0](https://github.com/stashed/stash/releases/tag/v0.42.0)
+
+- [b82f72f4](https://github.com/stashed/stash/commit/b82f72f4e) Prepare for release v0.42.0 (#1609)
+- [1570f2dc](https://github.com/stashed/stash/commit/1570f2dca) Update deps
+- [0f9cc687](https://github.com/stashed/stash/commit/0f9cc6874) Test against k8s 1.34 (#1606)
+- [303dc4df](https://github.com/stashed/stash/commit/303dc4dfe) Use Go 1.25 (#1605)
+- [4494513e](https://github.com/stashed/stash/commit/4494513eb) Test against k8s 1.33.2 (#1604)
+
+
+
+## [stashed/ui-server](https://github.com/stashed/ui-server)
+
+### [v0.23.0](https://github.com/stashed/ui-server/releases/tag/v0.23.0)
+
+- [785ede0f](https://github.com/stashed/ui-server/commit/785ede0f) Prepare for release v0.23.0 (#53)
+- [d7145e60](https://github.com/stashed/ui-server/commit/d7145e60) Use Go 1.25 (#52)
+
+
+
+## [stashed/vault](https://github.com/stashed/vault)
+
+### [1.10.3-v18](https://github.com/stashed/vault/releases/tag/1.10.3-v18)
+
+- [b4d3da40](https://github.com/stashed/vault/commit/b4d3da40) Prepare for release 1.10.3-v18 (#69)
+- [5ebfd8f7](https://github.com/stashed/vault/commit/5ebfd8f7) [cherry-pick] Use Go 1.25 (#67) (#68)
+
+
+
+


### PR DESCRIPTION
ProductLine: Stash
Release: v2025.10.17
Release-tracker: https://github.com/stashed/CHANGELOG/pull/85
Signed-off-by: 1gtm <1gtm@appscode.com>